### PR TITLE
[INTERNAL] generateManifestBundle: Fix unit test issue in CI environments

### DIFF
--- a/test/lib/tasks/bundlers/generateManifestBundle.js
+++ b/test/lib/tasks/bundlers/generateManifestBundle.js
@@ -25,9 +25,9 @@ const findFiles = (folder) => {
 };
 
 test("Build application.b with manifestBundler", (t) => {
-	const destPath = "./test/tmp/build/application.b/dest";
-	const destBundle = destPath + "/manifest-bundle";
-	const expectedPath = "./test/expected/build/application.b/dest";
+	const destPath = path.join(__dirname, "..", "..", "..", "tmp", "build", "application.b", "dest");
+	const destBundle = path.join(destPath, "manifest-bundle");
+	const expectedPath = path.join(__dirname, "..", "..", "..", "expected", "build", "application.b", "dest");
 	const excludedTasks = ["*"];
 	const includedTasks = ["generateManifestBundle"];
 
@@ -58,108 +58,7 @@ const applicationBTree = {
 	"id": "application.b",
 	"version": "1.0.0",
 	"path": applicationBPath,
-	"dependencies": [
-		{
-			"id": "library.d",
-			"version": "1.0.0",
-			"path": path.join(applicationBPath, "node_modules", "library.d"),
-			"dependencies": [],
-			"_level": 1,
-			"specVersion": "0.1",
-			"type": "library",
-			"metadata": {
-				"name": "library.d",
-				"copyright": "Some fancy copyright"
-			},
-			"resources": {
-				"configuration": {
-					"paths": {
-						"src": "main/src",
-						"test": "main/test"
-					}
-				},
-				"pathMappings": {
-					"/resources/": "main/src",
-					"/test-resources/": "main/test"
-				}
-			}
-		},
-		{
-			"id": "library.a",
-			"version": "1.0.0",
-			"path": path.join(applicationBPath, "node_modules", "collection", "library.a"),
-			"dependencies": [],
-			"_level": 1,
-			"specVersion": "0.1",
-			"type": "library",
-			"metadata": {
-				"name": "library.a",
-				"copyright": "${copyright}"
-			},
-			"resources": {
-				"configuration": {
-					"paths": {
-						"src": "src",
-						"test": "test"
-					}
-				},
-				"pathMappings": {
-					"/resources/": "src",
-					"/test-resources/": "test"
-				}
-			}
-		},
-		{
-			"id": "library.b",
-			"version": "1.0.0",
-			"path": path.join(applicationBPath, "node_modules", "collection", "library.b"),
-			"dependencies": [],
-			"_level": 1,
-			"specVersion": "0.1",
-			"type": "library",
-			"metadata": {
-				"name": "library.b",
-				"copyright": "${copyright}"
-			},
-			"resources": {
-				"configuration": {
-					"paths": {
-						"src": "src",
-						"test": "test"
-					}
-				},
-				"pathMappings": {
-					"/resources/": "src",
-					"/test-resources/": "test"
-				}
-			}
-		},
-		{
-			"id": "library.c",
-			"version": "1.0.0",
-			"path": path.join(applicationBPath, "node_modules", "collection", "library.c"),
-			"dependencies": [],
-			"_level": 1,
-			"specVersion": "0.1",
-			"type": "library",
-			"metadata": {
-				"name": "library.c",
-				"copyright": "${copyright}"
-			},
-			"resources": {
-				"configuration": {
-					"paths": {
-						"src": "src",
-						"test": "test"
-					}
-				},
-				"pathMappings": {
-					"/resources/": "src",
-					"/test-resources/": "test"
-				}
-			}
-		}
-	],
+	"dependencies": [],
 	"_level": 0,
 	"specVersion": "0.1",
 	"type": "application",


### PR DESCRIPTION
In some CI environments (Travis, Alpine Linux in Docker) we saw the "Build application.b with manifestBundler" test failing with the following error:

> 'Invalid filename: manifest.json'
> Error code: ELIFECYCLE

This PR fixes that error in those environments