### PR TITLE
[FIX] Restore default component preload

### DIFF
--- a/lib/processors/bundlers/moduleBundler.js
+++ b/lib/processors/bundlers/moduleBundler.js
@@ -68,7 +68,7 @@ module.exports = function({resources, options}) {
 			}
 
 			return Promise.all(bundles.map(function({name, content, bundleInfo}) {
-				console.log("creating bundle as '%s'", "/resources/" + name);
+				// console.log("creating bundle as '%s'", "/resources/" + name);
 				const resource = new EvoResource({
 					path: "/resources/" + name,
 					string: content

--- a/lib/tasks/bundlers/generateComponentPreload.js
+++ b/lib/tasks/bundlers/generateComponentPreload.js
@@ -11,8 +11,8 @@ const ReaderCollectionPrioritized = require("@ui5/fs").ReaderCollectionPrioritiz
  * @param {AbstractReader} parameters.dependencies Reader or Collection to read dependency files
  * @param {Object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
- * @param {Array} parameters.options.paths Array of paths (or glob patterns) for component files
- * @param {Array} parameters.options.namespaces Array of component namespaces
+ * @param {Array} [parameters.options.paths] Array of paths (or glob patterns) for component files
+ * @param {Array} [parameters.options.namespaces] Array of component namespaces
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written
  */
 module.exports = function({workspace, dependencies, options}) {
@@ -28,8 +28,6 @@ module.exports = function({workspace, dependencies, options}) {
 				namespaces = await Promise.all(options.paths.map(async (componentPath) => {
 					const components = await combo.byGlob("/resources/" + componentPath);
 					return components.map((component) => {
-						console.log(component.getPath());
-						console.log(path.dirname(component.getPath()));
 						return path.dirname(component.getPath()).replace(/^\/resources\//i, "");
 					});
 				}));

--- a/lib/types/application/ApplicationBuilder.js
+++ b/lib/types/application/ApplicationBuilder.js
@@ -33,8 +33,7 @@ class ApplicationBuilder extends AbstractBuilder {
 		];
 
 		this.addTask("replaceCopyright", () => {
-			const replaceCopyright = tasks.replaceCopyright;
-			return replaceCopyright({
+			return tasks.replaceCopyright({
 				workspace: resourceCollections.workspace,
 				options: {
 					copyright: project.metadata.copyright,
@@ -44,8 +43,7 @@ class ApplicationBuilder extends AbstractBuilder {
 		});
 
 		this.addTask("replaceVersion", () => {
-			const replaceVersion = tasks.replaceVersion;
-			return replaceVersion({
+			return tasks.replaceVersion({
 				workspace: resourceCollections.workspace,
 				options: {
 					version: project.version,
@@ -86,10 +84,8 @@ class ApplicationBuilder extends AbstractBuilder {
 
 		const componentPreload = project.builder && project.builder.componentPreload;
 		if (componentPreload) {
-			const generateComponentPreload = tasks.generateComponentPreload;
-
 			this.addTask("generateComponentPreload", async () => {
-				return generateComponentPreload({
+				return tasks.generateComponentPreload({
 					workspace: resourceCollections.workspace,
 					dependencies: resourceCollections.dependencies,
 					options: {
@@ -99,11 +95,22 @@ class ApplicationBuilder extends AbstractBuilder {
 					}
 				});
 			});
+		} else {
+			// Default component preload for application namespace
+			this.addTask("generateComponentPreload", async () => {
+				return tasks.generateComponentPreload({
+					workspace: resourceCollections.workspace,
+					dependencies: resourceCollections.dependencies,
+					options: {
+						projectName: project.metadata.name,
+						namespaces: [project.metadata.namespace]
+					}
+				});
+			});
 		}
 
 		this.addTask("generateStandaloneAppBundle", () => {
-			const generateStandaloneAppBundle = tasks.generateStandaloneAppBundle;
-			return generateStandaloneAppBundle({
+			return tasks.generateStandaloneAppBundle({
 				workspace: resourceCollections.workspace,
 				dependencies: resourceCollections.dependencies,
 				options: {
@@ -141,8 +148,7 @@ class ApplicationBuilder extends AbstractBuilder {
 		});
 
 		this.addTask("generateVersionInfo", () => {
-			const generateVersionInfo = tasks.generateVersionInfo;
-			return generateVersionInfo({
+			return tasks.generateVersionInfo({
 				workspace: resourceCollections.workspace,
 				dependencies: resourceCollections.dependencies,
 				options: {


### PR DESCRIPTION
If no component preload configuration is given, use the application namespace. This broke with #6 