### PR TITLE
Build DepCache info files (*-h2-preload.js) for better HTTP/2 support

### DIFF
--- a/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -151,6 +151,8 @@ const CALL_JQUERY_SAP_IS_DECLARED = [["jQuery", "$"], "sap", "isDeclared"];
 const CALL_JQUERY_SAP_REQUIRE = [["jQuery", "$"], "sap", "require"];
 const CALL_JQUERY_SAP_REGISTER_PRELOADED_MODULES = [["jQuery", "$"], "sap", "registerPreloadedModules"];
 
+const SPECIAL_AMD_DEPENDENCIES = ["require", "exports", "module"];
+
 
 /**
  * Analyzes an already parsed JSDocument to collect information about the contained module(s).
@@ -470,6 +472,10 @@ class JSModuleAnalyzer {
 			// console.log(array);
 			array.forEach( (item) => {
 				if ( isString(item) ) {
+					// ignore special AMD dependencies (require, exports, module)
+					if ( SPECIAL_AMD_DEPENDENCIES.indexOf(item.value) >= 0 ) {
+						return;
+					}
 					let requiredModule;
 					if (name == null) {
 						requiredModule = ModuleName.fromRequireJSName( item.value );

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -50,6 +50,14 @@ const UI5BundleFormat = {
 		outW.writeln(`}});`);
 	},
 
+	beforeH2Preloads(outW) {
+		outW.writeln(`"unsupported"; /* Bundle format 'h2' not supported (requires ui5loader)`);
+	},
+
+	afterH2Preloads(outW) {
+		outW.writeln(`*/`);
+	},
+
 	requireSync(outW, moduleName) {
 		outW.writeln(`sap.ui.requireSync("${ModuleName.toRequireJSName(moduleName)}");`);
 	},
@@ -74,6 +82,14 @@ const EVOBundleFormat = {
 			outW.write(`,"${section.getSectionName()}"`);
 		}
 		outW.writeln(`);`);
+	},
+
+	beforeH2Preloads(outW) {
+		outW.writeln(`sap.ui.loader.config({depCacheUI5:{`);
+	},
+
+	afterH2Preloads(outW) {
+		outW.writeln(`}});`);
 	},
 
 	requireSync(outW, moduleName) {
@@ -204,6 +220,8 @@ class BundleBuilder {
 			return this.writeRaw(section);
 		case SectionType.Preload:
 			return this.writePreloadFunction(section);
+		case SectionType.DepCache:
+			return this.writeDepCache(section);
 		case SectionType.Require:
 			return this.writeRequires(section);
 		default:
@@ -478,6 +496,43 @@ class BundleBuilder {
 		info.exposedGlobalNames.forEach( (globalName) => {
 			this.outW.writeln(`this.${globalName}=${globalName};`);
 		});
+	}
+
+	async writeDepCache(section) {
+		const outW = this.outW;
+
+		outW.ensureNewLine();
+
+		const sequence = section.modules.slice();
+
+		if ( sequence.length > 0 ) {
+			this.targetBundleFormat.beforeH2Preloads(outW, section);
+			let i = 0;
+			for (let module of sequence) {
+				let resource = await this.pool.findResourceWithInfo(module);
+				if ( resource != null ) {
+					let deps = resource.info.dependencies.filter(dep => 
+						!resource.info.isConditionalDependency(dep) && !resource.info.isImplicitDependency(dep) );
+					if ( deps.length > 0 ) {
+						if ( i > 0 ) {
+							outW.writeln(",");
+						}
+						outW.write(`"${module}": [${deps.map(dep=>"\"" + dep + "\"").join(",")}]`);
+						i++;
+					} else {
+						log.verbose("    skipped %s, no dependencies", module);
+					}
+				} else {
+					log.error("    couldn't find %s", module);
+				}
+			}
+
+			if ( i > 0 ) {
+				outW.writeln();
+			}
+			this.targetBundleFormat.afterH2Preloads(outW, section);
+		}
+
 	}
 
 	writeRequires(section) {

--- a/lib/lbt/bundle/BundleDefinition.js
+++ b/lib/lbt/bundle/BundleDefinition.js
@@ -18,6 +18,12 @@ const SectionType = {
 	Preload: "preload",
 
 	/**
+	 * Only the dependencies of the modules are stored as 'depCache' configuration.
+	 * Requires UI5 Evolution runtime.
+	 */
+	DepCache: "depcache",
+
+	/**
 	 * For each module, a jQuery.sap.require call will be created.
 	 * Usually used as the last section in a merged module to enforce loading and
 	 * execution of some specific module or modules.

--- a/lib/tasks/bundlers/generateComponentPreload.js
+++ b/lib/tasks/bundlers/generateComponentPreload.js
@@ -56,24 +56,54 @@ module.exports = function({workspace, dependencies, options}) {
 					}
 				});
 
-				return moduleBundler({
-					resources,
-					options: {
-						bundleDefinition: {
-							name: `${namespace}/Component-preload.js`,
-							defaultFileTypes: [".js", ".fragment.xml", ".view.xml", ".properties", ".json"],
-							sections: [
-								{
-									mode: "preload",
-									filters: filters,
-									resolve: false,
-									resolveConditional: false,
-									renderer: false
-								}
-							]
+				return Promise.all([
+					moduleBundler({
+						resources,
+						options: {
+							bundleDefinition: {
+								name: `${namespace}/Component-preload.js`,
+								defaultFileTypes: [".js", ".fragment.xml", ".view.xml", ".properties", ".json"],
+								sections: [
+									{
+										mode: "preload",
+										filters: filters,
+										resolve: false,
+										resolveConditional: false,
+										renderer: false
+									}
+								]
+							}
 						}
-					}
-				});
+					}),
+					moduleBundler({
+						resources,
+						options: {
+							bundleDefinition: {
+								name: `${namespace}/Component-h2-preload.js`,
+								defaultFileTypes: [".js", ".fragment.xml", ".view.xml", ".properties", ".json"],
+								sections: [
+									{
+										mode: "preload",
+										filters: [
+											`${namespace}/library.js`,
+											`${namespace}/manifest.json`
+										],
+										resolve: false,
+										resolveConditional: false,
+										renderer: false
+									},
+									{
+										mode: "depcache",
+										filters: filters,
+										resolve: false,
+										resolveConditional: false,
+										renderer: false
+									}
+								]
+							}
+						}
+					})
+				]);	
 			}));
 		})
 		.then((processedResources) => {

--- a/lib/tasks/bundlers/generateLibraryPreload.js
+++ b/lib/tasks/bundlers/generateLibraryPreload.js
@@ -2,15 +2,17 @@ const log = require("@ui5/logger").getLogger("builder:tasks:bundlers:generateLib
 const moduleBundler = require("../../processors/bundlers/moduleBundler");
 const ReaderCollectionPrioritized = require("@ui5/fs").ReaderCollectionPrioritized;
 
-function getBundleDefinition(namespace) {
+function getBundleDefinition(namespace, h2) {
+	let h2infix = h2 ? "h2-" : "";
+	let bundleDef;
 	// TODO: move to config of actual core project
 	if (namespace === "sap/ui/core") {
-		return {
-			name: `${namespace}/library-preload.js`,
+		bundleDef = {
+			name: `${namespace}/library-${h2infix}preload.js`,
 			defaultFileTypes: [".js", ".fragment.xml", ".view.xml", ".properties", ".json"],
 			sections: [
 				{
-					mode: "preload",
+					mode: h2 ? "depcache" : "preload",
 					filters: [
 						`${namespace}/`,
 						`!${namespace}/.library`,
@@ -41,26 +43,41 @@ function getBundleDefinition(namespace) {
 				}
 			]
 		};
+	} else {
+		bundleDef = {
+			name: `${namespace}/library-${h2infix}preload.js`,
+			defaultFileTypes: [".js", ".fragment.xml", ".view.xml", ".properties", ".json"],
+			sections: [
+				{
+					mode: h2 ? "depcache" : "preload",
+					filters: [
+						`${namespace}/`,
+						`!${namespace}/.library`,
+						`!${namespace}/themes/`,
+						`!${namespace}/messagebundle*`
+					],
+					resolve: false,
+					resolveConditional: false,
+					renderer: true
+				}
+			]
+		};
 	}
-	return {
-		name: `${namespace}/library-preload.js`,
-		defaultFileTypes: [".js", ".fragment.xml", ".view.xml", ".properties", ".json"],
-		sections: [
-			{
-				mode: "preload",
-				filters: [
-					`${namespace}/`,
-					`!${namespace}/.library`,
-					`!${namespace}/themes/`,
-					`!${namespace}/messagebundle*`
-				],
-				resolve: false,
-				resolveConditional: false,
-				renderer: true
-			}
-		]
-	};
+	if ( h2 ) {
+		bundleDef.sections.unshift({
+			mode: "preload",
+			filters: [
+				`${namespace}/library.js`,
+				`${namespace}/manifest.json`
+			],
+			resolve: false,
+			resolveConditional: false,
+			renderer: false
+		});
+	}
+	return bundleDef;
 }
+
 
 /**
  * Task for library bundling.
@@ -168,17 +185,30 @@ module.exports = function({workspace, dependencies, options}) {
 					const libraryNamespaceMatch = libraryIndicatorPath.match(libraryNamespacePattern);
 					if (libraryNamespaceMatch && libraryNamespaceMatch[1]) {
 						const libraryNamespace = libraryNamespaceMatch[1];
-						return moduleBundler({
-							options: {
-								bundleDefinition: getBundleDefinition(libraryNamespace)
-							},
-							resources
-						}).then(([bundle]) => {
-							if (bundle) {
-								// console.log(`${libraryNamespace}/library-preload.js bundle created`);
-								return workspace.write(bundle);
-							}
-						});
+						return Promise.all([
+							moduleBundler({
+								options: {
+									bundleDefinition: getBundleDefinition(libraryNamespace)
+								},
+								resources
+							}).then(([bundle]) => {
+								if (bundle) {
+									// console.log(`${libraryNamespace}/library-preload.js bundle created`);
+									return workspace.write(bundle);
+								}
+							}),
+							moduleBundler({
+								options: {
+									bundleDefinition: getBundleDefinition(libraryNamespace, /* h2 */ true)
+								},
+								resources
+							}).then(([bundle]) => {
+								if (bundle) {
+									// console.log(`${libraryNamespace}/library-h2-preload.js bundle created`);
+									return workspace.write(bundle);
+								}
+							})
+						]);
 					} else {
 						log.verbose(`Could not determine library namespace from file "${libraryIndicatorPath}" for project ${options.projectName}. Skipping library preload bundling.`);
 						return Promise.resolve();


### PR DESCRIPTION
Create the same kind of depCache info files that the existing inhouse-tooling (Maven) already creates.