### PR TITLE
[FIX] Use the target bundle format to decide decoration

### DIFF
--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -136,7 +136,8 @@ class BundleBuilder {
 		// when decorateBootstrapModule is set to false, we don't write the optimized flag
 		// and don't write the try catch wrapper
 		this.shouldDecorate = this.options.decorateBootstrapModule &&
-			(((this.optimizedSources && !this.options.debugMode) || this.optimize) && resolvedModule.containsGlobal);
+			(((this.optimizedSources && !this.options.debugMode) || this.optimize) &&
+				this.targetBundleFormat.shouldDecorate(resolvedModule));
 		// TODO is the following condition ok or should the availability of jquery.sap.global.js be configurable?
 		this.jqglobalAvailable = !resolvedModule.containsGlobal;
 		this.openModule(resolvedModule.name);


### PR DESCRIPTION
- To judge whether a module should be decorated or not depends on
  the currently being used bundle format. Therefore the target
  bundle format should be used instead of checking whether the
  global module is inside the resolved modules