### PR TITLE
Minor improvements around logging and error reporting (in lib/lbt package)

### DIFF
--- a/lib/lbt/analyzer/ComponentAnalyzer.js
+++ b/lib/lbt/analyzer/ComponentAnalyzer.js
@@ -21,7 +21,7 @@
 "use strict";
 
 const ModuleName = require("../utils/ModuleName");
-const log = require("@ui5/logger").getLogger("ComponentAnalyzer");
+const log = require("@ui5/logger").getLogger("lbt:analyzer:ComponentAnalyzer");
 
 // ---------------------------------------------------------------------------------------------------------
 
@@ -51,9 +51,13 @@ class ComponentAnalyzer {
 
 		let manifestName = resource.name.replace(/Component\.js$/, "manifest.json");
 		try {
-			let manifestResource = await this._pool.findResource(manifestName);
-			let fileContent = await manifestResource.buffer();
-			this._analyzeManifest( JSON.parse(fileContent.toString()), info );
+			let manifestResource = await this._pool.findResource(manifestName).catch(() => null);
+			if ( manifestResource ) {
+				let fileContent = await manifestResource.buffer();
+				this._analyzeManifest( JSON.parse(fileContent.toString()), info );
+			} else {
+				log.verbose("No manifest found for '%s', skipping analysis", resource.name);
+			}
 		} catch (err) {
 			log.error("an error occurred while analyzing component %s (ignored)", resource.name, err);
 		}

--- a/lib/lbt/analyzer/FioriElementsAnalyzer.js
+++ b/lib/lbt/analyzer/FioriElementsAnalyzer.js
@@ -63,7 +63,7 @@ const SapUiDefine = require("../calls/SapUiDefine");
 const esprima = require("esprima");
 const {Syntax} = esprima;
 const {getValue, isMethodCall, isString} = require("../utils/ASTUtils");
-const log = require("@ui5/logger").getLogger("FioriElementAnalyzer");
+const log = require("@ui5/logger").getLogger("lbt:analyzer:FioriElementAnalyzer");
 
 // ---------------------------------------------------------------------------------------------------------
 
@@ -95,9 +95,13 @@ class FioriElementsAnalyzer {
 
 		let manifestName = resource.name.replace(/Component\.js$/, "manifest.json");
 		try {
-			let manifestResource = await this._pool.findResource(manifestName);
-			let fileContent = await manifestResource.buffer();
-			await this._analyzeManifest( JSON.parse(fileContent.toString()), info );
+			let manifestResource = await this._pool.findResource(manifestName).catch(() => null);
+			if ( manifestResource ) {
+				let fileContent = await manifestResource.buffer();
+				await this._analyzeManifest( JSON.parse(fileContent.toString()), info );
+			} else {
+				log.verbose("No manifest found for '%s', skipping analysis", resource.name);
+			}
 		} catch (err) {
 			log.error("an error occurred while analyzing template app %s (ignored)", resource.name, err);
 		}

--- a/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -7,7 +7,7 @@ const ModuleName = require("../utils/ModuleName");
 const {Format: ModuleFormat} = require("../resources/ModuleInfo");
 const UI5ClientConstants = require("../UI5ClientConstants");
 const {findOwnProperty, getLocation, getPropertyKey, isMethodCall, isString} = require("../utils/ASTUtils");
-const log = require("@ui5/logger").getLogger("JSModuleAnalyzer");
+const log = require("@ui5/logger").getLogger("lbt:analyzer:JSModuleAnalyzer");
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -386,7 +386,7 @@ class JSModuleAnalyzer {
 			const nArgs = args.length;
 
 			if ( nArgs > 0 && args[0].type == Syntax.OBJECT ) {
-				log.warn("jQuery.sap.require: cannot evaluate complex require (view/controller)");
+				log.verbose("jQuery.sap.require: cannot evaluate complex require (view/controller)");
 			} else {
 				// UI5 signature with one or many required modules
 				for (let i = 0; i < nArgs; i++) {
@@ -401,7 +401,7 @@ class JSModuleAnalyzer {
 						const requiredModuleName2 = ModuleName.fromUI5LegacyName( arg.alternate.value );
 						info.addDependency(requiredModuleName2, true);
 					} else {
-						log.warn("jQuery.sap.require: cannot evaluate dynamic arguments: ", arg);
+						log.verbose("jQuery.sap.require: cannot evaluate dynamic arguments: ", arg);
 						info.dynamicDependencies = true;
 					}
 				}

--- a/lib/lbt/analyzer/SmartTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/SmartTemplateAnalyzer.js
@@ -30,7 +30,7 @@ const SapUiDefine = require("../calls/SapUiDefine");
 const esprima = require("esprima");
 const {Syntax} = esprima;
 const {getValue, isMethodCall, isString} = require("../utils/ASTUtils");
-const log = require("@ui5/logger").getLogger("SmartTemplateAnalyzer");
+const log = require("@ui5/logger").getLogger("lbt:analyzer:SmartTemplateAnalyzer");
 
 // ---------------------------------------------------------------------------------------------------------
 
@@ -54,9 +54,13 @@ class TemplateComponentAnalyzer {
 
 		let manifestName = resource.name.replace(/Component\.js$/, "manifest.json");
 		try {
-			let manifestResource = await this._pool.findResource(manifestName);
-			let fileContent = await manifestResource.buffer();
-			await this._analyzeManifest( JSON.parse(fileContent.toString()), info );
+			let manifestResource = await this._pool.findResource(manifestName).catch(() => null);
+			if ( manifestResource ) {
+				let fileContent = await manifestResource.buffer();
+				await this._analyzeManifest( JSON.parse(fileContent.toString()), info );
+			} else {
+				log.verbose("No manifest found for '%s', skipping analysis", resource.name);
+			}
 		} catch (err) {
 			log.error("an error occurred while analyzing template app %s (ignored)", resource.name, err);
 		}

--- a/lib/lbt/analyzer/XMLCompositeAnalyzer.js
+++ b/lib/lbt/analyzer/XMLCompositeAnalyzer.js
@@ -5,7 +5,7 @@ const {Syntax} = esprima;
 const SapUiDefine = require("../calls/SapUiDefine");
 const {getValue, isMethodCall, isString} = require("../utils/ASTUtils");
 const ModuleName = require("../utils/ModuleName");
-const log = require("@ui5/logger").getLogger("XMLCompositeAnalyzer");
+const log = require("@ui5/logger").getLogger("lbt:analyzer:XMLCompositeAnalyzer");
 
 const CALL_DEFINE = ["define"];
 const CALL_SAP_UI_DEFINE = ["sap", "ui", "define"];
@@ -54,7 +54,7 @@ class XMLCompositeAnalyzer {
 	}
 
 	_analyzeXMLCClassDefinition(clazz) {
-		log.verbose(clazz);
+		// log.verbose(clazz);
 		let fragmentName = getValue(clazz, ["fragment"]);
 		if ( isString(fragmentName) ) {
 			return fragmentName.value;

--- a/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -12,7 +12,7 @@
 
 const xml2js = require("xml2js");
 const ModuleName = require("../utils/ModuleName");
-const log = require("@ui5/logger").getLogger("XMLTemplateAnalyzer");
+const log = require("@ui5/logger").getLogger("lbt:analyzer:XMLTemplateAnalyzer");
 
 // ---------------------------------------------------------------------------------------------------------
 

--- a/lib/lbt/bundle/AutoSplitter.js
+++ b/lib/lbt/bundle/AutoSplitter.js
@@ -4,7 +4,7 @@ const uglify = require("uglify-es");
 const {pd} = require("pretty-data");
 const ModuleName = require("../utils/ModuleName");
 const {SectionType} = require("./BundleDefinition");
-const log = require("@ui5/logger").getLogger("AutoSplitter");
+const log = require("@ui5/logger").getLogger("lbt:bundle:AutoSplitter");
 
 const copyrightCommentsPattern = /copyright|\(c\)|released under|license|\u00a9/i;
 const xmlHtmlPrePattern = /<(?:\w+:)?pre>/;

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -16,7 +16,7 @@ const BundleResolver = require("./Resolver");
 const BundleSplitter = require("./AutoSplitter");
 const {SectionType} = require("./BundleDefinition");
 const BundleWriter = require("./BundleWriter");
-const log = require("@ui5/logger").getLogger("Builder");
+const log = require("@ui5/logger").getLogger("lbt:bundle:Builder");
 
 const copyrightCommentsPattern = /copyright|\(c\)|released under|license|\u00a9/i;
 const xmlHtmlPrePattern = /<(?:\w+:)?pre>/;

--- a/lib/lbt/bundle/Resolver.js
+++ b/lib/lbt/bundle/Resolver.js
@@ -9,7 +9,7 @@ const ResourceFilterList = require("../resources/ResourceFilterList");
 
 const {SectionType} = require("./BundleDefinition");
 const ResolvedBundleDefinition = require("./ResolvedBundleDefinition");
-const log = require("@ui5/logger").getLogger("Resolver");
+const log = require("@ui5/logger").getLogger("lbt:bundle:Resolver");
 
 let dependencyTracker;
 

--- a/lib/lbt/graph/dependencyGraph.js
+++ b/lib/lbt/graph/dependencyGraph.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const log = require("@ui5/logger").getLogger("dependencyGraph");
+const log = require("@ui5/logger").getLogger("lbt:graph:dependencyGraph");
 
 class Node {
 	constructor(name) {

--- a/lib/lbt/graph/dominatorTree.js
+++ b/lib/lbt/graph/dominatorTree.js
@@ -16,7 +16,7 @@
  * @private
  */
 function calculateDominatorTree({n0, nodes}) {
-	const log = require("@ui5/logger").getLogger("dominatorTree");
+	const log = require("@ui5/logger").getLogger("lbt:graph:dominatorTree");
 	// initialize set of dominators for each node
 	for ( let n of nodes.values() ) {
 		if ( n === n0 ) {

--- a/lib/lbt/graph/topologicalSort.js
+++ b/lib/lbt/graph/topologicalSort.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const log = require("@ui5/logger").getLogger("topologicalSort");
+const log = require("@ui5/logger").getLogger("lbt:graph:topologicalSort");
 
 /**
  * Represents a module and its dependencies in a dependency graph.

--- a/lib/lbt/resources/ResourceFilterList.js
+++ b/lib/lbt/resources/ResourceFilterList.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const log = require("@ui5/logger").getLogger("ResourceFilterList");
+const log = require("@ui5/logger").getLogger("lbt:resources:ResourceFilterList");
 
 function makeMatcher(globPattern) {
 	let result = {

--- a/lib/lbt/resources/ResourcePool.js
+++ b/lib/lbt/resources/ResourcePool.js
@@ -14,7 +14,7 @@ const LibraryFileAnalyzer = require("./LibraryFileAnalyzer");
 const ModuleInfo = require("./ModuleInfo");
 const ResourceFilterList = require("./ResourceFilterList");
 const Resource = require("./Resource");
-const log = require("@ui5/logger").getLogger("ResourcePool");
+const log = require("@ui5/logger").getLogger("lbt:resources:ResourcePool");
 
 const jsAnalyzer = new JSModuleAnalyzer();
 

--- a/lib/lbt/utils/ModuleName.js
+++ b/lib/lbt/utils/ModuleName.js
@@ -98,16 +98,13 @@ function resolveRelativePath(path, relativePath) {
 				case 2:
 					// segment '../' -> navigate to parent if possible
 					if ( segments.length === 0 ) {
-						throw new Error(String.format("Can't navigate to parent of root (%s", relativePath));
-						// NODE-TODO, getPackagePath not defined:
-						//	throw new Error(String.format(
-						//		"Can't navigate to parent of root (%s %s", getPackagePath(), relativePath));
+						throw new Error(`Can't navigate to parent of root (${path}, ${relativePath})`);
 					}
 					segments.pop();
 					break;
 				default:
 					// segment '...' or more dots: not allowed
-					throw new Error(String.format("Illegal path segment '%s'", segment));
+					throw new Error(`Illegal path segment '${segment}'`);
 				}
 			} else {
 				// normal segment: add


### PR DESCRIPTION
- all loggers in the lib/lbt modules now use the same hierarchical
  naming scheme as the other modules
- component analyzers no longer fail but return silently when there's
  no manifest.json (often occurs in test data)
- more log outputs of the JSModuleAnalyzer now have been classified as
  'verbose' to reduce the noise during build
- usages of the Java method 'String.format' that had been missed
  during migration have been fixed