### PR TITLE
Fix #30 by using a for loop instead of .forEach

### DIFF
--- a/lib/lbt/analyzer/ComponentAnalyzer.js
+++ b/lib/lbt/analyzer/ComponentAnalyzer.js
@@ -113,21 +113,40 @@ class ComponentAnalyzer {
 
 		let routing = ui5.routing;
 		if ( routing ) {
-			// console.log("routing: ", routing);
-			routing.routes.forEach( (route) => {
-				let target = routing.targets[route.target];
-				if ( target && target.viewName ) {
-					let module = ModuleName.fromUI5LegacyName(
-						(routing.config.viewPath ? routing.config.viewPath + "." : "") +
-						target.viewName, ".view." + routing.config.viewType.toLowerCase() );
-					log.verbose("converting route to view dependency ", module);
-					// TODO make this a conditional dependency, depending on the pattern?
-					info.addDependency(module);
+			if (Array.isArray(routing.routes)) {
+				routing.routes.forEach((route) => this._visitRoute(route, routing, info));
+			} else {
+				for (let key in routing.routes) {
+					if (!routing.routes.hasOwnProperty(key)) {
+						continue;
+					}
+					const route = routing.routes[key];
+					this._visitRoute(route, routing, info);
 				}
-			});
+			}
 		}
 
 		return info;
+	}
+
+	/**
+	 * called for any route, this adds the view used by a route as a dependency.
+	 *
+	 * @param {object} route the single route
+	 * @param {object} routing the full routing object from the manifest
+	 * @param {ModuleInfo} info  ModuleInfo object that should be enriched
+	 * @private
+	 */
+	_visitRoute( route, routing, info ) {
+		const viewPath = routing.config.viewPath ? routing.config.viewPath + "." : "";
+		const viewType = routing.config.viewType.toLowerCase();
+		const target = routing.targets[route.target];
+		if ( target && target.viewName ) {
+			const module = ModuleName.fromUI5LegacyName(viewPath + target.viewName, ".view." + viewType);
+			log.verbose("converting route to view dependency ", module);
+			// TODO make this a conditional dependency, depending on the pattern?
+			info.addDependency(module);
+		}
 	}
 }
 

--- a/test/lib/lbt/analyzer/ComponentAnalyzer.js
+++ b/test/lib/lbt/analyzer/ComponentAnalyzer.js
@@ -1,0 +1,86 @@
+const {test} = require("ava");
+const Path = require("path");
+const ComponentAnalyzer = require("../../../../lib/lbt/analyzer/ComponentAnalyzer");
+
+
+function createMockPool(path, manifest) {
+	const expectedPath = Path.join(path, "manifest.json");
+	return {
+		async findResource(name) {
+			if (name !== expectedPath) {
+				throw new Error(`unexpected resource name: ${name}, expected ${expectedPath}`);
+			}
+			return {
+				async buffer() {
+					return JSON.stringify(manifest);
+				}
+			};
+		}
+	};
+}
+
+test("routing with routes as array", (t) => {
+	const mockManifest = {
+		"sap.ui5": {
+			routing: {
+				config: {
+					viewPath: "test.view",
+					viewType: "XML"
+				},
+				routes: [
+					{
+						name: "test",
+						target: "test"
+					}
+				],
+				targets: {
+					test: {viewName: "App"}
+				}
+			}
+		}
+	};
+
+	const mockPool = createMockPool("test/", mockManifest);
+
+	const mockInfo = {
+		addDependency(name) {
+			t.is(name, "test/view/App.view.xml");
+		}
+	};
+
+	const subject = new ComponentAnalyzer(mockPool);
+	return subject.analyze({name: "test/Component.js"}, mockInfo);
+});
+
+
+test("routing with routes as object", (t) => {
+	const mockManifest = {
+		"sap.ui5": {
+			routing: {
+				config: {
+					viewPath: "test.view",
+					viewType: "XML"
+				},
+				routes: {
+					test: {
+						target: "test"
+					}
+				},
+				targets: {
+					test: {viewName: "App"}
+				}
+			}
+		}
+	};
+
+	const mockPool = createMockPool("test/", mockManifest);
+
+	const mockInfo = {
+		addDependency(name) {
+			t.is(name, "test/view/App.view.xml");
+		}
+	};
+
+	const subject = new ComponentAnalyzer(mockPool);
+	return subject.analyze({name: "test/Component.js"}, mockInfo);
+});


### PR DESCRIPTION
> iterate over routes using a for loop instead of .forEach so we can iterate over objects as well

I figured I might as well create a PR for this issue. afaik this should be the "cleanest" solution for this problem the inner body does not care about the routes name anyway. 

It hurts me a little bit to remove functional syntax and the fat arrow, but I guess its for the greater good ;)

An alternative would be to use `Object.values(routing.routes).forEach` but that would give no access to the route name at all. With the for loop theres still the `key` if one needs the name. 

Additionally I guess this is faster than Object.values. 