### PR TITLE
[FIX] Bundles should be built one after another

### DIFF
--- a/lib/types/library/LibraryBuilder.js
+++ b/lib/types/library/LibraryBuilder.js
@@ -83,17 +83,19 @@ class LibraryBuilder extends AbstractBuilder {
 		const bundles = project.builder && project.builder.bundles;
 		if (bundles) {
 			this.addTask("generateBundle", () => {
-				return Promise.all(bundles.map((bundle) => {
-					return tasks.generateBundle({
-						workspace: resourceCollections.workspace,
-						dependencies: resourceCollections.dependencies,
-						options: {
-							projectName: project.metadata.name,
-							bundleDefinition: bundle.bundleDefinition,
-							bundleOptions: bundle.bundleOptions
-						}
+				return bundles.reduce(function(sequence, bundle) {
+					return sequence.then(function() {
+						return tasks.generateBundle({
+							workspace: resourceCollections.workspace,
+							dependencies: resourceCollections.dependencies,
+							options: {
+								projectName: project.metadata.name,
+								bundleDefinition: bundle.bundleDefinition,
+								bundleOptions: bundle.bundleOptions
+							}
+						});
 					});
-				}));
+				}, Promise.resolve());
 			});
 		}
 


### PR DESCRIPTION
the current implementation builds multiple bundles in parallel.
If there's dependency between the bundles, it can't be resolved
correctly. The bundles need to built with the same order as they
are specified in the bundle definition.