### PR TITLE
[FIX] reduce build time at the price of a slightly increased code size

### DIFF
--- a/lib/processors/uglifier.js
+++ b/lib/processors/uglifier.js
@@ -18,7 +18,8 @@ module.exports = function({resources}) {
 				warnings: false,
 				output: {
 					comments: copyrightCommentsPattern
-				}
+				},
+				compress: false
 			});
 			if (result.error) {
 				throw new Error(


### PR DESCRIPTION
Documentation of uglify-es suggests that `compress:false` already achieves
a very good code size reduction at a much higher speed, see
https://github.com/mishoo/UglifyJS2/tree/harmony#uglify-fast-minify-mode