### PR TITLE
[INTERNAL] Task createDebugFiles checks path before writes

### DIFF
--- a/lib/processors/debugFileCreator.js
+++ b/lib/processors/debugFileCreator.js
@@ -1,4 +1,5 @@
 const copier = require("./resourceCopier");
+const util = require("util");
 
 /**
  * Creates *-dbg.js files for all supplied resources.
@@ -8,12 +9,41 @@ const copier = require("./resourceCopier");
  * @param {Resource[]} parameters.resources List of resources to be processed
  * @returns {Promise<Resource[]>} Promise resolving with debug resources
  */
-module.exports = function({resources}) {
-	return copier({
-		resources: resources,
-		options: {
-			pattern: /((\.view|\.fragment|\.controller)?\.js)/,
-			replacement: "-dbg$1"
-		}
+module.exports = function({resources, fs}) {
+	const options = {
+		pattern: /((\.view|\.fragment|\.controller)?\.js)/,
+		replacement: "-dbg$1"
+	};
+
+	const stat = util.promisify(fs.stat);
+
+	return Promise.all(
+		resources.map((resource) => {
+			// check whether the debug resource path is already used in the
+			// previous tasks
+			return stat(resource.getPath().replace(options.pattern, options.replacement))
+				.then(
+					// if the file can be found, it should be filtered out from creating debug file
+					() => false,
+					(err) => {
+						if (err.code === "ENOENT") {
+							// if the file can't be found, it should be included in creating debug file
+							return resource;
+						}
+						// if it's other error, forward it
+						throw err;
+					}
+				);
+		})
+	).then((results) => {
+		// filter out the resouces whose debug source path is already used
+		return results.filter((result) => {
+			return !!result;
+		});
+	}).then((filteredResources) => {
+		return copier({
+			resources: filteredResources,
+			options: options
+		});
 	});
 };

--- a/lib/tasks/createDebugFiles.js
+++ b/lib/tasks/createDebugFiles.js
@@ -1,4 +1,5 @@
 const dbg = require("../processors/debugFileCreator");
+const fsInterface = require("@ui5/fs").fsInterface;
 
 /**
  * Task to create dbg files.
@@ -18,6 +19,7 @@ module.exports = async function({workspace, options}) {
 		allResources = await workspace.byGlob(options.pattern);
 	}
 	return dbg({
+		fs: fsInterface(workspace),
 		resources: allResources
 	}).then((processedResources) => {
 		return Promise.all(processedResources.map((resource) => {


### PR DESCRIPTION
- The `debugFileCreator` processor checks whether the debug file path
  is used and only writes the content to the path when it's not
  used yet.

- The debug file path can be used, for example, by the `createBundle`
  task which may create a specific bundle for the debug version of
  another bundle. In this case, the `debugFileCreator` shouldn't
  overwrite the created debug bundle.