### PR TITLE
[FEATURE] BundleBuilder: support modules using ES6 with usePredefineCalls

### DIFF
--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -5,6 +5,7 @@
 const uglify = require("uglify-es");
 const {pd} = require("pretty-data");
 const esprima = require("esprima");
+const escodegen = require("escodegen");
 const {Syntax} = esprima;
 // const MOZ_SourceMap = require("source-map");
 
@@ -321,46 +322,25 @@ class BundleBuilder {
 
 	compressJS(fileContent, resource) {
 		if ( this.optimize ) {
-			if ( typeof fileContent === "object" && fileContent.type in Syntax ) {
-				let uglifyAST = uglify.AST_Node.from_mozilla_ast(fileContent);
-				let result = uglify.minify(uglifyAST, {
-					warnings: false, // TODO configure?
-					compress: false, // TODO configure?
-					output: {
-						comments: copyrightCommentsPattern
-					}
-					// , outFileName: resource.name
-					// , outSourceMap: true
-				});
-				if ( result.error ) {
-					throw result.error;
+			let result = uglify.minify({
+				[resource.name]: String(fileContent)
+			}, {
+				warnings: false, // TODO configure?
+				compress: false, // TODO configure?
+				output: {
+					comments: copyrightCommentsPattern
 				}
-				// console.log(result.map);
-				// const map = new MOZ_SourceMap.SourceMapConsumer(result.map);
-				// map.eachMapping(function (m) { console.log(m); }); // console.log(map);
-				fileContent = result.code;
-				// throw new Error();
-			} else {
-				let result = uglify.minify({
-					[resource.name]: String(fileContent)
-				}, {
-					warnings: false, // TODO configure?
-					compress: false, // TODO configure?
-					output: {
-						comments: copyrightCommentsPattern
-					}
-					// , outFileName: resource.name
-					// , outSourceMap: true
-				});
-				if ( result.error ) {
-					throw result.error;
-				}
-				// console.log(result.map);
-				// const map = new MOZ_SourceMap.SourceMapConsumer(result.map);
-				// map.eachMapping(function (m) { console.log(m); }); // console.log(map);
-				fileContent = result.code;
-				// throw new Error();
+				// , outFileName: resource.name
+				// , outSourceMap: true
+			});
+			if ( result.error ) {
+				throw result.error;
 			}
+			// console.log(result.map);
+			// const map = new MOZ_SourceMap.SourceMapConsumer(result.map);
+			// map.eachMapping(function (m) { console.log(m); }); // console.log(map);
+			fileContent = result.code;
+			// throw new Error();
 		}
 		return fileContent;
 	}
@@ -382,14 +362,15 @@ class BundleBuilder {
 			let remaining = [];
 			for ( let module of sequence ) {
 				if ( /\.js$/.test(module) ) {
-					// console.log("trying to read " + module);
+					// console.log("Processing " + module);
 					let resource = await this.pool.findResourceWithInfo(module);
 					let code = await resource.buffer();
 					const ast = rewriteDefine(this.targetBundleFormat, code, module, avoidLazyParsing);
 					if ( ast ) {
 						outW.startSegment(module);
 						outW.ensureNewLine();
-						const fileContent = this.compressJS( ast, resource );
+						let astAsCode = escodegen.generate(ast);
+						const fileContent = this.compressJS(astAsCode, resource);
 						outW.write( fileContent );
 						outW.ensureNewLine();
 						const compressedSize = outW.endSegment();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2204,8 +2204,7 @@
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"dev": true
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"defaults": {
 			"version": "1.0.3",
@@ -2536,6 +2535,31 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
+		"escodegen": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+			"requires": {
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"optional": true
+				}
+			}
+		},
 		"escope": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
@@ -2761,8 +2785,7 @@
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"event-emitter": {
 			"version": "0.3.5",
@@ -3005,8 +3028,7 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-			"dev": true
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"figures": {
 			"version": "2.0.0",
@@ -3171,8 +3193,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -3193,14 +3214,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3215,20 +3234,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3345,8 +3361,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3358,7 +3373,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3373,7 +3387,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -3381,14 +3394,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -3407,7 +3418,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3488,8 +3498,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3501,7 +3510,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3587,8 +3595,7 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3624,7 +3631,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3644,7 +3650,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3688,14 +3693,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -4731,7 +4734,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
@@ -5277,7 +5279,6 @@
 					"version": "0.1.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -6220,8 +6221,7 @@
 				"longest": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"lru-cache": {
 					"version": "4.1.3",
@@ -7467,7 +7467,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",
 				"fast-levenshtein": "~2.0.4",
@@ -7703,8 +7702,7 @@
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"prepend-http": {
 			"version": "1.0.4",
@@ -9043,7 +9041,6 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
@@ -9370,8 +9367,7 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-			"dev": true
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 		},
 		"wrappy": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
 		"@ui5/fs": "^0.2.0",
 		"@ui5/logger": "^0.2.0",
 		"archiver": "^2.1.0",
+		"escodegen": "^1.11.0",
 		"escope": "^3.6.0",
 		"esprima": "^2.7.2",
 		"estraverse": "^4.2.0",


### PR DESCRIPTION
When using the bundle option usePredefineCalls modules using ES6
features such as arrow functions, classes, ... are not supported
and the bundler will break as the mozilla-ast of uglify-es is not
ES6 ready.