### PR TITLE
[FIX] processors/versionInfoGenerator: Remove "gav" property

### DIFF
--- a/lib/processors/versionInfoGenerator.js
+++ b/lib/processors/versionInfoGenerator.js
@@ -23,7 +23,7 @@ module.exports = async function({options}) {
 		version: options.rootProjectVersion, // TODO: insert current application version here
 		buildTimestamp: buildTimestamp,
 		scmRevision: "", // TODO: insert current application scm revision here
-		gav: "", // TODO: insert current application id + version here
+		// gav: "", // TODO: insert current application id + version here
 		libraries: options.libraryInfos.map(function(libraryInfo) {
 			return {
 				name: libraryInfo.name,


### PR DESCRIPTION
Currently the "gav" property isn't filled with any value, so it should
not be added at all, as this currently causes issues when parsing the
value at runtime (e.g. within the UI5 Demokit).
This solves that issue but the "gav" property should anyway be discussed
again.