### PR TITLE
[FIX] generateLibraryPreload: Add new sap.ui.core library namespaces

### DIFF
--- a/lib/tasks/bundlers/generateLibraryPreload.js
+++ b/lib/tasks/bundlers/generateLibraryPreload.js
@@ -19,9 +19,14 @@ function getBundleDefinition(namespace) {
 						`!${namespace}/messagebundle*`,
 
 						"*.js",
+						"sap/base/",
 						"sap/ui/base/",
-						"sap/ui/model/",
 						"sap/ui/xml/",
+						"sap/ui/dom/",
+						"sap/ui/events/",
+						"sap/ui/model/",
+						"sap/ui/security/",
+						"sap/ui/util/",
 						"sap/ui/Global.js",
 
 						// files are already part of sap-ui-core.js


### PR DESCRIPTION
Fixes #80 

Successfully tested with OpenUI5 `1.58.2` and `1.52.5`

Core namespaces that are missing from the preload bundle:
- `sap/ui/debug`
- `sap/ui/performance`
- `sap/ui/qunit`
- `sap/ui/test`
- `sap/ui/thirdparty`