### PR TITLE
[INTERNAL] ComponentAnalyzer Test: Remove additional promise

### DIFF
--- a/test/lib/lbt/analyzer/ComponentAnalyzer.js
+++ b/test/lib/lbt/analyzer/ComponentAnalyzer.js
@@ -372,7 +372,7 @@ test("analyze: without manifest", async (t) => {
 	const mockPool = {
 		async findResource() {
 			return {
-				buffer: async () => Promise.reject()
+				buffer: () => Promise.reject(new Error("File not found"))
 			};
 		}
 	};


### PR DESCRIPTION
Promise.reject already creates a promise so the async function is not
needed.
This caused the error log to be displayed as last entry in the test
output.
