### PR TITLE
[FIX] SmartTemplateAnalyzer: Detect dependencies from "pages" object

### DIFF
--- a/lib/lbt/analyzer/SmartTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/SmartTemplateAnalyzer.js
@@ -81,17 +81,20 @@ class TemplateComponentAnalyzer {
 		const promises = [];
 		const that = this;
 		const st = (manifest && manifest["sap.ui.generic.app"]) || {};
+		function recursePage(page) {
+			if ( page.component && page.component.name ) {
+				const module = ModuleName.fromUI5LegacyName( page.component.name + ".Component" );
+				log.verbose("template app: add dependency to template component %s", module);
+				info.addDependency(module);
+				promises.push( that._analyzeTemplateComponent(module, page, info) );
+			}
+			recurse(page);
+		}
 		function recurse(ctx) {
-			if ( ctx.pages ) {
-				ctx.pages.forEach((page) => {
-					if ( page.component && page.component.name ) {
-						const module = ModuleName.fromUI5LegacyName( page.component.name + ".Component" );
-						log.verbose("template app: add dependency to template component %s", module);
-						info.addDependency(module);
-						promises.push( that._analyzeTemplateComponent(module, page, info) );
-					}
-					recurse(page);
-				});
+			if ( Array.isArray(ctx.pages) ) {
+				ctx.pages.forEach(recursePage);
+			} else if (typeof ctx.pages === "object") {
+				Object.values(ctx.pages).forEach(recursePage);
 			}
 		}
 		recurse(st);


### PR DESCRIPTION
The "pages" property can be either an array or an object.

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [x] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
