### PR TITLE
[FIX] manifestCreator: Only consider component files called Component.js

### DIFF
--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -159,7 +159,7 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 		function findComponentPaths() {
 			const result = [];
 			const prefix = libraryResource.getPath().slice(0, - ".library".length);
-			const components = libBundle.getResources(/(?:[^/]+\/)*Component\.js$/);
+			const components = libBundle.getResources(/^(?:[^/]*\/)*Component\.js$/);
 			components.forEach((comp) => {
 				const relativePath = comp.getPath().slice(prefix.length);
 				if ( relativePath.lastIndexOf("/") >= 0 ) {

--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -159,7 +159,7 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 		function findComponentPaths() {
 			const result = [];
 			const prefix = libraryResource.getPath().slice(0, - ".library".length);
-			const components = libBundle.getResources(/^/(?:[^/]+\/)*Component\.js$/);
+			const components = libBundle.getResources(/^\/(?:[^/]+\/)*Component\.js$/);
 			components.forEach((comp) => {
 				const relativePath = comp.getPath().slice(prefix.length);
 				if ( relativePath.lastIndexOf("/") >= 0 ) {

--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -159,7 +159,7 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 		function findComponentPaths() {
 			const result = [];
 			const prefix = libraryResource.getPath().slice(0, - ".library".length);
-			const components = libBundle.getResources(/^(?:[^/]*\/)*Component\.js$/);
+			const components = libBundle.getResources(/^/(?:[^/]+\/)*Component\.js$/);
 			components.forEach((comp) => {
 				const relativePath = comp.getPath().slice(prefix.length);
 				if ( relativePath.lastIndexOf("/") >= 0 ) {

--- a/test/expected/build/library.h/dest/resources/library/h/components/Component-preload.js
+++ b/test/expected/build/library.h/dest/resources/library/h/components/Component-preload.js
@@ -1,4 +1,9 @@
 sap.ui.require.preload({
 	"library/h/components/Component.js":function(){sap.ui.define(["sap/ui/core/UIComponent"],function(n){"use strict";return n.extend("application.g.Component",{})});
+},
+	"library/h/components/TodoComponent.js":function(){/*!
+ * Some fancy copyright
+ */
+console.log(" File ");
 }
 });

--- a/test/expected/build/library.h/dest/resources/library/h/components/TodoComponent.js
+++ b/test/expected/build/library.h/dest/resources/library/h/components/TodoComponent.js
@@ -1,0 +1,4 @@
+/*!
+ * Some fancy copyright
+ */
+console.log(" File ");

--- a/test/fixtures/library.h/main/src/library/h/components/TodoComponent.js
+++ b/test/fixtures/library.h/main/src/library/h/components/TodoComponent.js
@@ -1,0 +1,4 @@
+/*!
+ * ${copyright}
+ */
+console.log(' File ');


### PR DESCRIPTION
In the past files called *Component.js where also considered as
Components during manifest creation.