### PR TITLE
Bundle builder now uses same regexp for copyrights as uglifier task

### DIFF
--- a/lib/lbt/bundle/AutoSplitter.js
+++ b/lib/lbt/bundle/AutoSplitter.js
@@ -6,7 +6,7 @@ const ModuleName = require("../utils/ModuleName");
 const {SectionType} = require("./BundleDefinition");
 const log = require("@ui5/logger").getLogger("lbt:bundle:AutoSplitter");
 
-const copyrightCommentsPattern = /copyright|\(c\)|released under|license|\u00a9/i;
+const copyrightCommentsPattern = /copyright|\(c\)(?:[0-9]+|\s+[0-9A-za-z])|released under|license|\u00a9/i;
 const xmlHtmlPrePattern = /<(?:\w+:)?pre>/;
 
 /**

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -19,7 +19,7 @@ const {SectionType} = require("./BundleDefinition");
 const BundleWriter = require("./BundleWriter");
 const log = require("@ui5/logger").getLogger("lbt:bundle:Builder");
 
-const copyrightCommentsPattern = /copyright|\(c\)|released under|license|\u00a9/i;
+const copyrightCommentsPattern = /copyright|\(c\)(?:[0-9]+|\s+[0-9A-za-z])|released under|license|\u00a9/i;
 const xmlHtmlPrePattern = /<(?:\w+:)?pre>/;
 
 const strReplacements = {

--- a/test/expected/build/sap.ui.core/preload/resources/sap/ui/core/some.js
+++ b/test/expected/build/sap.ui.core/preload/resources/sap/ui/core/some.js
@@ -2,3 +2,13 @@
  * ${copyright}
  */
 console.log('HelloWorld');
+
+/*
+ * function add(c) - this is still not implemented.
+ * @private
+ * @param {Component} c
+ * @name add
+ * This comment should be removed in the preload bundle although it contains the magic
+ * sequence "opening parenthesis - letter c - closing parenthesis" which usually indicates
+ * a  c o p y r i g h t  comment.
+ */

--- a/test/fixtures/sap.ui.core/main/src/sap/ui/core/some.js
+++ b/test/fixtures/sap.ui.core/main/src/sap/ui/core/some.js
@@ -2,3 +2,13 @@
  * ${copyright}
  */
 console.log('HelloWorld');
+
+/*
+ * function add(c) - this is still not implemented.
+ * @private
+ * @param {Component} c
+ * @name add
+ * This comment should be removed in the preload bundle although it contains the magic
+ * sequence "opening parenthesis - letter c - closing parenthesis" which usually indicates
+ * a  c o p y r i g h t  comment.
+ */


### PR DESCRIPTION
Fixes https://github.com/SAP/ui5-builder/issues/257 .

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [ ] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
