### PR TITLE
[INTERNAL] coverage: exclude .eslintrc.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 			"text-summary"
 		],
 		"exclude": [
+			".eslintrc.js",
 			"docs/**",
 			"jsdocs/**",
 			"coverage/**",


### PR DESCRIPTION
Exclude eslint config file since it is not treated as source code which
should be covered by a test.