### PR TITLE
[FEATURE] XMLTemplateAnalyzer: Support core:require

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -4,6 +4,7 @@
     },
     "source": {
         "include": ["README.md", "index.js"],
+        "exclude": ["lib/lbt/utils/JSTokenizer.js"],
         "includePattern": ".+\\.js$",
         "excludePattern": "(node_modules(\\\\|/))"
     },

--- a/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -12,6 +12,7 @@
 
 const xml2js = require("xml2js");
 const ModuleName = require("../utils/ModuleName");
+const JSTokenizer = require("../utils/JSTokenizer");
 const log = require("@ui5/logger").getLogger("lbt:analyzer:XMLTemplateAnalyzer");
 
 // ---------------------------------------------------------------------------------------------------------
@@ -43,12 +44,22 @@ const XMLVIEW_MODULE = "sap/ui/core/mvc/XMLView.js";
 const ANYVIEW_VIEWNAME_ATTRIBUTE = "viewName";
 const XMLVIEW_CONTROLLERNAME_ATTRIBUTE = "controllerName";
 const XMLVIEW_RESBUNDLENAME_ATTRIBUTE = "resourceBundleName";
+const XMLVIEW_CORE_REQUIRE_ATTRIBUTE_NS = {
+	uri: "sap.ui.core",
+	local: "require"
+};
 
 /*
  * Helper to simplify access to node attributes.
  */
 function getAttribute(node, attr) {
 	return (node.$ && node.$[attr] && node.$[attr].value) || null;
+}
+function getAttributeNS(node, attrNS) {
+	const attr = Object.values(node.$).find((n) => {
+		return n.uri === attrNS.uri && n.local === attrNS.local;
+	});
+	return (attr && attr.value) || null;
 }
 
 /**
@@ -187,6 +198,8 @@ class XMLTemplateAnalyzer {
 			this._addDependency( resourceBundleModuleName );
 		}
 
+		this._analyzeCoreRequire(node);
+
 		this._analyzeChildren(node);
 	}
 
@@ -210,6 +223,8 @@ class XMLTemplateAnalyzer {
 
 			// ignore FragmentDefinition (also skipped by runtime XMLTemplateProcessor)
 			if ( FRAGMENTDEFINITION_MODULE !== moduleName ) {
+				this._analyzeCoreRequire(node);
+
 				this.promises.push(
 
 					this._pool.findResource(moduleName).then( () => {
@@ -284,6 +299,24 @@ class XMLTemplateAnalyzer {
 	_analyzeChildren(node) {
 		if ( Array.isArray(node.$$) ) {
 			node.$$.forEach( (child) => this._analyzeNode( child ) );
+		}
+	}
+
+	_analyzeCoreRequire(node) {
+		const coreRequire = getAttributeNS(node, XMLVIEW_CORE_REQUIRE_ATTRIBUTE_NS);
+		let requireContext;
+		if ( coreRequire ) {
+			try {
+				requireContext = JSTokenizer.parseJS(coreRequire);
+			} catch (e) {
+				log.error("Require attribute can't be parsed on Node: ", node.$ns.local);
+				throw e;
+			}
+			if (requireContext) {
+				Object.values(requireContext).forEach((requireJsName) => {
+					this._addDependency(ModuleName.fromRequireJSName(requireJsName));
+				});
+			}
 		}
 	}
 

--- a/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -309,12 +309,17 @@ class XMLTemplateAnalyzer {
 			try {
 				requireContext = JSTokenizer.parseJS(coreRequire);
 			} catch (e) {
-				log.error("Require attribute can't be parsed on Node: ", node.$ns.local);
-				throw e;
+				log.error("Ignoring core:require: Attribute can't be parsed on Node ", node.$ns.local);
+				log.error(coreRequire);
 			}
-			if (requireContext) {
-				Object.values(requireContext).forEach((requireJsName) => {
-					this._addDependency(ModuleName.fromRequireJSName(requireJsName));
+			if ( requireContext ) {
+				Object.keys(requireContext).forEach((key) => {
+					const requireJsName = requireContext[key];
+					if ( requireJsName && typeof requireJsName === "string" ) {
+						this._addDependency(ModuleName.fromRequireJSName(requireJsName));
+					} else {
+						log.error(`Ignoring core:require: '${key}' refers to invalid module name '${requireJsName}'`);
+					}
 				});
 			}
 		}

--- a/lib/lbt/utils/JSTokenizer.js
+++ b/lib/lbt/utils/JSTokenizer.js
@@ -1,0 +1,381 @@
+/* eslint-disable */
+
+/*!
+ * ${copyright}
+ */
+/*
+ * IMPORTANT: This is a private module, its API must not be used and is subject to change.
+ * Code other than the OpenUI5 libraries must not introduce dependencies to this module.
+ */
+//sap.ui.define([], function() {
+	"use strict";
+
+	/*
+	 * The following code has been taken from the component JSON in JavaScript
+	 * from Douglas Crockford which is licensed under Public Domain
+	 * (http://www.json.org/ > JavaScript > json-2). The code contains
+	 * local modifications.
+	 *
+	 * Git URL: https://github.com/douglascrockford/JSON-js/blob/42c18c621a411c3f39a81bb0a387fc50dcd738d9/json_parse.js
+	 */
+
+	// /**
+	//  * @class Tokenizer for JS values.
+	//  *
+	//  * Contains functions to consume tokens on an input string.
+	//  *
+	//  * @example
+	//  * sap.ui.require(["sap/base/util/JSTokenizer"], function(JSTokenizer){
+	//  *      JSTokenizer().parseJS("{test:'123'}"); // {test:'123'}
+	//  * });
+	//  *
+	//  * @alias module:sap/base/util/JSTokenizer
+	//  * @since 1.58
+	//  * @private
+	//  * @ui5-restricted sap.ui.core
+	//  */
+	var JSTokenizer = function() {
+
+		this.at; // The index of the current character
+		this.ch; // The current character
+		this.escapee = {
+			'"': '"',
+			'\'': '\'',
+			'\\': '\\',
+			'/': '/',
+			b: '\b',
+			f: '\f',
+			n: '\n',
+			r: '\r',
+			t: '\t'
+		};
+		this.text;
+	};
+
+
+	JSTokenizer.prototype.error = function(m) {
+
+		// Call error when something is wrong.
+		throw {
+			name: 'SyntaxError',
+			message: m,
+			at: this.at,
+			text: this.text
+		};
+	};
+
+	JSTokenizer.prototype.next = function(c) {
+
+		// If a c parameter is provided, verify that it matches the current character.
+		if (c && c !== this.ch) {
+			this.error("Expected '" + c + "' instead of '" + this.ch + "'");
+		}
+
+		// Get the next character. When there are no more characters,
+		// return the empty string.
+		this.ch = this.text.charAt(this.at);
+		this.at += 1;
+		return this.ch;
+	};
+
+	JSTokenizer.prototype.number = function() {
+
+		// Parse a number value.
+		var number, string = '';
+
+		if (this.ch === '-') {
+			string = '-';
+			this.next('-');
+		}
+		while (this.ch >= '0' && this.ch <= '9') {
+			string += this.ch;
+			this.next();
+		}
+		if (this.ch === '.') {
+			string += '.';
+			while (this.next() && this.ch >= '0' && this.ch <= '9') {
+				string += this.ch;
+			}
+		}
+		if (this.ch === 'e' || this.ch === 'E') {
+			string += this.ch;
+			this.next();
+			if (this.ch === '-' || this.ch === '+') {
+				string += this.ch;
+				this.next();
+			}
+			while (this.ch >= '0' && this.ch <= '9') {
+				string += this.ch;
+				this.next();
+			}
+		}
+		number = +string;
+		if (!isFinite(number)) {
+			this.error("Bad number");
+		} else {
+			return number;
+		}
+	};
+
+	JSTokenizer.prototype.string = function() {
+
+		// Parse a string value.
+		var hex, i, string = '', quote,
+			uffff;
+
+		// When parsing for string values, we must look for " and \ characters.
+		if (this.ch === '"' || this.ch === '\'') {
+			quote = this.ch;
+			while (this.next()) {
+				if (this.ch === quote) {
+					this.next();
+					return string;
+				}
+				if (this.ch === '\\') {
+					this.next();
+					if (this.ch === 'u') {
+						uffff = 0;
+						for (i = 0; i < 4; i += 1) {
+							hex = parseInt(this.next(), 16);
+							if (!isFinite(hex)) {
+								break;
+							}
+							uffff = uffff * 16 + hex;
+						}
+						string += String.fromCharCode(uffff);
+					} else if (typeof this.escapee[this.ch] === 'string') {
+						string += this.escapee[this.ch];
+					} else {
+						break;
+					}
+				} else {
+					string += this.ch;
+				}
+			}
+		}
+		this.error("Bad string");
+	};
+
+	JSTokenizer.prototype.name = function() {
+
+		// Parse a name value.
+		var name = '',
+			allowed = function(ch) {
+				return ch === "_" || ch === "$" ||
+					(ch >= "0" && ch <= "9") ||
+					(ch >= "a" && ch <= "z") ||
+					(ch >= "A" && ch <= "Z");
+			};
+
+		if (allowed(this.ch)) {
+			name += this.ch;
+		} else {
+			this.error("Bad name");
+		}
+
+		while (this.next()) {
+			if (this.ch === ' ') {
+				this.next();
+				return name;
+			}
+			if (this.ch === ':') {
+				return name;
+			}
+			if (allowed(this.ch)) {
+				name += this.ch;
+			} else {
+				this.error("Bad name");
+			}
+		}
+		this.error("Bad name");
+	};
+
+	JSTokenizer.prototype.white = function() {
+
+		// Skip whitespace.
+		while (this.ch && this.ch <= ' ') {
+			this.next();
+		}
+	};
+
+	JSTokenizer.prototype.word = function() {
+
+		// true, false, or null.
+		switch (this.ch) {
+		case 't':
+			this.next('t');
+			this.next('r');
+			this.next('u');
+			this.next('e');
+			return true;
+		case 'f':
+			this.next('f');
+			this.next('a');
+			this.next('l');
+			this.next('s');
+			this.next('e');
+			return false;
+		case 'n':
+			this.next('n');
+			this.next('u');
+			this.next('l');
+			this.next('l');
+			return null;
+		}
+		this.error("Unexpected '" + this.ch + "'");
+	};
+
+		//value, // Place holder for the value function.
+	JSTokenizer.prototype.array = function() {
+
+		// Parse an array value.
+		var array = [];
+
+		if (this.ch === '[') {
+			this.next('[');
+			this.white();
+			if (this.ch === ']') {
+				this.next(']');
+				return array; // empty array
+			}
+			while (this.ch) {
+				array.push(this.value());
+				this.white();
+				if (this.ch === ']') {
+					this.next(']');
+					return array;
+				}
+				this.next(',');
+				this.white();
+			}
+		}
+		this.error("Bad array");
+	};
+
+	var object = function() {
+
+		// Parse an object value.
+		var key, object = {};
+
+		if (this.ch === '{') {
+			this.next('{');
+			this.white();
+			if (this.ch === '}') {
+				this.next('}');
+				return object; // empty object
+			}
+			while (this.ch) {
+				if (this.ch >= "0" && this.ch <= "9") {
+					key = this.number();
+				} else if (this.ch === '"' || this.ch === '\'') {
+					key = this.string();
+				} else {
+					key = this.name();
+				}
+				this.white();
+				this.next(':');
+				if (Object.hasOwnProperty.call(object, key)) {
+					this.error('Duplicate key "' + key + '"');
+				}
+				object[key] = this.value();
+				this.white();
+				if (this.ch === '}') {
+					this.next('}');
+					return object;
+				}
+				this.next(',');
+				this.white();
+			}
+		}
+		this.error("Bad object");
+	};
+
+	JSTokenizer.prototype.value = function() {
+
+		// Parse a JS value. It could be an object, an array, a string, a number,
+		// or a word.
+		this.white();
+		switch (this.ch) {
+			case '{':
+				return object.call(this);
+			case '[':
+				return this.array();
+			case '"':
+			case '\'':
+				return this.string();
+			case '-':
+				return this.number();
+			default:
+				return this.ch >= '0' && this.ch <= '9' ? this.number() : this.word();
+		}
+	};
+
+	// /**
+	//  * Returns the index of the current character.
+	//  *
+	//  * @private
+	//  * @returns {int} The current character's index.
+	//  */
+	JSTokenizer.prototype.getIndex = function() {
+		return this.at - 1;
+	};
+
+	JSTokenizer.prototype.getCh = function() {
+		return this.ch;
+	};
+
+	JSTokenizer.prototype.init = function(sSource, iIndex) {
+		this.text = sSource;
+		this.at = iIndex || 0;
+		this.ch = ' ';
+	};
+
+	// /**
+	//  * Advances the index in the text to <code>iIndex</code>. Fails if the new index
+	//  * is smaller than the previous index.
+	//  *
+	//  * @private
+	//  * @param {int} iIndex - the new index
+	//  */
+	JSTokenizer.prototype.setIndex = function(iIndex) {
+		if (iIndex < this.at - 1) {
+			throw new Error("Must not set index " + iIndex
+				+ " before previous index " + (this.at - 1));
+		}
+		this.at = iIndex;
+		this.next();
+	};
+
+	// /**
+	//  * Return the parse function. It will have access to all of the above
+	//  * functions and variables.
+	//  *
+	//  * @private
+	//  * @ui5-restricted sap.ui.core
+	//  * @static
+	//  * @param {string} sSource The js source
+	//  * @param {int} iStart The start position
+	//  * @returns {object} the JavaScript object
+	//  */
+	JSTokenizer.parseJS = function(sSource, iStart) {
+
+		var oJSTokenizer = new JSTokenizer();
+		var result;
+		oJSTokenizer.init(sSource, iStart);
+		result = oJSTokenizer.value();
+
+		if ( isNaN(iStart) ) {
+			oJSTokenizer.white();
+			if (oJSTokenizer.getCh()) {
+				oJSTokenizer.error("Syntax error");
+			}
+			return result;
+		} else {
+			return { result : result, at : oJSTokenizer.getIndex()};
+		}
+
+	};
+
+//	return JSTokenizer;
+//});
+module.exports = JSTokenizer;

--- a/lib/lbt/utils/JSTokenizer.js
+++ b/lib/lbt/utils/JSTokenizer.js
@@ -1,3 +1,8 @@
+/*
+ * This is a copy of the sap/base/util/JSTokenizer.js module from OpenUI5
+ * https://github.com/SAP/openui5/blob/99ddaf3e3d2b1217fba25d570235bc28cea736fd/src/sap.ui.core/src/sap/base/util/JSTokenizer.js
+ */
+
 /* eslint-disable */
 
 /*!
@@ -19,21 +24,21 @@
 	 * Git URL: https://github.com/douglascrockford/JSON-js/blob/42c18c621a411c3f39a81bb0a387fc50dcd738d9/json_parse.js
 	 */
 
-	// /**
-	//  * @class Tokenizer for JS values.
-	//  *
-	//  * Contains functions to consume tokens on an input string.
-	//  *
-	//  * @example
-	//  * sap.ui.require(["sap/base/util/JSTokenizer"], function(JSTokenizer){
-	//  *      JSTokenizer().parseJS("{test:'123'}"); // {test:'123'}
-	//  * });
-	//  *
-	//  * @alias module:sap/base/util/JSTokenizer
-	//  * @since 1.58
-	//  * @private
-	//  * @ui5-restricted sap.ui.core
-	//  */
+	/**
+	 * @class Tokenizer for JS values.
+	 *
+	 * Contains functions to consume tokens on an input string.
+	 *
+	 * @example
+	 * sap.ui.require(["sap/base/util/JSTokenizer"], function(JSTokenizer){
+	 *      JSTokenizer().parseJS("{test:'123'}"); // {test:'123'}
+	 * });
+	 *
+	 * @alias module:sap/base/util/JSTokenizer
+	 * @since 1.58
+	 * @private
+	 * @ui5-restricted sap.ui.core
+	 */
 	var JSTokenizer = function() {
 
 		this.at; // The index of the current character
@@ -310,12 +315,12 @@
 		}
 	};
 
-	// /**
-	//  * Returns the index of the current character.
-	//  *
-	//  * @private
-	//  * @returns {int} The current character's index.
-	//  */
+	/**
+	 * Returns the index of the current character.
+	 *
+	 * @private
+	 * @returns {int} The current character's index.
+	 */
 	JSTokenizer.prototype.getIndex = function() {
 		return this.at - 1;
 	};
@@ -330,13 +335,13 @@
 		this.ch = ' ';
 	};
 
-	// /**
-	//  * Advances the index in the text to <code>iIndex</code>. Fails if the new index
-	//  * is smaller than the previous index.
-	//  *
-	//  * @private
-	//  * @param {int} iIndex - the new index
-	//  */
+	/**
+	 * Advances the index in the text to <code>iIndex</code>. Fails if the new index
+	 * is smaller than the previous index.
+	 *
+	 * @private
+	 * @param {int} iIndex - the new index
+	 */
 	JSTokenizer.prototype.setIndex = function(iIndex) {
 		if (iIndex < this.at - 1) {
 			throw new Error("Must not set index " + iIndex
@@ -346,17 +351,17 @@
 		this.next();
 	};
 
-	// /**
-	//  * Return the parse function. It will have access to all of the above
-	//  * functions and variables.
-	//  *
-	//  * @private
-	//  * @ui5-restricted sap.ui.core
-	//  * @static
-	//  * @param {string} sSource The js source
-	//  * @param {int} iStart The start position
-	//  * @returns {object} the JavaScript object
-	//  */
+	/**
+	 * Return the parse function. It will have access to all of the above
+	 * functions and variables.
+	 *
+	 * @private
+	 * @ui5-restricted sap.ui.core
+	 * @static
+	 * @param {string} sSource The js source
+	 * @param {int} iStart The start position
+	 * @returns {object} the JavaScript object
+	 */
 	JSTokenizer.parseJS = function(sSource, iStart) {
 
 		var oJSTokenizer = new JSTokenizer();
@@ -378,4 +383,5 @@
 
 //	return JSTokenizer;
 //});
+
 module.exports = JSTokenizer;

--- a/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -3,7 +3,7 @@ const XMLTemplateAnalyzer = require("../../../../lib/lbt/analyzer/XMLTemplateAna
 const ModuleInfo = require("../../../../lib/lbt/resources/ModuleInfo");
 const sinon = require("sinon");
 
-test("integration: Analysis of an xml view", async (t) => {
+test("integration: Analysis of a xml view", async (t) => {
 	const xml = `<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:m="sap.m" xmlns:l="sap.ui.layout"
 		controllerName="myController">
 			<l:HorizontalLayout id="layout">
@@ -33,7 +33,7 @@ test("integration: Analysis of an xml view", async (t) => {
 		"Implicit dependency should be added since an XMLView is analyzed");
 });
 
-test("integration: Analysis of an xml view with data binding in properties", async (t) => {
+test("integration: Analysis of a xml view with data binding in properties", async (t) => {
 	const xml = `<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core"
 		controllerName="myController">
 			<core:ComponentContainer async="true" name="{/component}" />
@@ -58,7 +58,41 @@ test("integration: Analysis of an xml view with data binding in properties", asy
 		"Implicit dependency should be added since an XMLView is analyzed");
 });
 
-test("integration: Analysis of an xml fragment", async (t) => {
+test("integration: Analysis of a xml view with core:require", async (t) => {
+	const xml = `<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core" xmlns="sap.m"
+		controllerName="myController"
+		core:require="{
+			Foo:'sap/ui/Foo',
+			Bar:'myApp/Bar'
+		}">
+
+			<Button core:require="{Toast:'sap/m/MessageToast'}" text="Show Toast" press="Toast.show(\${$source>text})"/>
+
+		</mvc:View>`;
+	const mockPool = {async findResource(name) {
+		return {
+			buffer: () => name.endsWith(".xml") ? JSON.stringify(xml): "test"
+		};
+	}};
+
+	const moduleInfo = new ModuleInfo();
+
+	const analyzer = new XMLTemplateAnalyzer(mockPool);
+	await analyzer.analyzeView(xml, moduleInfo);
+	t.deepEqual(moduleInfo.dependencies,
+		[
+			"sap/ui/core/mvc/XMLView.js",
+			"myController.controller.js",
+			"sap/ui/Foo.js",
+			"myApp/Bar.js",
+			"sap/m/MessageToast.js",
+			"sap/m/Button.js"
+		], "Dependencies should come from the XML template");
+	t.true(moduleInfo.isImplicitDependency("sap/ui/core/mvc/XMLView.js"),
+		"Implicit dependency should be added since an XMLView is analyzed");
+});
+
+test("integration: Analysis of a xml fragment", async (t) => {
 	const xml = `<HBox xmlns:m="sap.m" xmlns:l="sap.ui.layout" controllerName="myController">
 			<items>
 				<l:HorizontalLayout id="layout">

--- a/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -92,6 +92,68 @@ test("integration: Analysis of a xml view with core:require", async (t) => {
 		"Implicit dependency should be added since an XMLView is analyzed");
 });
 
+test("integration: Analysis of a xml view with core:require (invalid module name)", async (t) => {
+	const xml = `<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core" xmlns="sap.m"
+		controllerName="myController"
+		core:require="{
+			Foo: { 'bar': true },
+			Bar: 123
+		}">
+
+			<Button core:require="{ Toast: '' }" text="Show Toast" press="Toast.show(\${$source>text})"/>
+
+		</mvc:View>`;
+	const mockPool = {async findResource(name) {
+		return {
+			buffer: () => name.endsWith(".xml") ? JSON.stringify(xml): "test"
+		};
+	}};
+
+	const moduleInfo = new ModuleInfo();
+
+	const analyzer = new XMLTemplateAnalyzer(mockPool);
+	await analyzer.analyzeView(xml, moduleInfo);
+	t.deepEqual(moduleInfo.dependencies,
+		[
+			"sap/ui/core/mvc/XMLView.js",
+			"myController.controller.js",
+			"sap/m/Button.js"
+		], "Dependencies should come from the XML template");
+	t.true(moduleInfo.isImplicitDependency("sap/ui/core/mvc/XMLView.js"),
+		"Implicit dependency should be added since an XMLView is analyzed");
+});
+
+test("integration: Analysis of a xml view with core:require (parsing error)", async (t) => {
+	const xml = `<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core" xmlns="sap.m"
+		controllerName="myController"
+		core:require="{
+			Foo:'sap/ui/Foo'
+			Bar:'myApp/Bar'
+		}">
+
+			<Button core:require="this can't be parsed" text="Show Toast" press="Toast.show(\${$source>text})"/>
+
+		</mvc:View>`;
+	const mockPool = {async findResource(name) {
+		return {
+			buffer: () => name.endsWith(".xml") ? JSON.stringify(xml): "test"
+		};
+	}};
+
+	const moduleInfo = new ModuleInfo();
+
+	const analyzer = new XMLTemplateAnalyzer(mockPool);
+	await analyzer.analyzeView(xml, moduleInfo);
+	t.deepEqual(moduleInfo.dependencies,
+		[
+			"sap/ui/core/mvc/XMLView.js",
+			"myController.controller.js",
+			"sap/m/Button.js"
+		], "Dependencies should come from the XML template");
+	t.true(moduleInfo.isImplicitDependency("sap/ui/core/mvc/XMLView.js"),
+		"Implicit dependency should be added since an XMLView is analyzed");
+});
+
 test("integration: Analysis of a xml fragment", async (t) => {
 	const xml = `<HBox xmlns:m="sap.m" xmlns:l="sap.ui.layout" controllerName="myController">
 			<items>

--- a/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -3,7 +3,7 @@ const XMLTemplateAnalyzer = require("../../../../lib/lbt/analyzer/XMLTemplateAna
 const ModuleInfo = require("../../../../lib/lbt/resources/ModuleInfo");
 const sinon = require("sinon");
 
-test("integration: Analysis of a xml view", async (t) => {
+test("integration: Analysis of an xml view", async (t) => {
 	const xml = `<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:m="sap.m" xmlns:l="sap.ui.layout"
 		controllerName="myController">
 			<l:HorizontalLayout id="layout">
@@ -33,7 +33,7 @@ test("integration: Analysis of a xml view", async (t) => {
 		"Implicit dependency should be added since an XMLView is analyzed");
 });
 
-test("integration: Analysis of a xml view with data binding in properties", async (t) => {
+test("integration: Analysis of an xml view with data binding in properties", async (t) => {
 	const xml = `<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core"
 		controllerName="myController">
 			<core:ComponentContainer async="true" name="{/component}" />
@@ -58,7 +58,7 @@ test("integration: Analysis of a xml view with data binding in properties", asyn
 		"Implicit dependency should be added since an XMLView is analyzed");
 });
 
-test("integration: Analysis of a xml view with core:require", async (t) => {
+test("integration: Analysis of an xml view with core:require", async (t) => {
 	const xml = `<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core" xmlns="sap.m"
 		controllerName="myController"
 		core:require="{
@@ -92,7 +92,7 @@ test("integration: Analysis of a xml view with core:require", async (t) => {
 		"Implicit dependency should be added since an XMLView is analyzed");
 });
 
-test("integration: Analysis of a xml view with core:require (invalid module name)", async (t) => {
+test("integration: Analysis of an xml view with core:require (invalid module name)", async (t) => {
 	const xml = `<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core" xmlns="sap.m"
 		controllerName="myController"
 		core:require="{
@@ -123,7 +123,7 @@ test("integration: Analysis of a xml view with core:require (invalid module name
 		"Implicit dependency should be added since an XMLView is analyzed");
 });
 
-test("integration: Analysis of a xml view with core:require (parsing error)", async (t) => {
+test("integration: Analysis of an xml view with core:require (parsing error)", async (t) => {
 	const xml = `<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core" xmlns="sap.m"
 		controllerName="myController"
 		core:require="{
@@ -154,7 +154,7 @@ test("integration: Analysis of a xml view with core:require (parsing error)", as
 		"Implicit dependency should be added since an XMLView is analyzed");
 });
 
-test("integration: Analysis of a xml fragment", async (t) => {
+test("integration: Analysis of an xml fragment", async (t) => {
 	const xml = `<HBox xmlns:m="sap.m" xmlns:l="sap.ui.layout" controllerName="myController">
 			<items>
 				<l:HorizontalLayout id="layout">

--- a/test/lib/lbt/utils/JSTokenizer.js
+++ b/test/lib/lbt/utils/JSTokenizer.js
@@ -1,0 +1,87 @@
+const test = require("ava");
+const JSTokenizer = require("../../../../lib/lbt/utils/JSTokenizer");
+
+test("valid expressions", function(t) {
+	const list = [
+		"{}",
+		"{test:'123'}",
+		"{test:456.00}",
+		"{test:-456}",
+		"{test:-456e9}",
+		"{test:77E-4}",
+		"{test:\"123\"}",
+		"{23:'test'}",
+		"{'23':'test'}",
+		"{aa:'123', bb:'456'}",
+		"{a1:123, b2:'456', c3:false, c4:true, d5:null}",
+		"{a:{}, b:[], c:'test'}",
+		"{a:{a:{a:{a:{a:{}}}}}}",
+		"{$a:{$a:{$a:{$a:{$a:{}}}}}}",
+		"{arr:[1,2,3,4]}",
+		"{arr:[1,'2',3,false]}",
+		"{test:'{test}'}",
+		"{test:'\\'\"\\\\'}"
+	];
+	for (let i = 0; i < list.length; i++) {
+		let evalResult;
+		eval("evalResult=" + list[i]); // eslint-disable-line no-eval
+		t.deepEqual(JSTokenizer.parseJS(list[i]), evalResult, "Parse " + list[i]);
+	}
+});
+
+test("invalid expressions", function(t) {
+	[
+		"{[}",
+		"{test:'123\"}",
+		"{test:\"123}",
+		"{23a:'test'}",
+		"{aa:'123' bb:'456'}",
+		"{a1:123a, b2:'456', c3:false}",
+		"{a:{}, b:[}, c:'test'}",
+		"{a:{a:{a:{a:{a:{}}}}}}}",
+		"{arr:[1,2,3,4,,]}",
+		"{arr:[1,'2,3,false]}",
+		"{test:'{test}',test}",
+		"{test:''\"\\'}"
+	].forEach(function(input) {
+		t.throws(function() {
+			try {
+				JSTokenizer.parseJS(input);
+			} catch (e) {
+				// Wrap as Error as JSTokenizer might just throw an object
+				// which is not accepted as error by ava
+				throw new Error(e);
+			}
+		});
+	});
+});
+
+test("tokenizer with enhancements getCh, getIndex, init, setIndex", function(t) {
+	const oTokenizer = new JSTokenizer();
+	const oTokenizer2 = new JSTokenizer();
+
+	oTokenizer.init("{='foo'}");
+	t.is(oTokenizer.getIndex(), -1, "index after init without start index");
+	t.is(oTokenizer.getCh(), " ");
+
+	oTokenizer.init("{='foo'}", 2);
+	t.is(oTokenizer.getIndex(), 1, "index after init with start index");
+	t.is(oTokenizer.getCh(), " ");
+
+	oTokenizer.next();
+	t.is(oTokenizer.getIndex(), 2, "index after next");
+	t.is(oTokenizer.getCh(), "'");
+
+	oTokenizer.setIndex(7);
+	t.is(oTokenizer.getIndex(), 7, "index after setIndex");
+	t.is(oTokenizer.getCh(), "}");
+
+	t.throws(function() {
+		oTokenizer.setIndex(0);
+	}, /Must not set index 0 before previous index 7/, "setIndex must not go back in text");
+	oTokenizer.setIndex(42);
+	t.is(oTokenizer.getCh(), "", "move index beyond text end");
+
+	oTokenizer2.init("{='other foo'}");
+	t.true(oTokenizer2.getIndex() !== oTokenizer.getIndex(), "different instances");
+});


### PR DESCRIPTION
Starting with UI5 1.69, a core:require attribute can be used in XML
views/fragments to require modules/controls to be used within the XML
context.
https://github.com/SAP/openui5/commit/2dab48e8c3604099f7d2bd56741f5635d3357639

This change supports detecting those modules to be included in bundles.

### Open Issues
- [x] How to integrate/reuse JSTokenizer? (Currently a copy from OpenUI5 is included)
- [x] Add more test cases