### PR TITLE
[INTERNAL] Align set of known file types with runtime

### DIFF
--- a/lib/lbt/utils/ModuleName.js
+++ b/lib/lbt/utils/ModuleName.js
@@ -45,7 +45,7 @@ function toRequireJSName(path) {
 	return path.slice(0, -3); // cut off '.js'
 }
 
-const KNOWN_TYPES = /\.(properties|css|(?:(?:view\.|fragment\.)?(?:html|json|xml|js))|(?:(?:controller\.)?js))$/;
+const KNOWN_TYPES = /\.(properties|css|(?:(?:view\.|fragment\.)?(?:html|json|xml|js))|(?:(?:controller\.|designtime\.|support\.)?js))$/;
 
 function getDebugName(name) {
 	const m = KNOWN_TYPES.exec(name);

--- a/lib/processors/debugFileCreator.js
+++ b/lib/processors/debugFileCreator.js
@@ -12,7 +12,7 @@ const util = require("util");
  */
 module.exports = function({resources, fs}) {
 	const options = {
-		pattern: /((\.view|\.fragment|\.controller)?\.js)/,
+		pattern: /((\.view|\.fragment|\.controller|\.designtime|\.support)?\.js)/,
 		replacement: "-dbg$1"
 	};
 

--- a/test/lib/lbt/utils/ModuleName.js
+++ b/test/lib/lbt/utils/ModuleName.js
@@ -50,6 +50,10 @@ test("toRequireJSName", (t) => {
 
 test("getDebugName", (t) => {
 	t.deepEqual(ModuleName.getDebugName("a.controller.js"), "a-dbg.controller.js", "'-dbg' is added");
+	t.deepEqual(ModuleName.getDebugName("a.designtime.js"), "a-dbg.designtime.js", "'-dbg' is added");
+	t.deepEqual(ModuleName.getDebugName("a.fragment.js"), "a-dbg.fragment.js", "'-dbg' is added");
+	t.deepEqual(ModuleName.getDebugName("a.support.js"), "a-dbg.support.js", "'-dbg' is added");
+	t.deepEqual(ModuleName.getDebugName("a.view.js"), "a-dbg.view.js", "'-dbg' is added");
 	t.deepEqual(ModuleName.getDebugName("a.css"), "a-dbg.css", "'-dbg' is added");
 	t.falsy(ModuleName.getDebugName("a"), "non supported file ending");
 	t.falsy(ModuleName.getDebugName("a.mjs"), "non supported file ending");
@@ -57,6 +61,10 @@ test("getDebugName", (t) => {
 
 test("getNonDebugName", (t) => {
 	t.deepEqual(ModuleName.getNonDebugName("a-dbg.controller.js"), "a.controller.js", "contains '-dbg'");
+	t.deepEqual(ModuleName.getNonDebugName("a-dbg.designtime.js"), "a.designtime.js", "contains '-dbg'");
+	t.deepEqual(ModuleName.getNonDebugName("a-dbg.fragment.js"), "a.fragment.js", "contains '-dbg'");
+	t.deepEqual(ModuleName.getNonDebugName("a-dbg.support.js"), "a.support.js", "contains '-dbg'");
+	t.deepEqual(ModuleName.getNonDebugName("a-dbg.view.js"), "a.view.js", "contains '-dbg'");
 	t.deepEqual(ModuleName.getNonDebugName("a-dbg.css"), "a.css", "contains '-dbg'");
 	t.falsy(ModuleName.getNonDebugName("a"), "does not contain '-dbg'");
 	t.falsy(ModuleName.getNonDebugName("a-dbg.mjs"), "does contain '-dbg' but ending is not supported");

--- a/test/lib/tasks/createDebugFiles.js
+++ b/test/lib/tasks/createDebugFiles.js
@@ -98,6 +98,37 @@ test("integration: test.controller.js: dbg file creation", (t) => {
 	});
 });
 
+test("integration: test.designtime.js: dbg file creation", (t) => {
+	const sourceAdapter = resourceFactory.createAdapter({
+		virBasePath: "/"
+	});
+	const content = "sap.ui.define([],function(){return {};});";
+
+	const resource = resourceFactory.createResource({
+		path: "/test.designtime.js",
+		string: content
+	});
+
+	return sourceAdapter.write(resource).then(() => {
+		return tasks.createDebugFiles({
+			workspace: sourceAdapter,
+			options: {
+				pattern: "/**/*.js"
+			}
+		}).then(() => {
+			return sourceAdapter.byPath("/test-dbg.designtime.js").then((resource) => {
+				if (!resource) {
+					t.fail("Could not find /test-dbg.designtime.js in target");
+				} else {
+					return resource.getBuffer();
+				}
+			});
+		}).then((buffer) => {
+			t.deepEqual(buffer.toString(), content, "Correct content");
+		});
+	});
+});
+
 test("integration: test.fragment.js: dbg file creation", (t) => {
 	const sourceAdapter = resourceFactory.createAdapter({
 		virBasePath: "/"
@@ -119,6 +150,37 @@ test("integration: test.fragment.js: dbg file creation", (t) => {
 			return sourceAdapter.byPath("/test-dbg.fragment.js").then((resource) => {
 				if (!resource) {
 					t.fail("Could not find /test-dbg.fragment.js in target locator");
+				} else {
+					return resource.getBuffer();
+				}
+			});
+		}).then((buffer) => {
+			t.deepEqual(buffer.toString(), content, "Correct content");
+		});
+	});
+});
+
+test("integration: test.support.js: dbg file creation", (t) => {
+	const sourceAdapter = resourceFactory.createAdapter({
+		virBasePath: "/"
+	});
+	const content = "sap.ui.define([],function(){return {};});";
+
+	const resource = resourceFactory.createResource({
+		path: "/test.support.js",
+		string: content
+	});
+
+	return sourceAdapter.write(resource).then(() => {
+		return tasks.createDebugFiles({
+			workspace: sourceAdapter,
+			options: {
+				pattern: "/**/*.js"
+			}
+		}).then(() => {
+			return sourceAdapter.byPath("/test-dbg.support.js").then((resource) => {
+				if (!resource) {
+					t.fail("Could not find /test-dbg.support.js in target");
 				} else {
 					return resource.getBuffer();
 				}


### PR DESCRIPTION
UI5 runtime knows JavaScript file types controller, designtime, fragment, support and view.

TODO: support files should not be uglified (to keep the rules source code readable). It has to be decided whether this is realized by configuration or whether it should be hard coded in the task / processor or (library) type. Nevertheless, the tooling should know that type anyhow to be able to handle it correctly.

Fixes #336 
