### PR TITLE
[FIX] Improve recognition of main module in case of bundles

### DIFF
--- a/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -470,7 +470,7 @@ class JSModuleAnalyzer {
 			let i = 0;
 
 			// get the documentation from a preceding comment
-			let desc = getDocumentation(defineCall);
+			const desc = getDocumentation(defineCall);
 
 			// determine the name of the module
 			let name = null;

--- a/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -215,9 +215,19 @@ const CALL_JQUERY_SAP_DECLARE = [["jQuery", "$"], "sap", "declare"];
 const CALL_JQUERY_SAP_IS_DECLARED = [["jQuery", "$"], "sap", "isDeclared"];
 const CALL_JQUERY_SAP_REQUIRE = [["jQuery", "$"], "sap", "require"];
 const CALL_JQUERY_SAP_REGISTER_PRELOADED_MODULES = [["jQuery", "$"], "sap", "registerPreloadedModules"];
+const SPECIAL_AMD_DEPENDENCIES = ["require", "exports", "module"];
+
 
 function isCallableExpression(node) {
 	return node.type == Syntax.FunctionExpression || node.type == Syntax.ArrowFunctionExpression;
+}
+
+/*
+ * Dummy implementation.
+ * Sole purpose is to easier align with the old (Java) implementation of the bundle tooling.
+ */
+function getDocumentation(node) {
+	return undefined;
 }
 
 /**
@@ -231,21 +241,56 @@ function isCallableExpression(node) {
  */
 class JSModuleAnalyzer {
 	analyze(ast, defaultName, info) {
+		let mainModuleFound = false;
+		/**
+		 * Number of (sap.ui.)define calls without a module ID.
+		 * Only tracked to be able to complain about multiple module definitions without ID.
+		 */
+		let nUnnamedDefines = 0;
+		/**
+		 * ID of the first named (sap.ui.)define call.
+		 * Remembered together with the corresponding description in case no other main module
+		 * can be found (no unnamed module, no module with the ID that matches the filename).
+		 * Will be used as main module ID if only one module definition exists in the file.
+		 */
+		let candidateName = null;
+		let candidateDescription = null;
+
+		/**
+		 * Total number of module declarations (declare or define).
+		 */
 		let nModuleDeclarations = 0;
 
-		// console.log(JSON.stringify(ast, null, "  "));
-
+		// first analyze the whole AST
 		visit(ast, false);
 
+		// then take conclusions about the file's content
+		if ( !mainModuleFound ) {
+			// if there's exactly one module definition in this file but it didn't
+			// immediately qualify as main module, make it now the main module
+			if ( candidateName != null && nModuleDeclarations == 1 ) {
+				info.name = candidateName;
+				info.description = candidateDescription;
+				mainModuleFound = true;
+			} else {
+				// no main module found, use the default name
+				info.name = defaultName;
+			}
+		}
+
+		// depending on the used module APIs, add an implicit dependency to the loader entry module
 		if ( info.format === ModuleFormat.UI5_LEGACY ) {
 			info.addImplicitDependency(UI5ClientConstants.MODULE__JQUERY_SAP_GLOBAL);
 		} else if ( info.format === ModuleFormat.UI5_DEFINE ) {
+			// Note: the implicit dependency for sap.ui.define modules points to the standard UI5
+			// loader config module. A more general approach would be to add a dependency to the loader
+			// only, but then standard configuration would be missed by dependency resolution
+			// (to be clarified)
 			info.addImplicitDependency(UI5ClientConstants.MODULE__UI5LOADER_AUTOCONFIG);
 		}
-		if ( nModuleDeclarations === 0 && info.name == null ) {
-			info.name = defaultName;
-		}
-		if ( info.dependencies.length === 0 && info.subModules.length === 0 ) {
+
+		if ( nModuleDeclarations === 0 && info.dependencies.length === 0 && info.subModules.length === 0 ) {
+			// when there are no indicators for module APIs, mark the module as 'raw' module
 			info.rawModule = true;
 		}
 
@@ -260,6 +305,16 @@ class JSModuleAnalyzer {
 		return;
 
 		// hoisted functions
+		function setMainModuleInfo(name, description) {
+			if ( mainModuleFound ) {
+				throw new Error("conflicting main modules found (unnamed + named)");
+			}
+			mainModuleFound = true;
+			info.name = name;
+			if ( description != null ) {
+				info.description = description;
+			}
+		}
 
 		function visit(node, conditional) {
 			// console.log("visiting ", node);
@@ -393,16 +448,13 @@ class JSModuleAnalyzer {
 			const args = node.arguments;
 			if ( args.length > 0 && isString(args[0]) ) {
 				const name = ModuleName.fromUI5LegacyName( args[0].value );
-				if ( nModuleDeclarations === 1 ) {
+				if ( nModuleDeclarations === 1 && !mainModuleFound) {
 					// if this is the first declaration, then this is the main module declaration
 					// note that this overrides an already given name
-					info.name = name;
-					/* NODE-TODO
-					info.description = getDocumentation(node);
-					 */
+					setMainModuleInfo(name, getDocumentation(node));
 				} else if ( nModuleDeclarations > 1 && name === info.name ) {
 					// ignore duplicate declarations (e.g. in behavior file of design time controls)
-					log.warn(`duplicate declaration of module ${getLocation(args)} in ${name}`);
+					log.warn(`duplicate declaration of module name at ${getLocation(args)} in ${name}`);
 				} else {
 					// otherwise it is just a submodule declaration
 					info.addSubModule(name);
@@ -417,29 +469,35 @@ class JSModuleAnalyzer {
 			const nArgs = args.length;
 			let i = 0;
 
+			// get the documentation from a preceding comment
+			let desc = getDocumentation(defineCall);
+
 			// determine the name of the module
-			let name = defaultName;
+			let name = null;
 			if ( i < nArgs && isString(args[i]) ) {
 				name = ModuleName.fromRequireJSName( args[i++].value );
-			}
-			if ( name == null ) {
-				throw new TypeError("define/sap.ui.define: module name could not be determined," +
-					`neither from environment nor from first argument: ${args[i] && args[i].type}`);
-			}
-
-			if ( nModuleDeclarations === 1 ) {
-				// if this is the first declaration, then this is the main module declaration
-				info.name = name;
-
-				// get the documentation from a preceding comment
-				/* NODE-TODO
-				info.description = getDocumentation(defineNode);
-				*/
-			} else {
 				if ( name === defaultName ) {
-					throw new Error("module name could not be determined");
+					// hardcoded name equals the file name, so this definition qualifies as main module definition
+					setMainModuleInfo(name, desc);
+				} else {
+					info.addSubModule(name);
+					if ( candidateName == null ) {
+						// remember the name and description in case no other module qualifies as main module
+						candidateName = name;
+						candidateDescription = desc;
+					}
 				}
-				info.addSubModule(name);
+			} else {
+				nUnnamedDefines++;
+				if ( nUnnamedDefines > 1 ) {
+					throw new Error("if multiple modules are contained in a file, only one of them may omit the module ID " + name + " " + nUnnamedDefines);
+				}
+				if ( defaultName == null ) {
+					throw new Error("unnamed module found, but no default name given");
+				}
+				name = defaultName;
+				// the first unnamed module definition qualifies as main module
+				setMainModuleInfo(name, desc);
 			}
 
 			// process array of required modules, if given
@@ -538,6 +596,10 @@ class JSModuleAnalyzer {
 			// console.log(array);
 			array.forEach( (item) => {
 				if ( isString(item) ) {
+					// ignore special AMD dependencies (require, exports, module)
+					if ( SPECIAL_AMD_DEPENDENCIES.indexOf(item.value) >= 0 ) {
+						return;
+					}
 					let requiredModule;
 					if (name == null) {
 						requiredModule = ModuleName.fromRequireJSName( item.value );

--- a/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -205,7 +205,6 @@ const CALL_AMD_DEFINE = ["define"];
 const CALL_AMD_REQUIRE = ["require"];
 const CALL_REQUIRE_SYNC = ["require", "sync"];
 const CALL_REQUIRE_PREDEFINE = ["require", "predefine"];
-const CALL_REQUIRE_PRELOAD = ["require", "preload"];
 const CALL_SAP_UI_DEFINE = ["sap", "ui", "define"];
 const CALL_SAP_UI_REQUIRE = ["sap", "ui", "require"];
 const CALL_SAP_UI_REQUIRE_SYNC = ["sap", "ui", "requireSync"];
@@ -261,10 +260,29 @@ class JSModuleAnalyzer {
 		 */
 		let nModuleDeclarations = 0;
 
-		// first analyze the whole AST
+		// first analyze the whole AST...
 		visit(ast, false);
 
-		// then take conclusions about the file's content
+		// ...then all the comments
+		if ( Array.isArray(ast.comments) ) {
+			ast.comments.forEach((comment) => {
+				if ( comment.type === "Line" && comment.value.startsWith("@ui5-bundle") ) {
+					if ( comment.value.startsWith("@ui5-bundle-raw-include ") ) {
+						const subModule = comment.value.slice("@ui5-bundle-raw-include ".length);
+						info.addSubModule(subModule);
+						log.debug(`bundle include directive ${subModule}`);
+					} else if ( comment.value.startsWith("@ui5-bundle ") ) {
+						const bundleName = comment.value.slice("@ui5-bundle ".length);
+						setMainModuleInfo(bundleName, null);
+						log.debug(`bundle name directive ${bundleName}`);
+					} else {
+						log.warn(`unrecognized bundle directive ${comment.value}`);
+					}
+				}
+			});
+		}
+
+		// ...and finally take conclusions about the file's content
 		if ( !mainModuleFound ) {
 			// if there's exactly one module definition in this file but it didn't
 			// immediately qualify as main module, make it now the main module
@@ -391,13 +409,14 @@ class JSModuleAnalyzer {
 					// recognizes a call to jQuery.sap.require
 					info.setFormat(ModuleFormat.UI5_LEGACY);
 					onJQuerySapRequire(node, conditional);
-				} else if ( isMethodCall(node, CALL_JQUERY_SAP_REGISTER_PRELOADED_MODULES)
-							|| isMethodCall(node, CALL_REQUIRE_PRELOAD)
-							|| isMethodCall(node, CALL_SAP_UI_REQUIRE_PRELOAD) ) {
+				} else if ( isMethodCall(node, CALL_JQUERY_SAP_REGISTER_PRELOADED_MODULES) ) {
 					// recognizes a call to jQuery.sap.registerPreloadedModules
-					const legacyCall = isMethodCall(node, CALL_JQUERY_SAP_REGISTER_PRELOADED_MODULES);
-					info.setFormat( legacyCall ? ModuleFormat.UI5_LEGACY : ModuleFormat.UI5_DEFINE);
-					onRegisterPreloadedModules(node, legacyCall);
+					info.setFormat(ModuleFormat.UI5_LEGACY);
+					onRegisterPreloadedModules(node, /* evoSyntax= */ false);
+				} else if ( isMethodCall(node, CALL_SAP_UI_REQUIRE_PRELOAD) ) {
+					// recognizes a call to sap.ui.require.preload
+					info.setFormat(ModuleFormat.UI5_DEFINE);
+					onRegisterPreloadedModules(node, /* evoSyntax= */ true);
 				} else if ( isCallableExpression(node.callee) ) {
 					// recognizes a scope function declaration + argument
 					visit(node.arguments, conditional);
@@ -560,35 +579,31 @@ class JSModuleAnalyzer {
 			}
 		}
 
-		function onRegisterPreloadedModules(node, legacyCall) {
+		function onRegisterPreloadedModules(node, evoSyntax) {
 			const args = node.arguments;
 
 			// trace.debug("**** registerPreloadedModules detected");
-			if ( args.length > 0 && args[0].type == Syntax.ObjectExpression ) {
-				let modules = args[0];
-				let isNewSyntax = true;
+			let modules = null;
+			let namesUseLegacyNotation = false;
 
-				if ( legacyCall ) {
-					const obj = args[0];
-					isNewSyntax = false;
-					const version = findOwnProperty(obj, "version");
-					if ( version && isString(version) && parseFloat(version.value) >= 2.0 ) {
-						isNewSyntax = true;
+			if ( evoSyntax ) {
+				modules = args[0];
+			} else {
+				const obj = args[0];
+				const version = findOwnProperty(obj, "version");
+				namesUseLegacyNotation = !(version && isString(version) && parseFloat(version.value) >= 2.0);
+				modules = findOwnProperty(obj, "modules");
+			}
+			if ( modules && modules.type == Syntax.ObjectExpression ) {
+				modules.properties.forEach( function(property) {
+					let	moduleName = getPropertyKey(property);
+					if ( namesUseLegacyNotation ) {
+						moduleName = ModuleName.fromUI5LegacyName(moduleName);
 					}
-					modules = findOwnProperty(obj, "modules");
-				}
-
-				if ( modules && modules.type == Syntax.ObjectExpression ) {
-					modules.properties.forEach( function(property) {
-						let	moduleName = getPropertyKey(property);
-						if ( !isNewSyntax ) {
-							moduleName = ModuleName.fromUI5LegacyName(moduleName);
-						}
-						info.addSubModule(moduleName);
-					});
-				} else {
-					log.warn("Cannot evaluate registerPreloadedModules: '%s'", modules && modules.type);
-				}
+					info.addSubModule(moduleName);
+				});
+			} else {
+				log.warn("Cannot evaluate registerPreloadedModules: '%s'", modules && modules.type);
 			}
 		}
 

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -42,7 +42,7 @@ const UI5BundleFormat = {
 		outW.write(`jQuery.sap.registerPreloadedModules(`);
 		outW.writeln(`{`);
 		if ( section.name ) {
-			outW.writeln(`"name":"${section.getSectionName()}",`);
+			outW.writeln(`"name":"${section.name}",`);
 		}
 		outW.writeln(`"version":"2.0",`);
 		outW.writeln(`"modules":{`);
@@ -73,7 +73,7 @@ const EVOBundleFormat = {
 	afterPreloads(outW, section) {
 		outW.write(`}`);
 		if ( section.name ) {
-			outW.write(`,"${section.getSectionName()}"`);
+			outW.write(`,"${section.name}"`);
 		}
 		outW.writeln(`);`);
 	},
@@ -143,8 +143,6 @@ class BundleBuilder {
 		// TODO is the following condition ok or should the availability of jquery.sap.global.js be configurable?
 		this.jqglobalAvailable = !resolvedModule.containsGlobal;
 		this.openModule(resolvedModule.name);
-
-		this.writeConfiguration(resolvedModule.configuration); // NODE-TODO configuration currently will be undefined
 
 		// create all sections in sequence
 		for ( const section of resolvedModule.sections ) {
@@ -229,24 +227,6 @@ class BundleBuilder {
 			});
 			this.missingRawDeclarations = [];
 		}
-	}
-
-	writeConfiguration(config) {
-		if ( !config ) {
-			return;
-		}
-		const outW = this.outW;
-		outW.ensureNewLine(); // for clarity and to avoid issues with single line comments
-		outW.writeln(`(function(window){`);
-		outW.writeln(`\tvar cfg=window['sap-ui-config']=window['sap-ui-config']||{},`);
-		outW.writeln(`\t\troots=cfg.resourceRoots=cfg.resourceRoots||{};`);
-		config.propertyName.forEach( (property) => {
-			outW.writeln(`\tcfg[${makeStringLiteral(property)}]=${config.getPropertyAsJSLiteral(property)};`);
-		});
-		Object.keys(config.resourceRoots).forEach( (prefix) => {
-			outW.writeln(`\troots[${makeStringLiteral(prefix)}]=${makeStringLiteral(config.resourceRoots[prefix])};`);
-		});
-		outW.writeln(`}(window));`);
 	}
 
 	// TODO check that there are only JS modules contained

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -169,6 +169,7 @@ class BundleBuilder {
 		this.outW = new BundleWriter();
 		this.missingRawDeclarations = [];
 
+		this.outW.writeln("//@ui5-bundle " + module);
 		if ( this.shouldDecorate ) {
 			this.outW.writeln(`window["sap-ui-optimized"] = true;`);
 			if ( this.options.addTryCatchRestartWrapper ) {
@@ -255,6 +256,8 @@ class BundleBuilder {
 			const resource = await this.pool.findResourceWithInfo(module);
 			if ( resource != null ) {
 				this.outW.startSegment(module);
+				this.outW.ensureNewLine();
+				this.outW.writeln("//@ui5-bundle-raw-include " + module);
 				await this.writeRawModule(module, resource);
 				const compressedSize = this.outW.endSegment();
 				log.verbose("    %s (%d,%d)", module, resource.info != null ? resource.info.size : -1, compressedSize);

--- a/lib/lbt/bundle/ResolvedBundleDefinition.js
+++ b/lib/lbt/bundle/ResolvedBundleDefinition.js
@@ -99,16 +99,13 @@ class ResolvedSection {
 		return this.sectionDefinition.mode;
 	}
 
-	/*
-	public String getSectionName() {
-		return sectionDefinition.getSectionName();
+	get name() {
+		return this.sectionDefinition.name;
 	}
 
-	public boolean isDeclareRawModules() {
-		return sectionDefinition.isDeclareRawModules();
+	get declareRawModules() {
+		return this.sectionDefinition.declareRawModules;
 	}
-
-	*/
 }
 
 module.exports = ResolvedBundleDefinition;

--- a/lib/lbt/calls/SapUiDefine.js
+++ b/lib/lbt/calls/SapUiDefine.js
@@ -72,21 +72,4 @@ class SapUiDefineCall {
 	}
 }
 
-function isSapUiDefineCall(node) {
-	return (
-		node
-		&& node.type === Syntax.CallExpression
-		&& node.callee.type === Syntax.MemberExpression
-		&& node.callee.object.type === Syntax.MemberExpression
-		&& node.callee.object.object.type === Syntax.Identifier
-		&& node.callee.object.object.name === "sap"
-		&& node.callee.object.property.type === Syntax.Identifier
-		&& node.callee.object.property.name === "ui"
-		&& node.callee.property.type === Syntax.Identifier
-		&& node.callee.property.name === "define"
-	);
-}
-
-SapUiDefineCall.check = isSapUiDefineCall;
-
 module.exports = SapUiDefineCall;

--- a/lib/lbt/resources/ModuleInfo.js
+++ b/lib/lbt/resources/ModuleInfo.js
@@ -179,13 +179,15 @@ class ModuleInfo {
 
 	set name(n) {
 		this._name = n;
-		if ( Object.prototype.hasOwnProperty.call(this._dependencies, n) ) {
-			delete dependencies[n];
-		}
+		if ( n != null ) {
+			if ( Object.prototype.hasOwnProperty.call(this._dependencies, n) ) {
+				delete dependencies[n];
+			}
 
-		const idx = this.subModules.indexOf(n);
-		if ( idx >= 0 ) {
-			this.subModules.splice(idx, 1);
+			const idx = this.subModules.indexOf(n);
+			if ( idx >= 0 ) {
+				this.subModules.splice(idx, 1);
+			}
 		}
 	}
 

--- a/lib/lbt/resources/ModuleInfo.js
+++ b/lib/lbt/resources/ModuleInfo.js
@@ -35,7 +35,7 @@ const Format = {
  */
 class ModuleInfo {
 	constructor(name) {
-		this.name = name;
+		this._name = name;
 		this.subModules = [];
 		this._dependencies = {};
 		this.dynamicDependencies = false;
@@ -171,6 +171,22 @@ class ModuleInfo {
 
 	isImplicitDependency(dependency) {
 		return this._dependencies[dependency] === IMPLICIT;
+	}
+
+	get name() {
+		return this._name;
+	}
+
+	set name(n) {
+		this._name = n;
+		if ( Object.prototype.hasOwnProperty.call(this._dependencies, n) ) {
+			delete dependencies[n];
+		}
+
+		const idx = this.subModules.indexOf(n);
+		if ( idx >= 0 ) {
+			this.subModules.splice(idx, 1);
+		}
 	}
 
 	get dependencies() {

--- a/lib/lbt/resources/ModuleInfo.js
+++ b/lib/lbt/resources/ModuleInfo.js
@@ -181,7 +181,7 @@ class ModuleInfo {
 		this._name = n;
 		if ( n != null ) {
 			if ( Object.prototype.hasOwnProperty.call(this._dependencies, n) ) {
-				delete dependencies[n];
+				delete this._dependencies[n];
 			}
 
 			const idx = this.subModules.indexOf(n);

--- a/lib/lbt/resources/ResourcePool.js
+++ b/lib/lbt/resources/ResourcePool.js
@@ -74,7 +74,7 @@ async function determineDependencyInfo(resource, rawInfo, pool) {
 			info.size = code.length;
 			const promises = [];
 			try {
-				const ast = esprima.parseScript(code.toString());
+				const ast = esprima.parseScript(code.toString(), {comment: true});
 				jsAnalyzer.analyze(ast, resource.name, info);
 				new XMLCompositeAnalyzer(pool).analyze(ast, resource.name, info);
 			} catch (error) {

--- a/test/expected/build/application.b/standalone/resources/sap-ui-custom-dbg.js
+++ b/test/expected/build/application.b/standalone/resources/sap-ui-custom-dbg.js
@@ -1,3 +1,4 @@
+//@ui5-bundle sap-ui-custom-dbg.js
 sap.ui.requireSync("sap/ui/core/Core");
 // as this module contains the Core, we ensure that the Core has been booted
 sap.ui.getCore().boot && sap.ui.getCore().boot();

--- a/test/expected/build/application.b/standalone/resources/sap-ui-custom.js
+++ b/test/expected/build/application.b/standalone/resources/sap-ui-custom.js
@@ -1,3 +1,4 @@
+//@ui5-bundle sap-ui-custom.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{

--- a/test/expected/build/application.g/cachebuster/Component-preload.js
+++ b/test/expected/build/application.g/cachebuster/Component-preload.js
@@ -1,13 +1,14 @@
+//@ui5-bundle application/g/Component-preload.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{
-	"application.g/Component.js":function(){sap.ui.define(["sap/ui/core/UIComponent"],function(n){"use strict";return n.extend("application.g.Component",{metadata:{manifest:"json"}})});
+	"application/g/Component.js":function(){sap.ui.define(["sap/ui/core/UIComponent"],function(n){"use strict";return n.extend("application.g.Component",{metadata:{manifest:"json"}})});
 },
-	"application.g/manifest.json":'{"_version":"1.1.0","sap.app":{"_version":"1.1.0","id":"application.g","type":"application","applicationVersion":{"version":"1.0.0"},"embeds":["embedded"],"title":"{{title}}"},"customCopyrightString":"Some fancy copyright"}',
-	"application.g/subcomponentA/Component.js":function(){sap.ui.define(["sap/ui/core/UIComponent"],function(n){"use strict";return n.extend("application.g.subcomponentA.Component",{metadata:{manifest:"json"}})});
+	"application/g/manifest.json":'{"_version":"1.1.0","sap.app":{"_version":"1.1.0","id":"application.g","type":"application","applicationVersion":{"version":"1.0.0"},"embeds":["embedded"],"title":"{{title}}"},"customCopyrightString":"Some fancy copyright"}',
+	"application/g/subcomponentA/Component.js":function(){sap.ui.define(["sap/ui/core/UIComponent"],function(n){"use strict";return n.extend("application.g.subcomponentA.Component",{metadata:{manifest:"json"}})});
 },
-	"application.g/subcomponentA/manifest.json":'{"_version":"1.1.0","sap.app":{"_version":"1.1.0","id":"application.g.subcomponentA","type":"application","applicationVersion":{"version":"1.2.2"},"embeds":["embedded"],"title":"{{title}}"}}',
-	"application.g/subcomponentB/Component.js":function(){sap.ui.define(["sap/ui/core/UIComponent"],function(n){"use strict";return n.extend("application.g.subcomponentB.Component",{metadata:{manifest:"json"}})});
+	"application/g/subcomponentA/manifest.json":'{"_version":"1.1.0","sap.app":{"_version":"1.1.0","id":"application.g.subcomponentA","type":"application","applicationVersion":{"version":"1.2.2"},"embeds":["embedded"],"title":"{{title}}"}}',
+	"application/g/subcomponentB/Component.js":function(){sap.ui.define(["sap/ui/core/UIComponent"],function(n){"use strict";return n.extend("application.g.subcomponentB.Component",{metadata:{manifest:"json"}})});
 },
-	"application.g/subcomponentB/manifest.json":'{"_version":"1.1.0","sap.app":{"_version":"1.1.0","id":"application.g.subcomponentB","type":"application","applicationVersion":{"version":"1.2.2"},"embeds":["embedded"],"title":"{{title}}"}}'
+	"application/g/subcomponentB/manifest.json":'{"_version":"1.1.0","sap.app":{"_version":"1.1.0","id":"application.g.subcomponentB","type":"application","applicationVersion":{"version":"1.2.2"},"embeds":["embedded"],"title":"{{title}}"}}'
 }});

--- a/test/expected/build/application.g/dest/Component-preload.js
+++ b/test/expected/build/application.g/dest/Component-preload.js
@@ -1,3 +1,4 @@
+//@ui5-bundle application/g/Component-preload.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{

--- a/test/expected/build/application.g/dest/subcomponentA/Component-preload.js
+++ b/test/expected/build/application.g/dest/subcomponentA/Component-preload.js
@@ -1,3 +1,4 @@
+//@ui5-bundle application/g/subcomponentA/Component-preload.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{

--- a/test/expected/build/application.g/dest/subcomponentB/Component-preload.js
+++ b/test/expected/build/application.g/dest/subcomponentB/Component-preload.js
@@ -1,3 +1,4 @@
+//@ui5-bundle application/g/subcomponentB/Component-preload.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{

--- a/test/expected/build/application.h/dest/sectionsA/customBundle.js
+++ b/test/expected/build/application.h/dest/sectionsA/customBundle.js
@@ -1,3 +1,4 @@
+//@ui5-bundle application/h/sectionsA/customBundle.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{

--- a/test/expected/build/application.h/dest/sectionsB/customBundle.js
+++ b/test/expected/build/application.h/dest/sectionsB/customBundle.js
@@ -1,3 +1,4 @@
+//@ui5-bundle application/h/sectionsB/customBundle.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{

--- a/test/expected/build/application.i/dest/Component-preload.js
+++ b/test/expected/build/application.i/dest/Component-preload.js
@@ -1,3 +1,4 @@
+//@ui5-bundle application/i/Component-preload.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{

--- a/test/expected/build/application.j/dest/Component-preload.js
+++ b/test/expected/build/application.j/dest/Component-preload.js
@@ -1,3 +1,4 @@
+//@ui5-bundle application/j/Component-preload.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{

--- a/test/expected/build/library.d/preload/resources/library/d/library-preload.js
+++ b/test/expected/build/library.d/preload/resources/library/d/library-preload.js
@@ -1,3 +1,4 @@
+//@ui5-bundle library/d/library-preload.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{

--- a/test/expected/build/library.h/dest/resources/library/h/components/Component-preload.js
+++ b/test/expected/build/library.h/dest/resources/library/h/components/Component-preload.js
@@ -1,3 +1,4 @@
+//@ui5-bundle library/h/components/Component-preload.js
 sap.ui.require.preload({
 	"library/h/components/Component.js":function(){sap.ui.define(["sap/ui/core/UIComponent"],function(n){"use strict";return n.extend("application.g.Component",{})});
 },

--- a/test/expected/build/library.h/dest/resources/library/h/components/subcomponent1/Component-preload.js
+++ b/test/expected/build/library.h/dest/resources/library/h/components/subcomponent1/Component-preload.js
@@ -1,3 +1,4 @@
+//@ui5-bundle library/h/components/subcomponent1/Component-preload.js
 sap.ui.require.preload({
 	"library/h/components/subcomponent1/Component.js":function(){sap.ui.define(["sap/ui/core/UIComponent"],function(n){"use strict";return n.extend("application.g.Component",{})});
 }

--- a/test/expected/build/library.h/dest/resources/library/h/components/subcomponent2/Component-preload.js
+++ b/test/expected/build/library.h/dest/resources/library/h/components/subcomponent2/Component-preload.js
@@ -1,3 +1,4 @@
+//@ui5-bundle library/h/components/subcomponent2/Component-preload.js
 sap.ui.require.preload({
 	"library/h/components/subcomponent2/Component.js":function(){sap.ui.define(["sap/ui/core/UIComponent"],function(n){"use strict";return n.extend("application.g.Component",{})});
 }

--- a/test/expected/build/library.h/dest/resources/library/h/components/subcomponent3/Component-preload.js
+++ b/test/expected/build/library.h/dest/resources/library/h/components/subcomponent3/Component-preload.js
@@ -1,3 +1,4 @@
+//@ui5-bundle library/h/components/subcomponent3/Component-preload.js
 sap.ui.require.preload({
 	"library/h/components/subcomponent3/Component.js":function(){sap.ui.define(["sap/ui/core/UIComponent"],function(n){"use strict";return n.extend("application.g.Component",{})});
 }

--- a/test/expected/build/library.h/dest/resources/library/h/customBundle.js
+++ b/test/expected/build/library.h/dest/resources/library/h/customBundle.js
@@ -1,3 +1,4 @@
+//@ui5-bundle library/h/customBundle.js
 sap.ui.require.preload({
 	"library/h/file.js":function(){/*!
  * Some fancy copyright

--- a/test/expected/build/sap.ui.core/preload/resources/sap-ui-core-dbg.js
+++ b/test/expected/build/sap.ui.core/preload/resources/sap-ui-core-dbg.js
@@ -1,3 +1,4 @@
+//@ui5-bundle sap-ui-core-dbg.js
 sap.ui.requireSync("sap/ui/core/Core");
 // as this module contains the Core, we ensure that the Core has been booted
 sap.ui.getCore().boot && sap.ui.getCore().boot();

--- a/test/expected/build/sap.ui.core/preload/resources/sap-ui-core-nojQuery-dbg.js
+++ b/test/expected/build/sap.ui.core/preload/resources/sap-ui-core-nojQuery-dbg.js
@@ -1,3 +1,4 @@
+//@ui5-bundle sap-ui-core-nojQuery-dbg.js
 sap.ui.requireSync("sap/ui/core/Core");
 // as this module contains the Core, we ensure that the Core has been booted
 sap.ui.getCore().boot && sap.ui.getCore().boot();

--- a/test/expected/build/sap.ui.core/preload/resources/sap-ui-core-nojQuery.js
+++ b/test/expected/build/sap.ui.core/preload/resources/sap-ui-core-nojQuery.js
@@ -1,3 +1,4 @@
+//@ui5-bundle sap-ui-core-nojQuery.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{

--- a/test/expected/build/sap.ui.core/preload/resources/sap-ui-core.js
+++ b/test/expected/build/sap.ui.core/preload/resources/sap-ui-core.js
@@ -1,3 +1,4 @@
+//@ui5-bundle sap-ui-core.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{

--- a/test/expected/build/sap.ui.core/preload/resources/sap/ui/core/library-preload.js
+++ b/test/expected/build/sap.ui.core/preload/resources/sap/ui/core/library-preload.js
@@ -1,3 +1,4 @@
+//@ui5-bundle sap/ui/core/library-preload.js
 jQuery.sap.registerPreloadedModules({
 "version":"2.0",
 "modules":{

--- a/test/fixtures/lbt/modules/amd_multiple_modules_first_unnamed.js
+++ b/test/fixtures/lbt/modules/amd_multiple_modules_first_unnamed.js
@@ -1,0 +1,15 @@
+/* amd-multiple-modules-first-unnamed
+ * 
+ * Multiple modules, the first one unnamed, the others having names that don't match the file name.
+ * The unnamed one should be interpreted as the main module, its documentation should be used 
+ * as module documentation.  
+ */
+sap.ui.define(["./dep1","../dep2"], function() {});
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper1", ["./dep1","../dep2"], function() {});
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper2", ["./dep1","../dep2"], function() {});

--- a/test/fixtures/lbt/modules/amd_multiple_modules_other_than_first_one_unnamed.js
+++ b/test/fixtures/lbt/modules/amd_multiple_modules_other_than_first_one_unnamed.js
@@ -1,0 +1,19 @@
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper1", ["./dep1","../dep2"], function() {});
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper2", ["./dep1","../dep2"], function() {});
+
+/* amd-multiple-modules-other-than-first-one-unnamed
+ * 
+ * Multiple modules, the first one unnamed, the others having names that don't match the file name.
+ * The unnamed one should be interpreted as the main module, its documentation should be used 
+ * as module documentation. 
+ * 
+ * The dependencies of the different modules contain special AMD dependencies. 
+ * They should not be listed in the dependency info. 
+ */
+sap.ui.define(["./dep1","../dep2"], function() {});

--- a/test/fixtures/lbt/modules/amd_multiple_modules_with_conflict_between_named_and_unnamed.js
+++ b/test/fixtures/lbt/modules/amd_multiple_modules_with_conflict_between_named_and_unnamed.js
@@ -1,0 +1,16 @@
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper1", ["./dep1","../dep2"], function() {});
+/* amd-multiple-modules-with-conflict-between-named-and-unnamed
+ * 
+ * Multiple modules, named and unnamed, the id of one of the named modules matches 
+ * the default id derived from the file path. A later module is unnamed.
+ * Analyzing the file must throw an exception because of the conflict between the named
+ * and unnamed module.  
+ */
+sap.ui.define("modules/amd_multiple_modules_with_conflict_between_named_and_unnamed", ["./dep1","../dep2"], function() {});
+/*
+ * irrelevant documentation
+ */
+sap.ui.define(["./dep1","../dep2"], function() {});

--- a/test/fixtures/lbt/modules/amd_multiple_modules_with_conflict_between_two_named.js
+++ b/test/fixtures/lbt/modules/amd_multiple_modules_with_conflict_between_two_named.js
@@ -1,0 +1,16 @@
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper1", ["./dep1","../dep2"], function() {});
+/* amd-multiple-modules-with-conflict-between-two-named
+ * 
+ * Multiple named modules, the id of more than one of them matches 
+ * the default id derived from the file path.
+ * Analyzing the file must throw an exception because of the conflict between the two named
+ * modules.
+ */
+sap.ui.define("modules/amd_multiple_modules_with_conflict_between_two_named", ["./dep2","../dep1"], function() {});
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("modules/amd_multiple_modules_with_conflict_between_two_named", ["./dep1","../dep2"], function() {});

--- a/test/fixtures/lbt/modules/amd_multiple_modules_with_conflict_between_unnamed_and_named.js
+++ b/test/fixtures/lbt/modules/amd_multiple_modules_with_conflict_between_unnamed_and_named.js
@@ -1,0 +1,16 @@
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper1", ["./dep1","../dep2"], function() {});
+/* amd-multiple-modules-with-conflict-between-unnamed-and-named
+ * 
+ * Multiple modules, named and unnamed, the id of one of the named modules matches 
+ * the default id derived from the file path. An earlier module is unnamed.
+ * Analyzing the file must throw an exception because of the conflict between the named
+ * and unnamed module.  
+ */
+sap.ui.define(["./dep1","../dep2"], function() {});
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("modules/amd_multiple_modules_with_conflict_between_unnamed_and_named", ["./dep1","../dep2"], function() {});

--- a/test/fixtures/lbt/modules/amd_multiple_named_modules_none_matching_filename.js
+++ b/test/fixtures/lbt/modules/amd_multiple_named_modules_none_matching_filename.js
@@ -1,0 +1,12 @@
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper1", ["./dep1","../dep2"], function() {});
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper3", ["./dep1","../dep2"], function() {});
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper2", ["./dep1","../dep2"], function() {});

--- a/test/fixtures/lbt/modules/amd_multiple_named_modules_one_matching_filename.js
+++ b/test/fixtures/lbt/modules/amd_multiple_named_modules_one_matching_filename.js
@@ -1,0 +1,15 @@
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper1", ["./dep1","../dep2"], function() {});
+/* amd-multiple-named-modules-one-matching-filename
+ * 
+ * Multiple named modules, the id of one of them matches the default id derived from the file path.
+ * That module should be interpreted as the main module, its documentation should be used 
+ * as module documentation.  
+ */
+sap.ui.define("modules/amd_multiple_named_modules_one_matching_filename", ["./dep1","../dep2"], function() {});
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper2", ["./dep1","../dep2"], function() {});

--- a/test/fixtures/lbt/modules/amd_multiple_unnamed_modules.js
+++ b/test/fixtures/lbt/modules/amd_multiple_unnamed_modules.js
@@ -1,0 +1,8 @@
+/* 
+ * A file with multiple unnamed modules should cause an exception when being analyzed.
+ * The exception should indicate that only one module can omit the name, the others must be named.  
+ */
+sap.ui.define(["./dep1","../dep2"], function() {});
+sap.ui.define("utils/helper1",["./dep1","../dep2"], function() {});
+sap.ui.define(["./dep1","../dep2"], function() {});
+sap.ui.define("utils/helper2",["./dep1","../dep2"], function() {});

--- a/test/fixtures/lbt/modules/amd_single_named_module.js
+++ b/test/fixtures/lbt/modules/amd_single_named_module.js
@@ -1,0 +1,7 @@
+/* amd-single-named-module
+ * 
+ * A single named module definition. Its name should replace the default name,
+ * its documentation should be used as module documentation.  
+ */
+sap.ui.define("alternative/name", ["./dep1", "../dep2"], function() {});
+

--- a/test/fixtures/lbt/modules/amd_single_unnamed_module.js
+++ b/test/fixtures/lbt/modules/amd_single_unnamed_module.js
@@ -1,0 +1,9 @@
+/* amd-single-unnamed-module
+ * 
+ * A single unnamed module definition. 
+ * It should be recognized as the main module, its name should be the name derived fro mthe filename,
+ * its documentation should be used as module documentation.  
+ */
+sap.ui.define(["./dep1","../dep2"], function() {});
+
+

--- a/test/fixtures/lbt/modules/amd_special_dependencies.js
+++ b/test/fixtures/lbt/modules/amd_special_dependencies.js
@@ -1,0 +1,20 @@
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper1", ["./dep1","../dep2", "exports"], function() {});
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper2", ["require", "./dep1","../dep2"], function() {});
+
+/* amd-special-dependencies
+ * 
+ * When the dependencies contain one or more of the AMD special dependencies, 
+ * they should be ignored and not be listed in the dependency info. 
+ */
+sap.ui.define(["./dep1","../dep2", "module"], function() {});
+/*
+ * irrelevant documentation
+ */
+sap.ui.define("utils/helper3", ["require", "exports", "module"], function() {});
+

--- a/test/fixtures/lbt/modules/bundle-evo.js
+++ b/test/fixtures/lbt/modules/bundle-evo.js
@@ -1,0 +1,40 @@
+//@ui5-bundle sap-ui-core.js
+window["sap-ui-optimized"] = true;
+try {
+//@ui5-bundle-raw-include sap/ui/thirdparty/baseuri.js
+if(!('baseURI'in Node.prototype)){}
+//@ui5-bundle-raw-include sap/ui/thirdparty/es6-promise.js
+(function(g,f){
+g.ES6Promise=f();}(this,(function(){})));
+//@ui5-bundle-raw-include sap/ui/thirdparty/es6-shim-nopromise.js
+(function(r,f){}());
+//@ui5-bundle-raw-include ui5loader.js
+(function(__global){}(window));
+//@ui5-bundle-raw-include ui5loader-autoconfig.js
+(function(){"use strict";
+var h=u._.defineModuleSync;
+h('ui5loader.js',null);
+}());
+
+sap.ui.predefine('jquery.sap.global',["sap/base/util/now","sap/base/util/Version","sap/base/assert","sap/base/Log","sap/ui/dom/getComputedStyleFix","sap/ui/dom/activeElementFix","sap/ui/dom/includeScript","sap/ui/dom/includeStylesheet","sap/ui/core/support/Hotkeys","sap/ui/security/FrameOptions","sap/ui/performance/Measurement","sap/ui/performance/trace/Interaction","sap/ui/base/syncXHRFix","sap/base/util/LoaderExtensions","sap/ui/Device","sap/ui/thirdparty/URI","sap/ui/thirdparty/jquery","sap/ui/thirdparty/jqueryui/jquery-ui-position","ui5loader-autoconfig","jquery.sap.stubs"],function(now,Version,assert,Log,getComputedStyleFix,activeElementFix,includeScript,includeStylesheet,SupportHotkeys,FrameOptions,Measurement,Interaction,syncXHRFix,LoaderExtensions,Device,URI,jQuery){
+});
+sap.ui.predefine('jquery.sap.stubs',["sap/base/Log","sap/base/util/defineLazyProperty","sap/ui/thirdparty/jquery"],function(){});
+sap.ui.predefine('sap/base/Log',["sap/base/util/now"],function(){});
+sap.ui.predefine('sap/base/assert',["./Log"],function(){});
+sap.ui.predefine('sap/ui/base/DataType',['sap/base/util/ObjectPath',"sap/base/assert","sap/base/Log","sap/base/util/isPlainObject"],function(){},true);
+sap.ui.predefine('sap/ui/base/Event',['./Object',"sap/base/assert"],function(){});
+sap.ui.predefine('sap/ui/base/ManagedObject',['./BindingParser','./DataType','./EventProvider','./ManagedObjectMetadata','./Object','../model/BindingMode','../model/StaticBinding','../model/CompositeBinding','../model/Context','../model/FormatException','../model/ParseException','../model/Type','../model/ValidateException',"sap/ui/base/SyncPromise","sap/ui/util/ActivityDetection","sap/base/util/ObjectPath","sap/base/Log","sap/base/assert","sap/base/util/deepClone","sap/base/util/deepEqual","sap/base/util/uid","sap/ui/thirdparty/jquery"],function(){});
+sap.ui.predefine('sap/ui/core/Core',['jquery.sap.global','sap/ui/Device','sap/ui/Global','sap/ui/base/BindingParser','sap/ui/base/DataType','sap/ui/base/EventProvider','sap/ui/base/Interface','sap/ui/base/Object','sap/ui/base/ManagedObject','./Component','./Configuration','./Control','./Element','./ElementMetadata','./FocusHandler','./RenderManager','./ResizeHandler','./ThemeCheck','./UIArea','./message/MessageManager',"sap/ui/util/ActivityDetection","sap/ui/dom/getScrollbarSize","sap/base/i18n/ResourceBundle","sap/base/Log","sap/ui/performance/Measurement","sap/ui/security/FrameOptions","sap/base/assert","sap/ui/dom/includeStylesheet","sap/base/util/ObjectPath","sap/base/util/Version","sap/base/util/array/uniqueSort","sap/base/util/uid",'sap/ui/performance/trace/initTraces','sap/base/util/LoaderExtensions','sap/base/util/isEmptyObject','sap/base/util/each','sap/ui/events/jquery/EventSimulation'],function(){}());
+sap.ui.require.preload({
+	"sap/ui/thirdparty/URI.js":function(){},
+	"sap/ui/thirdparty/jqueryui/jquery-ui-position.js":function(){},
+	"sap/ui/Device.js":function(){},
+	"sap/ui/thirdparty/jquery.js":function(){},
+	"sap/ui/thirdparty/jquery-mobile-custom.js":function(){}
+},"sap-ui-core-preload");
+sap.ui.requireSync("sap/ui/core/Core");
+// as this module contains the Core, we ensure that the Core has been booted
+sap.ui.getCore().boot && sap.ui.getCore().boot();
+} catch(oError) {
+if (oError.name != "Restart") { throw oError; }
+}

--- a/test/fixtures/lbt/modules/bundle-oldstyle-v2.js
+++ b/test/fixtures/lbt/modules/bundle-oldstyle-v2.js
@@ -1,0 +1,53 @@
+window["sap-ui-optimized"] = true;
+try {
+// sap/ui/Device
+if(window.jQuery&&window.jQuery.sap&&window.jQuery.sap.declare){window.jQuery.sap.declare("sap.ui.Device",false);}
+(function(){"use strict";var d={};if(sap.ui.define){sap.ui.define("sap/ui/Device",[],function(){return d;});}}());
+// sap/ui/thirdparty/URI.js
+(function(r,f){
+if(typeof exports==='object'){module.exports=f(require('./punycode'),require('./IPv6'),require('./SecondLevelDomains'));}
+else if(typeof define==='function'&&define.amd){r.URI=f(r.punycode,r.IPv6,r.SecondLevelDomains,r);define('sap/ui/thirdparty/URI',[],function(){return r.URI;});}
+else{r.URI=f(r.punycode,r.IPv6,r.SecondLevelDomains,r);}
+}(this,function(a,I,S,r){}));
+// sap/ui/thirdparty/es6-promise.js
+(function(){
+if(typeof define==='function'&&define['amd']){define('sap/ui/thirdparty/es6-promise',function(){return {};});}
+else if(typeof module!=='undefined'&&module['exports']){module['exports']={};}
+if(typeof this!=='undefined'){this['ES6Promise']={};}}).call(this);
+// sap/ui/thirdparty/jquery.js
+(function(g,f){}());
+// sap/ui/thirdparty/jqueryui/jquery-ui-position.js
+(function($){$.ui=$.ui||{};}(jQuery));
+// jquery.sap.global.js
+(function(){}());
+jQuery.sap.globalEval=function(){"use strict";eval(arguments[0]);};
+jQuery.sap.declare('sap-ui-core');
+jQuery.sap.declare('sap.ui.Device', false);
+jQuery.sap.declare('sap.ui.thirdparty.URI', false);
+jQuery.sap.declare('sap.ui.thirdparty.es6-promise', false);
+jQuery.sap.declare('sap.ui.thirdparty.jquery', false);
+jQuery.sap.declare('sap.ui.thirdparty.jqueryui.jquery-ui-position', false);
+jQuery.sap.declare('jquery.sap.global', false);
+sap.ui.predefine('jquery.sap.act',['jquery.sap.global'],function(q){});
+sap.ui.predefine('jquery.sap.encoder',['jquery.sap.global'],function(q){});
+sap.ui.predefine('jquery.sap.events',['jquery.sap.global','sap/ui/Device','jquery.sap.keycodes','jquery.sap.dom','jquery.sap.script',"sap/ui/thirdparty/jquery-mobile-custom"],function(){});
+sap.ui.predefine('jquery.sap.keycodes',['jquery.sap.global'],function(){});
+sap.ui.predefine('sap/ui/base/DataType',['jquery.sap.global'],function(){}, true);
+sap.ui.predefine('sap/ui/base/Event',['jquery.sap.global','./Object'],function(){});
+sap.ui.predefine('sap/ui/base/ManagedObject',['jquery.sap.global','./BindingParser','./DataType','./EventProvider','./ManagedObjectMetadata','../model/BindingMode','../model/CompositeBinding','../model/Context','../model/FormatException','../model/ListBinding','../model/Model','../model/ParseException','../model/TreeBinding','../model/Type','../model/ValidateException','jquery.sap.act','jquery.sap.script','jquery.sap.strings'],function(){});
+sap.ui.predefine('sap/ui/core/Core',['jquery.sap.global','sap/ui/Device','sap/ui/Global','sap/ui/base/BindingParser','sap/ui/base/DataType','sap/ui/base/EventProvider','sap/ui/base/Interface','sap/ui/base/Object','sap/ui/base/ManagedObject','./Component','./Configuration','./Control','./Element','./ElementMetadata','./FocusHandler','./RenderManager','./ResizeHandler','./ThemeCheck','./UIArea','./message/MessageManager','jquery.sap.act','jquery.sap.dom','jquery.sap.events','jquery.sap.mobile','jquery.sap.properties','jquery.sap.resources','jquery.sap.script','jquery.sap.sjax'],function(){});
+jQuery.sap.registerPreloadedModules({
+"name":"sap-ui-core-preload",
+"modules":{
+	"sap.ui.thirdparty.jquery-mobile-custom":function(){
+		(function(r,d,f){
+			if(typeof define==="function"&&define.amd){define(["jquery"],function($){f($,r,d);return $.mobile;});}
+			else{f(r.jQuery,r,d);}}());
+	}
+}});
+sap.ui.requireSync("sap/ui/core/Core");
+// as this module contains the Core, we ensure that the Core has been booted
+sap.ui.getCore().boot && sap.ui.getCore().boot();
+} catch(oError) {
+if (oError.name != "Restart") { throw oError; }
+}

--- a/test/fixtures/lbt/modules/bundle-oldstyle.js
+++ b/test/fixtures/lbt/modules/bundle-oldstyle.js
@@ -1,0 +1,54 @@
+window["sap-ui-optimized"] = true;
+try {
+// sap/ui/Device
+if(window.jQuery&&window.jQuery.sap&&window.jQuery.sap.declare){window.jQuery.sap.declare("sap.ui.Device",false);}
+(function(){"use strict";var d={};if(sap.ui.define){sap.ui.define("sap/ui/Device",[],function(){return d;});}}());
+// sap/ui/thirdparty/URI.js
+(function(r,f){
+if(typeof exports==='object'){module.exports=f(require('./punycode'),require('./IPv6'),require('./SecondLevelDomains'));}
+else if(typeof define==='function'&&define.amd){r.URI=f(r.punycode,r.IPv6,r.SecondLevelDomains,r);define('sap/ui/thirdparty/URI',[],function(){return r.URI;});}
+else{r.URI=f(r.punycode,r.IPv6,r.SecondLevelDomains,r);}
+}(this,function(a,I,S,r){}));
+// sap/ui/thirdparty/es6-promise.js
+(function(){
+if(typeof define==='function'&&define['amd']){define('sap/ui/thirdparty/es6-promise',function(){return {};});}
+else if(typeof module!=='undefined'&&module['exports']){module['exports']={};}
+if(typeof this!=='undefined'){this['ES6Promise']={};}}).call(this);
+// sap/ui/thirdparty/jquery.js
+(function(g,f){}());
+// sap/ui/thirdparty/jqueryui/jquery-ui-position.js
+(function($){$.ui=$.ui||{};}(jQuery));
+// jquery.sap.global.js
+(function(){}());
+jQuery.sap.globalEval=function(){"use strict";eval(arguments[0]);};
+jQuery.sap.declare('sap-ui-core');
+jQuery.sap.declare('sap.ui.Device', false);
+jQuery.sap.declare('sap.ui.thirdparty.URI', false);
+jQuery.sap.declare('sap.ui.thirdparty.es6-promise', false);
+jQuery.sap.declare('sap.ui.thirdparty.jquery', false);
+jQuery.sap.declare('sap.ui.thirdparty.jqueryui.jquery-ui-position', false);
+jQuery.sap.declare('jquery.sap.global', false);
+sap.ui.predefine('jquery.sap.act',['jquery.sap.global'],function(q){});
+sap.ui.predefine('jquery.sap.encoder',['jquery.sap.global'],function(q){});
+sap.ui.predefine('jquery.sap.events',['jquery.sap.global','sap/ui/Device','jquery.sap.keycodes','jquery.sap.dom','jquery.sap.script',"sap/ui/thirdparty/jquery-mobile-custom"],function(){});
+sap.ui.predefine('jquery.sap.keycodes',['jquery.sap.global'],function(){});
+sap.ui.predefine('sap/ui/base/DataType',['jquery.sap.global'],function(){}, true);
+sap.ui.predefine('sap/ui/base/Event',['jquery.sap.global','./Object'],function(){});
+sap.ui.predefine('sap/ui/base/ManagedObject',['jquery.sap.global','./BindingParser','./DataType','./EventProvider','./ManagedObjectMetadata','../model/BindingMode','../model/CompositeBinding','../model/Context','../model/FormatException','../model/ListBinding','../model/Model','../model/ParseException','../model/TreeBinding','../model/Type','../model/ValidateException','jquery.sap.act','jquery.sap.script','jquery.sap.strings'],function(){});
+sap.ui.predefine('sap/ui/core/Core',['jquery.sap.global','sap/ui/Device','sap/ui/Global','sap/ui/base/BindingParser','sap/ui/base/DataType','sap/ui/base/EventProvider','sap/ui/base/Interface','sap/ui/base/Object','sap/ui/base/ManagedObject','./Component','./Configuration','./Control','./Element','./ElementMetadata','./FocusHandler','./RenderManager','./ResizeHandler','./ThemeCheck','./UIArea','./message/MessageManager','jquery.sap.act','jquery.sap.dom','jquery.sap.events','jquery.sap.mobile','jquery.sap.properties','jquery.sap.resources','jquery.sap.script','jquery.sap.sjax'],function(){});
+jQuery.sap.registerPreloadedModules({
+"name":"sap-ui-core-preload",
+"version":"2.0",
+"modules":{
+	"sap/ui/thirdparty/jquery-mobile-custom.js":function(){
+		(function(r,d,f){
+			if(typeof define==="function"&&define.amd){define(["jquery"],function($){f($,r,d);return $.mobile;});}
+			else{f(r.jQuery,r,d);}}());
+	}
+}});
+sap.ui.requireSync("sap/ui/core/Core");
+// as this module contains the Core, we ensure that the Core has been booted
+sap.ui.getCore().boot && sap.ui.getCore().boot();
+} catch(oError) {
+if (oError.name != "Restart") { throw oError; }
+}

--- a/test/fixtures/lbt/modules/define_with_legacy_calls.js
+++ b/test/fixtures/lbt/modules/define_with_legacy_calls.js
@@ -1,0 +1,4 @@
+//declares module sap.ui.testmodule
+sap.ui.define(["define/arg1","define/arg2"], function(Strings,Dom,Something) {
+	jQuery.sap.require("require/arg1");
+});

--- a/test/fixtures/lbt/modules/no_declare_but_requires.js
+++ b/test/fixtures/lbt/modules/no_declare_but_requires.js
@@ -1,4 +1,4 @@
 jQuery.sap.require("dependency1");
 jQuery.sap.require("dependency2");
 // this module has dependencies, but does not declare a name.
-// When such a module is scanned without enough knowledge about the folder structure, the name might be "unknown" (null) 
+// When such a module is scanned without enough knowledge about the folder structure, the name might be "unknown" (null)

--- a/test/fixtures/lbt/modules/no_declare_but_requires.js
+++ b/test/fixtures/lbt/modules/no_declare_but_requires.js
@@ -1,0 +1,4 @@
+jQuery.sap.require("dependency1");
+jQuery.sap.require("dependency2");
+// this module has dependencies, but does not declare a name.
+// When such a module is scanned without enough knowledge about the folder structure, the name might be "unknown" (null) 

--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -78,7 +78,7 @@ function analyzeModule(
 		}
 		if ( expectedDependencies != null ) {
 			assertModuleNamesEqual(t,
-				info.dependencies,
+				deps,
 				expectedDependencies,
 				"module dependencies should match");
 		}
@@ -94,7 +94,6 @@ function analyzeModule(
 				expectedSubmodules,
 				"submodules should match");
 		}
-		//t.end();
 	}).finally(() => t.end());
 }
 
@@ -127,9 +126,9 @@ test.cb("AMDSpecialDependenciesShouldBeIgnored", (t) => {
 	analyzeModule(t,
 		"modules/amd_special_dependencies.js",
 		"modules/amd_special_dependencies.js",
-		["modules/dep1.js", "dep2.js", "utils/dep1.js", "ui5loader-autoconfig.js" ],
+		["modules/dep1.js", "dep2.js", "utils/dep1.js", "ui5loader-autoconfig.js"],
 		[],
-		["utils/helper1.js", "utils/helper2.js", "utils/helper3.js" ]
+		["utils/helper1.js", "utils/helper2.js", "utils/helper3.js"]
 	);
 });
 
@@ -178,7 +177,6 @@ test("AMDMultipleUnnamedModules", (t) =>
 		.then(() => {
 			t.fail("parsing a file with multiple unnamed modules shouldn't succeed");
 		}, (err) => {
-			console.error("hi hopsa sa");
 			t.true(/only one of them/.test(err.message),
 				"Exception message should contain a hint on multiple unnamed modules");
 		})

--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -94,7 +94,7 @@ function analyzeModule(
 				expectedSubmodules,
 				"submodules should match");
 		}
-	}).finally(() => t.end());
+	}).then(() => t.end(), () => t.end());
 }
 
 test.cb("DeclareToplevel", analyzeModule, "modules/declare_toplevel.js", EXPECTED_MODULE_NAME, EXPECTED_DECLARE_DEPENDENCIES);

--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -39,7 +39,7 @@ function analyze(file, name) {
 				reject(err);
 			}
 			try {
-				const ast = esprima.parseScript(buffer.toString());
+				const ast = esprima.parseScript(buffer.toString(), {comment: true});
 				const info = new ModuleInfo(name);
 				new JSModuleAnalyzer().analyze(ast, name, info);
 				resolve(info);

--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -15,9 +15,17 @@ const EXPECTED_DECLARE_DEPENDENCIES = [
 	"nested/scope2/require/void.js", "nested/scope2/require/var.js", "nested/scope2/require/assign.js", "nested/scope2/requireSync/var.js", "nested/scope2/requireSync/assign.js"
 ];
 
-const EXPECTED_DEFINE_DEPENDENCIES = [
+const EXPECTED_DEFINE_DEPENDENCIES_NO_LEGACY = [
 	"ui5loader-autoconfig.js",
 	"define/arg1.js", "define/arg2.js"
+];
+
+const EXPECTED_DEFINE_DEPENDENCIES_WITH_LEGACY = [
+	// FIXME as long as the bug in the sap.ui.define handling of JSModuleAnalyzer
+	// has not been fixed, the wrong implicit dependency is determined here
+	"ui5loader-autoconfig.js", // should be "jquery.sap.global.js",
+	"define/arg1.js", "define/arg2.js",
+	"require/arg1.js"
 ];
 
 const NO_DEPENDENCIES = [];
@@ -37,21 +45,45 @@ function analyze(file, name) {
 	});
 }
 
-function analyzeModule(t, file, name, expectedDependencies, expectDocumentation) {
+function assertModuleNamesEqual(t, actual, expected, msg) {
+	actual.sort();
+	expected.sort();
+	t.deepEqual(actual, expected, msg);
+}
+
+function analyzeModule(
+	t,
+	file,
+	name,
+	expectedDependencies,
+	expectedConditionalDependencies,
+	expectedSubmodules) {
 	analyze(file, name).then( (info) => {
 		t.is(info.name, name, "module name should match");
 		// if ( expectDocumentation !== false ) {
 		// 	t.assertNotNull(info.description, "module should have documentation");
 		// 	t.assertTrue(info.description.indexOf("declares") >= 0, "module documentation should match", );
 		// }
-		const expected = expectedDependencies.sort();
-		const actual = info.dependencies.sort();
-		t.deepEqual(actual, expected, "module dependencies should match");
+		assertModuleNamesEqual(t,
+			info.dependencies,
+			expectedDependencies,
+			"module dependencies should match");
 		t.truthy(info.dependencies.every((dep) => !info.isConditionalDependency(dep)), "none of the dependencies must be 'conditional'");
+		if ( expectedConditionalDependencies != null ) {
+			assertModuleNamesEqual(t,
+				expectedConditionalDependencies,
+				getConditionalDependencies(info),
+				"conditional module dependencies should match");
+		}
+		if ( expectedSubmodules != null ) {
+			assertModuleNamesEqual(t,
+				expectedSubmodules,
+				getConditionalDependencies(info),
+				"submodules should match");
+		}
 		t.end();
 	});
 }
-
 
 test.cb("DeclareToplevel", analyzeModule, "modules/declare_toplevel.js", EXPECTED_MODULE_NAME, EXPECTED_DECLARE_DEPENDENCIES);
 
@@ -59,12 +91,218 @@ test.cb("DeclareFunctionExprScope", analyzeModule, "modules/declare_function_exp
 
 test.cb("DeclareFunctionInvocationScope", analyzeModule, "modules/declare_function_invocation_scope.js", EXPECTED_MODULE_NAME, EXPECTED_DECLARE_DEPENDENCIES);
 
-test.cb("DefineToplevelNamed", analyzeModule, "modules/define_toplevel_named.js", EXPECTED_MODULE_NAME, EXPECTED_DEFINE_DEPENDENCIES);
+test.cb("DefineToplevelNamed", analyzeModule, "modules/define_toplevel_named.js", EXPECTED_MODULE_NAME, EXPECTED_DEFINE_DEPENDENCIES_NO_LEGACY);
 
-test.cb("DefineToplevelUnnamed", analyzeModule, "modules/define_toplevel_unnamed.js", "modules/define_toplevel_unnamed.js", EXPECTED_DEFINE_DEPENDENCIES);
+test.cb("DefineToplevelUnnamed", analyzeModule, "modules/define_toplevel_unnamed.js", "modules/define_toplevel_unnamed.js", EXPECTED_DEFINE_DEPENDENCIES_NO_LEGACY);
+
+test.cb("DefineWithLegacyCalls", analyzeModule, "modules/define_with_legacy_calls.js", "modules/define_with_legacy_calls.js", EXPECTED_DEFINE_DEPENDENCIES_WITH_LEGACY);
+
+test.cb("OldStyleModuleWithoutDeclare", function(t) {
+	analyze("modules/no_declare_but_requires.js", "modules/define_with_legacy_calls.js").then((info) => {
+		t.is(info.name, null, "module nameshould be null");
+		t.end();
+	});
+});
 
 test.cb("NotAnUI5Module", analyzeModule, "modules/not_a_module.js", "modules/not_a_module.js", NO_DEPENDENCIES, false);
 
+test.cb("AMDSpecialDependenciesShouldBeIgnored", (t) => {
+	analyzeModule(t,
+		"modules/amd_special_dependencies.js",
+		"modules/amd_special_dependencies.js",
+		["modules/dep1.js", "dep2.js", "utils/dep1.js", "ui5loader-autoconfig.js" ],
+		[],
+		["utils/helper1.js", "utils/helper2.js", "utils/helper3.js" ]
+	);
+});
+
+test.cb("AMDMultipleModulesFirstUnnamed", (t) => {
+	analyzeModule(t,
+		"modules/amd_multiple_modules_first_unnamed.js",
+		"modules/amd_multiple_modules_first_unnamed.js",
+		["modules/dep1.js", "dep2.js", "utils/dep1.js", "ui5loader-autoconfig.js"],
+		[],
+		["utils/helper1.js", "utils/helper2.js"]
+	);
+});
+
+test.cb("AMDMultipleModulesOtherThanFirstOneUnnamed", (t) => {
+	analyzeModule(t,
+		"modules/amd_multiple_modules_other_than_first_one_unnamed.js",
+		"modules/amd_multiple_modules_other_than_first_one_unnamed.js",
+		["modules/dep1.js", "dep2.js", "utils/dep1.js", "ui5loader-autoconfig.js"],
+		[],
+		["utils/helper1.js", "utils/helper2.js"]
+	);
+});
+
+test.cb("AMDMultipleNamedModulesNoneMatchingFileName", (t) => {
+	analyzeModule(t,
+		"modules/amd_multiple_named_modules_none_matching_filename.js",
+		"modules/amd_multiple_named_modules_none_matching_filename.js",
+		["dep2.js", "utils/dep1.js", "ui5loader-autoconfig.js"],
+		[],
+		["utils/helper1.js", "utils/helper2.js", "utils/helper3.js"]
+	);
+});
+
+test.cb("AMDMultipleNamedModulesOneMatchingFileName", (t) => {
+	analyzeModule(t,
+		"modules/amd_multiple_named_modules_one_matching_filename.js",
+		"modules/amd_multiple_named_modules_one_matching_filename.js",
+		["modules/dep1.js", "dep2.js", "utils/dep1.js", "ui5loader-autoconfig.js"],
+		[],
+		["utils/helper1.js", "utils/helper2.js"]
+	);
+});
+
+test.cb("AMDMultipleUnnamedModules", (t) => {
+	try {
+		analyzeModule(t, "modules/amd_multiple_unnamed_modules.js");
+		t.fail("parsing a file with multiple unnamed modules shouldn't succeed");
+	} catch (err) {
+		t.true(/only one of them/.test(err.message),
+			"Exception message should contain a hint on multiple unnamed modules");
+	}
+});
+
+test.cb("AMDSingleNamedModule", (t) => {
+	analyzeModule(t,
+		"modules/amd_single_named_module.js",
+		"alternative/name.js",
+		["alternative/dep1.js", "dep2.js", "ui5loader-autoconfig.js"],
+		[],
+		[]
+	);
+});
+
+test.cb("AMDSingleUnnamedModule", (t) => {
+	analyzeModule(t,
+		"modules/amd_single_unnamed_module.js",
+		"modules/amd_single_unnamed_module.js",
+		["modules/dep1.js", "dep2.js", "ui5loader-autoconfig.js"],
+		[],
+		[]
+	);
+});
+
+test.cb("AMDMultipleModulesWithConflictBetweenNamedAndUnnamed", (t) => {
+	try {
+		analyzeModule(t, "modules/amd_multiple_modules_with_conflict_between_named_and_unnamed.js");
+		t.fail("parsing a file with conflicting modules shouldn't succeed");
+	} catch (e) {
+		t.is("conflicting main modules found (unnamed + named)", err.nessage,
+			"Exception message should contain a hint on conflicting modules");
+	}
+});
+
+test.cb("AMDMultipleModulesWithConflictBetweenUnnamedAndNamed", (t) => {
+	try {
+		analyzeModule(t, "modules/amd_multiple_modules_with_conflict_between_unnamed_and_named.js");
+		t.fail("parsing a file with conflicting modules shouldn't succeed");
+	} catch (e) {
+		t.is("conflicting main modules found (unnamed + named)", e.message,
+			"Exception message should contain a hint on conflicting modules");
+	}
+});
+
+test.cb("AMDMultipleModulesWithConflictBetweenTwoNamed", (t) => {
+	try {
+		analyzeModule(t, "modules/amd_multiple_modules_with_conflict_between_two_named.js");
+		t.fail("parsing a file with conflicting modules shouldn't succeed");
+	} catch (e) {
+		t.is("conflicting main modules found (unnamed + named)", e.message,
+			"Exception message should contain a hint on conflicting modules");
+	}
+});
+
+test.cb("OldStyleBundle", (t) => {
+	analyzeModule(t,
+		"modules/bundle-oldstyle.js",
+		"sap-ui-core.js",
+		[],
+		[],
+		[
+			"sap/ui/Device.js",
+			"sap/ui/thirdparty/URI.js",
+			"sap/ui/thirdparty/es6-promise.js",
+			"sap/ui/thirdparty/jquery.js",
+			"sap/ui/thirdparty/jqueryui/jquery-ui-position.js",
+			"jquery.sap.global.js",
+			"jquery.sap.act.js",
+			"jquery.sap.encoder.js",
+			"jquery.sap.events.js",
+			"jquery.sap.keycodes.js",
+			"sap/ui/base/DataType.js",
+			"sap/ui/base/Event.js",
+			"sap/ui/base/ManagedObject.js",
+			"sap/ui/core/Core.js",
+			"sap/ui/thirdparty/jquery-mobile-custom.js"
+		],
+		/* ignoreImplicitDependencies: */ true
+	);
+});
+
+test.cb("OldStyleBundleV2", (t) => {
+	analyzeModule(t,
+		"modules/bundle-oldstyle-v2.js",
+		"sap-ui-core.js",
+		[],
+		[],
+		[
+			"sap/ui/Device.js",
+			"sap/ui/thirdparty/URI.js",
+			"sap/ui/thirdparty/es6-promise.js",
+			"sap/ui/thirdparty/jquery.js",
+			"sap/ui/thirdparty/jqueryui/jquery-ui-position.js",
+			"jquery.sap.global.js",
+			"jquery.sap.act.js",
+			"jquery.sap.encoder.js",
+			"jquery.sap.events.js",
+			"jquery.sap.keycodes.js",
+			"sap/ui/base/DataType.js",
+			"sap/ui/base/Event.js",
+			"sap/ui/base/ManagedObject.js",
+			"sap/ui/core/Core.js",
+			"sap/ui/thirdparty/jquery-mobile-custom.js"
+		],
+		/* ignoreImplicitDependencies: */ true
+	);
+});
+
+/*
+ * Note: this test still fails as the evo-style bundles don't declare the names of the
+ * contained raw-modules any longer.
+ */
+test.cb("EvoBundle", (t) => {
+	analyzeModule(t,
+		"modules/bundle-evo.js",
+		"sap-ui-core.js",
+		[],
+		[],
+		[
+			"sap/ui/thirdparty/baseuri.js",
+			"sap/ui/thirdparty/es6-promise.js",
+			"sap/ui/thirdparty/es6-shim-nopromise.js",
+			"ui5loader.js",
+			"ui5loader-autoconfig.js",
+			"jquery.sap.global.js",
+			"jquery.sap.stubs.js",
+			"sap/base/Log.js",
+			"sap/base/assert.js",
+			"sap/ui/base/DataType.js",
+			"sap/ui/base/Event.js",
+			"sap/ui/base/ManagedObject.js",
+			"sap/ui/core/Core.js",
+			"sap/ui/thirdparty/URI.js",
+			"sap/ui/thirdparty/jqueryui/jquery-ui-position.js",
+			"sap/ui/Device.js",
+			"sap/ui/thirdparty/jquery.js",
+			"sap/ui/thirdparty/jquery-mobile-custom.js"
+		],
+		/* ignoreImplicitDependencies: */ true
+	);
+});
 
 test("Bundle", (t) => {
 	return analyze("modules/bundle.js").then( (info) => {

--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -113,6 +113,10 @@ test.cb("DefineWithLegacyCalls", analyzeModule, "modules/define_with_legacy_call
 test.cb("OldStyleModuleWithoutDeclare", function(t) {
 	analyze("modules/no_declare_but_requires.js", null).then((info) => {
 		t.is(info.name, null, "module name should be null");
+		assertModuleNamesEqual(t,
+			info.dependencies,
+			["dependency1.js", "dependency2.js", "jquery.sap.global.js"],
+			"dependencies should be correct");
 		t.end();
 	});
 });

--- a/test/lib/lbt/bundle/Builder.js
+++ b/test/lib/lbt/bundle/Builder.js
@@ -24,6 +24,7 @@ test("integration: createBundle EVOBundleFormat (ui5loader.js)", async (t) => {
 		defaultFileTypes: [".js"],
 		sections: [{
 			mode: "preload",
+			name: "preload-section",
 			filters: ["jquery.sap.global-dbg.js"]
 		}, {
 			declareRawModules: undefined,
@@ -44,7 +45,7 @@ window["sap-ui-optimized"] = true;
 sap.ui.require.preload({
 	"jquery.sap.global-dbg.js":function(){sap.ui.define([], function(){return {};});
 }
-});
+},"preload-section");
 //@ui5-bundle-raw-include myModule.js
 (function(){window.mine = {};}());
 sap.ui.requireSync("ui5loader");
@@ -55,8 +56,140 @@ sap.ui.requireSync("ui5loader");
 		" raw part from myModule.js" +
 		" require part from ui5loader.js");
 	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
-	t.deepEqual(oResult.bundleInfo.size, 289, "bundle info size is correct");
+	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules, ["jquery.sap.global-dbg.js", "myModule.js"],
+		"bundle info subModules are correct");
+});
+
+test("integration: createBundle EVOBundleFormat, using predefine calls", async (t) => {
+	const pool = new ResourcePool();
+	pool.addResource({
+		name: "ui5loader.js",
+		buffer: async () => "(function(__global) {sap.ui.require = function(){};}(window));"
+	});
+	pool.addResource({ // the pool must contain this to activate optimization markers
+		name: "jquery.sap.global-dbg.js",
+		buffer: async () => "sap.ui.define([], function(){return {};});"
+	});
+	pool.addResource({
+		name: "jquery.sap.global.js",
+		buffer: async () => "sap.ui.define([], function(){return {};});"
+	});
+	pool.addResource({
+		name: "myRawModule.js",
+		buffer: async () => "(function(){window.mine = {};}());"
+	});
+	pool.addResource({
+		name: "myModuleUsingGlobalScope.js",
+		buffer: async () => "var magic = {};"
+	});
+
+	const bundleDefinition = {
+		name: `Component-preload.js`,
+		defaultFileTypes: [".js"],
+		sections: [{
+			mode: "preload",
+			name: "preload-section",
+			filters: ["jquery.sap.global.js", "myModuleUsingGlobalScope.js"]
+		}, {
+			declareRawModules: undefined,
+			mode: "raw",
+			filters: ["myRawModule.js"],
+			sort: undefined
+		}, {
+			mode: "require",
+			filters: ["ui5loader.js"]
+		}]
+	};
+
+	const builder = new Builder(pool);
+	const oResult = await builder.createBundle(bundleDefinition, {
+		usePredefineCalls: true,
+		numberOfParts: 1,
+		decorateBootstrapModule: true,
+		optimize: true // Note: using 'optimize' makes the test sensitive to changes in terser
+	});
+	t.deepEqual(oResult.name, "Component-preload.js");
+	const expectedContent = `//@ui5-bundle Component-preload.js
+window["sap-ui-optimized"] = true;
+sap.ui.predefine("jquery.sap.global",[],function(){return{}});
+sap.ui.require.preload({
+	"myModuleUsingGlobalScope.js":'var magic={};'
+},"preload-section");
+//@ui5-bundle-raw-include myRawModule.js
+(function(){window.mine={}})();
+sap.ui.requireSync("ui5loader");
+`;
+	t.deepEqual(oResult.content, expectedContent, "EVOBundleFormat should start with optomization and " +
+		"should contain:" +
+		" preload part from jquery.sap.global-dbg.js" +
+		" raw part from myModule.js" +
+		" require part from ui5loader.js");
+	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
+	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
+	t.deepEqual(oResult.bundleInfo.subModules, ["jquery.sap.global.js", "myModuleUsingGlobalScope.js", "myRawModule.js"],
+		"bundle info subModules are correct");
+});
+
+test("integration: createBundle (bootstrap bundle)", async (t) => {
+	const pool = new ResourcePool();
+	pool.addResource({
+		name: "ui5loader.js",
+		buffer: async () => "(function(__global) {sap.ui.require = function(){};}(window));"
+	});
+	pool.addResource({
+		name: "sap/ui/core/Core.js",
+		buffer: async () => "sap.ui.define([],function(){return {};});"
+	});
+
+	const bundleDefinition = {
+		name: `bootstrap.js`,
+		defaultFileTypes: [".js"],
+		sections: [{
+			mode: "raw",
+			filters: ["ui5loader.js"],
+			declareRawModules: undefined,
+			sort: undefined
+		}, {
+			mode: "preload",
+			filters: ["sap/ui/core/Core.js"],
+			resolve: true
+		}, {
+			mode: "require",
+			filters: ["sap/ui/core/Core.js"]
+		}]
+	};
+
+	const builder = new Builder(pool);
+	const oResult = await builder.createBundle(bundleDefinition, {
+		numberOfParts: 1,
+		decorateBootstrapModule: true,
+		addTryCatchRestartWrapper: true,
+		optimize: true,
+		usePredefineCalls: true
+	});
+	t.deepEqual(oResult.name, "bootstrap.js");
+	const expectedContent = `//@ui5-bundle bootstrap.js
+window["sap-ui-optimized"] = true;
+try {
+//@ui5-bundle-raw-include ui5loader.js
+(function(i){sap.ui.require=function(){}})(window);
+sap.ui.predefine("sap/ui/core/Core",[],function(){return{}});
+sap.ui.requireSync("sap/ui/core/Core");
+// as this module contains the Core, we ensure that the Core has been booted
+sap.ui.getCore().boot && sap.ui.getCore().boot();
+} catch(oError) {
+if (oError.name != "Restart") { throw oError; }
+}
+`;
+	t.deepEqual(oResult.content, expectedContent, "EVOBundleFormat should start with optomization and " +
+		"should contain:" +
+		" preload part from jquery.sap.global-dbg.js" +
+		" raw part from myModule.js" +
+		" require part from ui5loader.js");
+	t.deepEqual(oResult.bundleInfo.name, "bootstrap.js", "bundle info name is correct");
+	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
+	t.deepEqual(oResult.bundleInfo.subModules, ["ui5loader.js", "sap/ui/core/Core.js"],
 		"bundle info subModules are correct");
 });
 
@@ -80,6 +213,7 @@ test("integration: createBundle UI5BundleFormat (non ui5loader.js)", async (t) =
 		defaultFileTypes: [".js", ".fragment.xml", ".view.xml", ".properties", ".json"],
 		sections: [{
 			mode: "preload",
+			name: "preload-section",
 			filters: ["jquery.sap.global-dbg.js"]
 		}, {
 			declareRawModules: undefined,
@@ -97,6 +231,7 @@ test("integration: createBundle UI5BundleFormat (non ui5loader.js)", async (t) =
 	t.deepEqual(oResult.name, "Component-preload.js");
 	const expectedContent = `//@ui5-bundle Component-preload.js
 jQuery.sap.registerPreloadedModules({
+"name":"preload-section",
 "version":"2.0",
 "modules":{
 	"jquery.sap.global-dbg.js":function(){sap.ui.define([], function(){return {};});
@@ -112,7 +247,81 @@ sap.ui.requireSync("sap-ui-core");
 		" raw part from myModule.js" +
 		" require part from sap-ui-core.js");
 	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
-	t.deepEqual(oResult.bundleInfo.size, 299, "bundle info size is correct");
+	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules, ["jquery.sap.global-dbg.js", "myModule.js"],
+		"bundle info subModules are correct");
+});
+
+test("integration: createBundle (bootstrap bundle, UI5BundleFormat)", async (t) => {
+	const pool = new ResourcePool();
+	pool.addResource({
+		name: "jquery.sap.global.js",
+		buffer: async () => "(function(__global) {sap.ui.require = function(){};}(window));"
+	});
+	pool.addResource({
+		name: "jquery.sap.global-dbg.js",
+		buffer: async () => "(function(__global) {sap.ui.require = function(){};}(window));"
+	});
+	pool.addResource({
+		name: "myRawModule.js",
+		buffer: async () => "(function(){window.mine = {};}());"
+	});
+	pool.addResource({
+		name: "sap/ui/core/Core.js",
+		buffer: async () => "sap.ui.define([],function(){return {};});"
+	});
+
+	const bundleDefinition = {
+		name: `bootstrap.js`,
+		defaultFileTypes: [".js"],
+		sections: [{
+			mode: "raw",
+			filters: ["jquery.sap.global.js", "myRawModule.js"],
+			sort: false,
+			declareRawModules: true
+		}, {
+			mode: "preload",
+			filters: ["sap/ui/core/Core.js"],
+			resolve: true
+		}, {
+			mode: "require",
+			filters: ["sap/ui/core/Core.js"]
+		}]
+	};
+
+	const builder = new Builder(pool);
+	const oResult = await builder.createBundle(bundleDefinition, {
+		numberOfParts: 1,
+		decorateBootstrapModule: true,
+		addTryCatchRestartWrapper: true,
+		optimize: true,
+		usePredefineCalls: true
+	});
+	t.deepEqual(oResult.name, "bootstrap.js");
+	const expectedContent = `//@ui5-bundle bootstrap.js
+window["sap-ui-optimized"] = true;
+try {
+//@ui5-bundle-raw-include jquery.sap.global.js
+(function(i){sap.ui.require=function(){}})(window);
+//@ui5-bundle-raw-include myRawModule.js
+(function(){window.mine={}})();
+jQuery.sap.declare('jquery.sap.global', false);
+jQuery.sap.declare('myRawModule', false);
+sap.ui.predefine("sap/ui/core/Core",[],function(){return{}});
+sap.ui.requireSync("sap/ui/core/Core");
+// as this module contains the Core, we ensure that the Core has been booted
+sap.ui.getCore().boot && sap.ui.getCore().boot();
+} catch(oError) {
+if (oError.name != "Restart") { throw oError; }
+}
+`;
+	t.deepEqual(oResult.content, expectedContent, "EVOBundleFormat should start with optomization and " +
+		"should contain:" +
+		" preload part from jquery.sap.global-dbg.js" +
+		" raw part from myModule.js" +
+		" require part from ui5loader.js");
+	t.deepEqual(oResult.bundleInfo.name, "bootstrap.js", "bundle info name is correct");
+	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
+	t.deepEqual(oResult.bundleInfo.subModules, ["jquery.sap.global.js", "myRawModule.js", "sap/ui/core/Core.js"],
 		"bundle info subModules are correct");
 });

--- a/test/lib/lbt/calls/SapUiDefine.js
+++ b/test/lib/lbt/calls/SapUiDefine.js
@@ -1,0 +1,61 @@
+const test = require("ava");
+const esprima = require("esprima");
+const Syntax = esprima.Syntax;
+
+const SapUiDefineCall = require("../../../../lib/lbt/calls/SapUiDefine");
+
+function parse(code) {
+	const ast = esprima.parseScript(code);
+	return ast.body[0].expression;
+}
+
+test("Named Define", (t) => {
+	const ast = parse("sap.ui.define('HardcodedName', [], function() {});");
+	const call = new SapUiDefineCall(ast, "FileSystemName");
+	t.is(call.name, "HardcodedName");
+});
+
+test("Unnamed Define", (t) => {
+	const ast = parse("sap.ui.define([], function() {});");
+	const call = new SapUiDefineCall(ast, "FileSystemName");
+	t.is(call.name, "FileSystemName");
+});
+
+test("Dependencies", (t) => {
+	const ast = parse("sap.ui.define(['a', 'b', 'c'], function(a,b,c) {});");
+	const call = new SapUiDefineCall(ast, "FileSystemName");
+	t.deepEqual(call.dependencies, ["a.js", "b.js", "c.js"]);
+	t.is(call.dependencyInsertionIdx, 3);
+});
+
+test("Insertion index for Dependencies", (t) => {
+	const ast = parse("sap.ui.define(['a', 'b'], function(a) {});");
+	const call = new SapUiDefineCall(ast, "FileSystemName");
+	t.deepEqual(call.dependencies, ["a.js", "b.js"]);
+	t.is(call.dependencyInsertionIdx, 1);
+});
+
+test("Factory", (t) => {
+	const ast = parse("sap.ui.define([], function() { return 42; });");
+	const call = new SapUiDefineCall(ast, "FileSystemName");
+	t.true(call.factory != null);
+	t.is(call.factory.type, Syntax.FunctionExpression);
+});
+
+test("Find Import Name (successful)", (t) => {
+	const ast = parse("sap.ui.define(['wanted'], function(johndoe) {});");
+	const call = new SapUiDefineCall(ast, "FileSystemName");
+	t.is(call.findImportName("wanted.js"), "johndoe");
+});
+
+test("Find Import Name (not successful)", (t) => {
+	const ast = parse("sap.ui.define(['bonnie'], function(clyde) {});");
+	const call = new SapUiDefineCall(ast, "FileSystemName");
+	t.is(call.findImportName("wanted.js"), null);
+});
+
+test("Find Import Name (no dependencies)", (t) => {
+	const ast = parse("sap.ui.define(function() {});");
+	const call = new SapUiDefineCall(ast, "FileSystemName");
+	t.is(call.findImportName("wanted.js"), null);
+});

--- a/test/lib/tasks/generateCachebusterInfo.js
+++ b/test/lib/tasks/generateCachebusterInfo.js
@@ -101,7 +101,7 @@ const applicationGTree = {
 	"type": "application",
 	"metadata": {
 		"name": "application.g",
-		"namespace": "application.g",
+		"namespace": "application/g",
 		"copyright": "Some fancy copyright"
 	},
 	"resources": {
@@ -131,7 +131,7 @@ const applicationGTreeWithCachebusterHash = {
 	"type": "application",
 	"metadata": {
 		"name": "application.g",
-		"namespace": "application.g",
+		"namespace": "application/g",
 		"copyright": "Some fancy copyright"
 	},
 	"resources": {


### PR DESCRIPTION
This is a port of several changes from the Maven tooling, which have been made after the initial migration of the bundle tooling. Additionally, code coverage has been slightly improved by adding additional unit and integration tests. Errors that have been revealed by the new tests have been fixed.

Details about the changes:

----
Change 3312369 (improve recognition of main module in case of bundles):

So far, the module analyzer always assumed the first module definition to be the main definition. This failed at least for CVOM bundles but might also fail for others.

The analysis has been improved and now accepts a module as main module only in the following cases:
- if it is an unnamed module
- if it is a named module whose name matches the external name
- if it is a named module and there's only one module (no bundle)

If multiple module definitions match the above criteria, this is
reported as an error.

Additionally, AMD special dependencies ('require', 'exports', 'module') are no longer reported in the dependency info.

----
Change 3945349 (JSModuleAnalyzer fails on modules that don't declare a name)

Basically, the JavaScript implementation was less sensitive to this issue. But if a resource could have a dependency to another resource named "null", the JavaScript tooling would fail, too. Although this looked like a purely theoretical scenario, adding a protective 'if' was trivial enough to just do it. 

----
Change 3562114 (fix dep. analysis of new evo bundles)

- recognize and evaluate sap.ui.require.preload calls
- write and extract bundle name and raw module names
