### PR TITLE
[INTERNAL] Update JSDoc to 3.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -234,8 +234,7 @@
 		"@babel/parser": {
 			"version": "7.6.4",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-			"integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
-			"dev": true
+			"integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.2.0",
@@ -668,7 +667,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -899,11 +897,6 @@
 				"espurify": "^1.6.0",
 				"estraverse": "^4.1.1"
 			}
-		},
-		"babylon": {
-			"version": "7.0.0-beta.19",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-			"integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -3807,11 +3800,11 @@
 			}
 		},
 		"js2xmlparser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
-			"integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.0.tgz",
+			"integrity": "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==",
 			"requires": {
-				"xmlcreate": "^1.0.1"
+				"xmlcreate": "^2.0.0"
 			}
 		},
 		"jsbn": {
@@ -3820,22 +3813,36 @@
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"jsdoc": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
-			"integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.3.tgz",
+			"integrity": "sha512-Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==",
 			"requires": {
-				"babylon": "7.0.0-beta.19",
-				"bluebird": "~3.5.0",
-				"catharsis": "~0.8.9",
-				"escape-string-regexp": "~1.0.5",
-				"js2xmlparser": "~3.0.0",
-				"klaw": "~2.0.0",
-				"marked": "~0.3.6",
-				"mkdirp": "~0.5.1",
-				"requizzle": "~0.2.1",
-				"strip-json-comments": "~2.0.1",
+				"@babel/parser": "^7.4.4",
+				"bluebird": "^3.5.4",
+				"catharsis": "^0.8.11",
+				"escape-string-regexp": "^2.0.0",
+				"js2xmlparser": "^4.0.0",
+				"klaw": "^3.0.0",
+				"markdown-it": "^8.4.2",
+				"markdown-it-anchor": "^5.0.2",
+				"marked": "^0.7.0",
+				"mkdirp": "^0.5.1",
+				"requizzle": "^0.2.3",
+				"strip-json-comments": "^3.0.1",
 				"taffydb": "2.6.2",
-				"underscore": "~1.8.3"
+				"underscore": "~1.9.1"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+				},
+				"strip-json-comments": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
+				}
 			}
 		},
 		"jsdoctypeparser": {
@@ -3927,9 +3934,9 @@
 			}
 		},
 		"klaw": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
-			"integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+			"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
 			"requires": {
 				"graceful-fs": "^4.1.9"
 			}
@@ -3996,6 +4003,14 @@
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
+			}
+		},
+		"linkify-it": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+			"integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+			"requires": {
+				"uc.micro": "^1.0.1"
 			}
 		},
 		"load-json-file": {
@@ -4171,10 +4186,27 @@
 			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
 			"dev": true
 		},
+		"markdown-it": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+			"integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+			"requires": {
+				"argparse": "^1.0.7",
+				"entities": "~1.1.1",
+				"linkify-it": "^2.0.0",
+				"mdurl": "^1.0.1",
+				"uc.micro": "^1.0.5"
+			}
+		},
+		"markdown-it-anchor": {
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.5.tgz",
+			"integrity": "sha512-xLIjLQmtym3QpoY9llBgApknl7pxAcN3WDRc2d3rwpl+/YvDZHPmKscGs+L6E05xf2KrCXPBvosWt7MZukwSpQ=="
+		},
 		"marked": {
-			"version": "0.3.19",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+			"integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
 		},
 		"matcher": {
 			"version": "2.0.0",
@@ -4207,6 +4239,11 @@
 			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
 			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
 			"dev": true
+		},
+		"mdurl": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
 		},
 		"meow": {
 			"version": "5.0.0",
@@ -5772,8 +5809,7 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.16.1",
@@ -5871,7 +5907,8 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"supertap": {
 			"version": "1.0.0",
@@ -6358,6 +6395,11 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
+		"uc.micro": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+		},
 		"uglify-js": {
 			"version": "3.6.3",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
@@ -6385,9 +6427,9 @@
 			"dev": true
 		},
 		"underscore": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+			"integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
@@ -6717,9 +6759,9 @@
 			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
 		},
 		"xmlcreate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
-			"integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz",
+			"integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA=="
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
 		"estraverse": "^4.3.0",
 		"globby": "^10.0.1",
 		"graceful-fs": "^4.2.2",
-		"jsdoc": "3.5.5",
+		"jsdoc": "^3.6.3",
 		"less-openui5": "^0.6.0",
 		"make-dir": "^3.0.0",
 		"pretty-data": "^0.40.0",


### PR DESCRIPTION
Re-open version range in package.json to patches like grunt-jsdoc is
doing:
https://github.com/krampstudio/grunt-jsdoc/blob/7b4c6eb9db6ae207b18f1fdf37bc71d8c98c76da/package.json#L44

Minor updates tend to break the UI5 JSDoc plugin.