### PR TITLE
[INTERNAL] jsdoc: Adopt version range to micro releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
 		"estraverse": "^4.3.0",
 		"globby": "^10.0.1",
 		"graceful-fs": "^4.2.2",
-		"jsdoc": "^3.6.3",
+		"jsdoc": "~3.6.3",
 		"less-openui5": "^0.6.0",
 		"make-dir": "^3.0.0",
 		"pretty-data": "^0.40.0",


### PR DESCRIPTION
Follow-up of https://github.com/SAP/ui5-builder/pull/356