### PR TITLE
[FIX] Use 'defaultFileTypes' from bundle configuration

### DIFF
--- a/lib/lbt/bundle/AutoSplitter.js
+++ b/lib/lbt/bundle/AutoSplitter.js
@@ -47,7 +47,7 @@ class AutoSplitter {
 		this.optimize = !!options.optimize;
 
 		// ---- resolve module definition
-		const resolvedModule = await this.resolver.resolve(moduleDef /* NODE-TODO , vars*/);
+		const resolvedModule = await this.resolver.resolve(moduleDef, options);
 		// ---- calculate overall size of merged module
 
 		if ( moduleDef.configuration ) {

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -129,8 +129,8 @@ class BundleBuilder {
 	}
 
 	async _createBundle(module, options) {
-		const resolvedModule = await this.resolver.resolve(module /* NODE-TODO, vars */);
-		log.verbose("  create '%s'",	resolvedModule.name);
+		const resolvedModule = await this.resolver.resolve(module, options);
+		log.verbose("  create '%s'", resolvedModule.name);
 
 		this.options = options || {};
 		this.optimize = !!this.options.optimize;

--- a/lib/lbt/bundle/Resolver.js
+++ b/lib/lbt/bundle/Resolver.js
@@ -30,10 +30,13 @@ class BundleResolver {
 	// NODE-TODO private final Map<ModuleName, AbstractModuleDefinition> moduleDefinitions;
 
 	/**
-	 * @param {ModuleDefinition} bundle
+	 * @param {ModuleDefinition} bundle Bundle definition to resolve
+	 * @param {Object} [options] Options
+	 * @param {string[]} [options.defaultFileTypes] List of default file types to which a prefix pattern shall be expanded.
 	 * @returns {Promise<ResolvedBundleDefinition>}
 	 */
-	resolve(bundle /* NODE-TODO, Map<string,string> vars */) {
+	resolve(bundle, options) {
+		const fileTypes = (options && options.defaultFileTypes) || undefined;
 		let visitedResources = Object.create(null);
 		let selectedResources = Object.create(null);
 		let selectedResourcesSequence = [];
@@ -47,7 +50,7 @@ class BundleResolver {
 			let prevLength;
 			let newKeys;
 
-			const filters = new ResourceFilterList( section.filters ); // resolvePlaceholders(section.getFilters());
+			const filters = new ResourceFilterList( section.filters, fileTypes ); // resolvePlaceholders(section.getFilters());
 
 			function isAccepted(resourceName, required) {
 				let match = required;

--- a/lib/lbt/resources/ResourceFilterList.js
+++ b/lib/lbt/resources/ResourceFilterList.js
@@ -2,7 +2,19 @@
 
 const log = require("@ui5/logger").getLogger("lbt:resources:ResourceFilterList");
 
-function makeMatcher(globPattern) {
+function makeFileTypePattern(fileTypes) {
+	if ( fileTypes == null ) {
+		return undefined;
+	}
+	return "(?:" + fileTypes.map((type) => {
+		if ( !type.startsWith(".") ) {
+			type = "." + type;
+		}
+		return type.replace(/[*+?.()|^$]/g, "\\$&");
+	}).join("|") + ")";
+}
+
+function makeMatcher(globPattern, fileTypesPattern) {
 	const result = {
 		pattern: globPattern,
 		include: true
@@ -14,29 +26,51 @@ function makeMatcher(globPattern) {
 		globPattern = globPattern.slice(1);
 	}
 
-	// check for wildcards
-	if ( /\*|\/$/.test(globPattern) ) {
-		if ( !/\/\*\*\/$/.test(globPattern) ) {
-			globPattern = globPattern.replace(/\/$/, "/**/");
+	// normalize some convenience shortcuts
+	// - a trailing 'any sub-path' pattern also implies the 'any file' pattern:
+	//      ".../foo/**/" --> "../foo/**/*"
+	// - a trailing slash matches any files in any sub-folder:
+	//      ".../foo/" --> ".../foo/**/*"
+	if ( globPattern.endsWith("/") ) {
+		if ( globPattern.endsWith("/**/") ) {
+			globPattern = globPattern + "*";
+		} else {
+			globPattern = globPattern + "**/*";
 		}
+	}
 
-		const regexp = globPattern.replace(/\*\*\/|\*|[[\]{}()+?.\\^$|]/g, function(match) {
+	// check for wildcards
+	if ( /\*/.test(globPattern) ) {
+		// Transform the globPattern into a regular expression pattern by converting
+		// the "all sub-directories" pattern "/**/" and the "any file name" pattern "*"
+		// to their respective regexp counterparts and escape all other regexp special
+		// characters.
+		let regexp = globPattern.replace(/^\*\*\/|\/\*\*\/|\*|[[\]{}()+?.\\^$|]/g, (match) => {
 			switch (match) {
 			case "**/": return "(?:[^/]+/)*";
+			case "/**/": return "/(?:[^/]+/)*";
 			case "*": return "[^/]*";
 			default: return "\\" + match;
 			}
 		});
 
-		log.verbose("%s -> %s,%s", result.pattern, "^" + regexp, result.include ? "include" : "exclude" );
-		result.regexp = new RegExp("^" + regexp);
+		// if the pattern ended with an asterisk and if a default file type pattern is defined,
+		// add that pattern. This limits the matches to the specified set of file types
+		if ( fileTypesPattern != null && regexp.endsWith("[^/]*") ) {
+			regexp = regexp + fileTypesPattern;
+		}
+
+		result.regexp = new RegExp("^" + regexp + "$");
 		result.calcMatch = result.include ? function(candidate, matchSoFar) {
 			return matchSoFar || this.regexp.test(candidate);
 		} : function(candidate, matchSoFar) {
 			return matchSoFar && !this.regexp.test(candidate);
 		};
+
+		log.verbose(`  ${result.pattern} --> ${result.include ? "include" : "exclude"}: /${result.regexp.source}/`);
 	} else {
 		result.value = globPattern;
+		log.verbose(`  ${result.pattern} --> ${result.include ? "include" : "exclude"}: "${globPattern}"`);
 		result.calcMatch = result.include ? function(candidate, matchSoFar) {
 			return matchSoFar || candidate === this.value;
 		} : function(candidate, matchSoFar) {
@@ -56,19 +90,20 @@ function makeMatcher(globPattern) {
  * @author Frank Weigel
  * @since 1.16.2
  * @private
- * TODO Share with plugins, esp. coldWater, lightening, ...
  */
 class ResourceFilterList {
-	constructor(filters) {
+	constructor(filters, fileTypes) {
 		this.matchers = [];
 		this.matchByDefault = true;
+		this.fileTypes = makeFileTypePattern(fileTypes);
+		log.verbose(`filetypes: ${fileTypes}`);
 		this.addFilters(filters);
 	}
 
 	addFilters(filters) {
 		if ( Array.isArray(filters) ) {
 			filters.forEach( (filter) => {
-				const matcher = makeMatcher(filter);
+				const matcher = makeMatcher(filter, this.fileTypes);
 				this.matchers.push( matcher );
 				this.matchByDefault = this.matchByDefault && !matcher.include;
 			});
@@ -77,59 +112,6 @@ class ResourceFilterList {
 		}
 		return this;
 	}
-
-	/* NODE-TODO
-	public ResourceFilterList addIncludes(String[] includes){
-		if ( includes != null ) {
-			for(String include : includes) {
-				add(include, false);
-			}
-		}
-		return this;
-	}
-
-	public ResourceFilterList addExcludes(String[] excludes) {
-		if ( excludes != null ) {
-			for(String exclude : excludes) {
-				add(exclude, true);
-			}
-		}
-		return this;
-	}
-
-	/**
-	 * old style resource pattern (from old Optimizer)
-	 * @param excludePattern
-	 * @deprecated Use the more flexible add or addFilters instead.
-	 *
-	public void addExcludePattern(Pattern excludePattern) {
-		isExclude.set(patterns.size(), true);
-		patterns.add(excludePattern);
-	}
-
-	public ResourceFilterList add(String patternList, boolean exclude) {
-		for(String pattern : patternList.trim().split("\\s*,\\s*")) {
-			if ( !pattern.isEmpty() ) {
-				isExclude.set(patterns.size(), exclude);
-				patterns.add(ModuleNamePattern.createRegEx(pattern, ignoreCase));
-				hasInclude = hasInclude || !exclude;
-			}
-		}
-		return this;
-	}
-
-	public ResourceFilterList add(String patternList) {
-		for(String pattern : patternList.trim().split("\\s*,\\s*")) {
-			if ( !pattern.isEmpty() ) {
-				boolean exclude = pattern.startsWith("!") || pattern.startsWith("-");
-				isExclude.set(patterns.size(), exclude);
-				patterns.add(ModuleNamePattern.createRegEx(exclude || pattern.startsWith("+")
-					? pattern.substring(1) : pattern, ignoreCase));
-				hasInclude = hasInclude || !exclude;
-			}
-		}
-		return this;
-	} */
 
 	matches(candidate, initialMatch) {
 		return this.matchers.reduce(

--- a/lib/lbt/resources/ResourceFilterList.js
+++ b/lib/lbt/resources/ResourceFilterList.js
@@ -27,12 +27,14 @@ function makeMatcher(globPattern, fileTypesPattern) {
 	}
 
 	// normalize some convenience shortcuts
+	// - a lonely 'any sub-path' pattern implies the 'any file' pattern:
+	//      "**/" --> "**/*"
 	// - a trailing 'any sub-path' pattern also implies the 'any file' pattern:
 	//      ".../foo/**/" --> "../foo/**/*"
-	// - a trailing slash matches any files in any sub-folder:
+	// - any other trailing slash matches any files in any sub-folder:
 	//      ".../foo/" --> ".../foo/**/*"
 	if ( globPattern.endsWith("/") ) {
-		if ( globPattern.endsWith("/**/") ) {
+		if ( globPattern === "**/" || globPattern.endsWith("/**/") ) {
 			globPattern = globPattern + "*";
 		} else {
 			globPattern = globPattern + "**/*";
@@ -128,7 +130,7 @@ class ResourceFilterList {
 ResourceFilterList.fromString = function(filterStr) {
 	const result = new ResourceFilterList();
 	if ( filterStr != null ) {
-		result.addFilters( filterStr.trim().split(/\s*,\s*/) );
+		result.addFilters( filterStr.trim().split(/\s*,\s*/).filter(Boolean) );
 	}
 	return result;
 };

--- a/test/lib/lbt/resources/ResourceFilterList.js
+++ b/test/lib/lbt/resources/ResourceFilterList.js
@@ -1,0 +1,200 @@
+const test = require("ava");
+const ResourceFilterList = require("../../../../lib/lbt/resources/ResourceFilterList");
+
+test("single string matcher", (t) => {
+	const filterList = new ResourceFilterList([
+		"foo/bar.js"
+	]);
+
+	t.is(filterList.toString(), "foo/bar.js");
+	t.true(filterList.matches("foo/bar.js"));
+	t.falsy(filterList.matches("boo/far.js"));
+	t.falsy(filterList.matches("foo/bar.json"));
+	t.falsy(filterList.matches("foo/bar"));
+	t.falsy(filterList.matches("bar.js"));
+});
+
+test("multiple string matchers", (t) => {
+	const filterList = new ResourceFilterList([
+		"foo/bar.js",
+		"foo/baz.js"
+	]);
+
+	t.is(filterList.toString(), "foo/bar.js,foo/baz.js");
+	t.true(filterList.matches("foo/bar.js"));
+	t.true(filterList.matches("foo/baz.js"));
+	t.falsy(filterList.matches("foo/fam.js"));
+});
+
+test("single prefix pattern + shortcuts", (t) => {
+	["foo/**/*", "foo/", "foo/**/"].forEach( (pattern) => {
+		const filterList = new ResourceFilterList([pattern]);
+
+		t.is(filterList.toString(), pattern);
+		t.true(filterList.matches("foo/bar"));
+		t.true(filterList.matches("foo/bar.js"));
+		t.true(filterList.matches("foo/bar.xml"));
+		t.true(filterList.matches("foo/bar.any"));
+		t.true(filterList.matches("foo/foo/bar"));
+		t.true(filterList.matches("foo/foo/bar.js"));
+		t.true(filterList.matches("foo/foo/bar.xml"));
+		t.true(filterList.matches("foo/foo/bar.any"));
+		t.falsy(filterList.matches("boo/far.js"));
+		t.falsy(filterList.matches("foo.js"));
+		t.falsy(filterList.matches("boo/foo/bar.js"), "doesn't match infix");
+	});
+});
+
+test("'any' pattern + shortcuts", (t) => {
+	["**/*", "**/"].forEach( (pattern) => {
+		const filterList = new ResourceFilterList([pattern]);
+
+		t.is(filterList.toString(), pattern);
+		t.true(filterList.matches("bar"));
+		t.true(filterList.matches("bar.js"));
+		t.true(filterList.matches("bar.xml"));
+		t.true(filterList.matches("bar.any"));
+		t.true(filterList.matches("foo/bar"));
+		t.true(filterList.matches("foo/bar.js"));
+		t.true(filterList.matches("foo/bar.xml"));
+		t.true(filterList.matches("foo/bar.any"));
+		t.true(filterList.matches("foo/baz/bar"));
+		t.true(filterList.matches("foo/baz/bar.js"));
+		t.true(filterList.matches("foo/baz/bar.xml"));
+		t.true(filterList.matches("foo/baz/bar.any"));
+	});
+});
+
+test("single infix pattern", (t) => {
+	const filterList = new ResourceFilterList([
+		"foo/**/bar.js"
+	]);
+
+	t.is(filterList.toString(), "foo/**/bar.js");
+	t.true(filterList.matches("foo/bar.js"));
+	t.true(filterList.matches("foo/baz/bar.js"));
+	t.true(filterList.matches("foo/baz/bam/bar.js"));
+	t.falsy(filterList.matches("foobar/bar.js"));
+});
+
+test("single suffix pattern", (t) => {
+	const filterList = new ResourceFilterList([
+		"**/bar.js"
+	]);
+
+	t.is(filterList.toString(), "**/bar.js");
+	t.true(filterList.matches("bar.js"));
+	t.true(filterList.matches("foo/bar.js"));
+	t.true(filterList.matches("foo/baz/bar.js"));
+	t.true(filterList.matches("foo/baz/bam/bar.js"));
+	t.falsy(filterList.matches("foobar.js"));
+	t.falsy(filterList.matches("foo/baz.js"));
+});
+
+test("include and exclude", (t) => {
+	const filterList = new ResourceFilterList([
+		"foo/",
+		"!foo/bar/*.xml"
+	]);
+
+	t.is(filterList.toString(), "foo/,!foo/bar/*.xml");
+	t.true(filterList.matches("foo/bar.js"));
+	t.true(filterList.matches("foo/bar.xml"));
+	t.true(filterList.matches("foo/bar/baz.js"));
+	t.true(filterList.matches("foo/bar/baz/bam.xml"));
+	t.falsy(filterList.matches("foo/bar/baz.xml"));
+});
+
+test("exclude and include", (t) => {
+	const filterList = new ResourceFilterList([
+		"!foo/",
+		"foo/bar/*.xml"
+	]);
+
+	t.is(filterList.toString(), "!foo/,foo/bar/*.xml");
+	t.falsy(filterList.matches("foo/bar.js"));
+	t.falsy(filterList.matches("foo/bar.xml"));
+	t.falsy(filterList.matches("foo/bar/baz.js"));
+	t.falsy(filterList.matches("foo/bar/baz/bam.xml"));
+	t.true(filterList.matches("foo/bar/baz.xml"));
+});
+
+test("file types", (t) => {
+	const filterList = new ResourceFilterList([
+		"foo/",
+		"bar.txt"
+	], [
+		".js",
+		"xml"
+	]);
+
+	t.true(filterList.matches("foo/bar.js"));
+	t.true(filterList.matches("foo/bar.xml"));
+	t.falsy(filterList.matches("foo/barjs"));
+	t.falsy(filterList.matches("foo/barxml"));
+	t.true(filterList.matches("foo/bar/baz.js"));
+	t.true(filterList.matches("foo/bar/baz.xml"));
+	t.falsy(filterList.matches("bar/foo.js"));
+	t.falsy(filterList.matches("bar/foo.xml"));
+	t.true(filterList.matches("bar.txt"));
+	t.falsy(filterList.matches("bar.js"));
+	t.falsy(filterList.matches("bar.xml"));
+});
+
+test("patterns with special chars", (t) => {
+	const filterList = new ResourceFilterList([
+		"foo?/",
+		"bar[variant]*"
+	]);
+	t.is(filterList.toString(), "foo?/,bar[variant]*");
+	t.true(filterList.matches("foo?/bar.js"));
+	t.falsy(filterList.matches("foo/bar.js"));
+	t.falsy(filterList.matches("fo/bar.js"));
+	t.true(filterList.matches("bar[variant].txt"));
+	t.true(filterList.matches("bar[variant].js"));
+	t.falsy(filterList.matches("barv.js"));
+});
+
+test("fromString", (t) => {
+	const filterList = ResourceFilterList.fromString(" foo?/ , bar[variant]*");
+
+	t.true(filterList.matches("foo?/bar.js"));
+	t.falsy(filterList.matches("foo/bar.js"));
+	t.falsy(filterList.matches("fo/bar.js"));
+	t.true(filterList.matches("bar[variant].txt"));
+	t.true(filterList.matches("bar[variant].js"));
+	t.falsy(filterList.matches("barv.js"));
+});
+
+test("fromString: undefined", (t) => {
+	const filterList = ResourceFilterList.fromString();
+
+	t.true(filterList.matches("foo/bar.js"));
+	t.true(filterList.matches("bar.js"));
+	t.true(filterList.matches("foobar"));
+});
+
+test("fromString: empty", (t) => {
+	const filterList = ResourceFilterList.fromString("");
+
+	t.true(filterList.matches("foo/bar.js"));
+	t.true(filterList.matches("bar.js"));
+	t.true(filterList.matches("foobar"));
+});
+
+test("error handling", (t) => {
+	const filterList = new ResourceFilterList();
+
+	// these are accepted
+	filterList.addFilters(null);
+	filterList.addFilters(undefined);
+	filterList.addFilters([]);
+	// these are not
+	t.throws(() => {
+		filterList.addFilters("test");
+	});
+	t.throws(() => {
+		filterList.addFilters({});
+	});
+});
+


### PR DESCRIPTION
The 'defaultFileTypes' option for bundles was completely ignored. The
list should be used to limit the set of accepted files when an include
or exclude pattern ends with a '*'.
