### PR TITLE
[FIX] Avoid redundant bundle creation

### DIFF
--- a/lib/tasks/bundlers/generateComponentPreload.js
+++ b/lib/tasks/bundlers/generateComponentPreload.js
@@ -14,6 +14,7 @@ const ReaderCollectionPrioritized = require("@ui5/fs").ReaderCollectionPrioritiz
  * @param {string} parameters.options.projectName Project name
  * @param {Array} [parameters.options.paths] Array of paths (or glob patterns) for component files
  * @param {Array} [parameters.options.namespaces] Array of component namespaces
+ * @param {string[]} [parameters.options.customBundleNames] List of custom bundles defined for the project
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written
  */
 module.exports = function({workspace, dependencies, options}) {
@@ -21,6 +22,8 @@ module.exports = function({workspace, dependencies, options}) {
 		name: `generateComponentPreload - prioritize workspace over dependencies: ${options.projectName}`,
 		readers: [workspace, dependencies]
 	});
+
+	const customBundleNames = (options && options.customBundleNames) || [];
 
 	return combo.byGlob("/resources/**/*.{js,json,xml,html,properties,library}")
 		.then(async (resources) => {
@@ -46,6 +49,11 @@ module.exports = function({workspace, dependencies, options}) {
 			}
 
 			return Promise.all(namespaces.map((namespace) => {
+				const bundleName = `${namespace}/Component-preload.js`;
+				if (customBundleNames.includes(bundleName)) {
+					return null;
+				}
+
 				const filters = [
 					`${namespace}/`,
 					`!${namespace}/test/`,
@@ -63,7 +71,7 @@ module.exports = function({workspace, dependencies, options}) {
 					resources,
 					options: {
 						bundleDefinition: {
-							name: `${namespace}/Component-preload.js`,
+							name: bundleName,
 							defaultFileTypes: [".js", ".fragment.xml", ".view.xml", ".properties", ".json"],
 							sections: [
 								{
@@ -79,6 +87,7 @@ module.exports = function({workspace, dependencies, options}) {
 				});
 			}));
 		})
+		.then((processedResources) => processedResources.filter(Boolean))
 		.then((processedResources) => {
 			return Promise.all(processedResources.map((resource) => {
 				return workspace.write(resource[0]);

--- a/lib/tasks/bundlers/generateLibraryPreload.js
+++ b/lib/tasks/bundlers/generateLibraryPreload.js
@@ -166,6 +166,7 @@ function getSapUiCoreBunDef(name, filters, preload) {
  * @param {module:@ui5/fs.AbstractReader} parameters.dependencies Reader or Collection to read dependency files
  * @param {Object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
+ * @param {string[]} [parameters.options.customBundleNames] List of custom bundles defined for the project
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written
  */
 module.exports = function({workspace, dependencies, options}) {
@@ -173,6 +174,15 @@ module.exports = function({workspace, dependencies, options}) {
 		name: `libraryBundler - prioritize workspace over dependencies: ${options.projectName}`,
 		readers: [workspace, dependencies]
 	});
+
+	const customBundleNames = (options && options.customBundleNames) || [];
+	const execModuleBundlerIfNeeded = ({options, resources}) => {
+		if (customBundleNames.includes(options.bundleDefinition.name)) {
+			log.verbose(`skipping overridden built-in bundle ${options.bundleDefinition.name}`);
+			return null;
+		}
+		return moduleBundler({options, resources});
+	};
 
 	return combo.byGlob("/**/*.{js,json,xml,html,properties,library}").then((resources) => {
 		// Find all libraries and create a library-preload.js bundle
@@ -199,24 +209,24 @@ module.exports = function({workspace, dependencies, options}) {
 			}
 
 			p = Promise.all([
-				moduleBundler({
+				execModuleBundlerIfNeeded({
 					options: getModuleBundlerOptions({name: "sap-ui-core.js", filters, preload: true}),
 					resources
 				}),
-				moduleBundler({
+				execModuleBundlerIfNeeded({
 					options: getModuleBundlerOptions({name: "sap-ui-core-dbg.js", filters, preload: false}),
 					resources
 				}),
-				moduleBundler({
+				execModuleBundlerIfNeeded({
 					options: getModuleBundlerOptions({name: "sap-ui-core-nojQuery.js", filters, preload: true, provided: true}),
 					resources
 				}),
-				moduleBundler({
+				execModuleBundlerIfNeeded({
 					options: getModuleBundlerOptions({name: "sap-ui-core-nojQuery-dbg.js", filters, preload: false, provided: true}),
 					resources
 				}),
 			]).then((results) => {
-				const bundles = Array.prototype.concat.apply([], results);
+				const bundles = Array.prototype.concat.apply([], results).filter(Boolean);
 				return Promise.all(bundles.map((bundle) => workspace.write(bundle)));
 			});
 		} else {
@@ -249,7 +259,7 @@ module.exports = function({workspace, dependencies, options}) {
 					const libraryNamespaceMatch = libraryIndicatorPath.match(libraryNamespacePattern);
 					if (libraryNamespaceMatch && libraryNamespaceMatch[1]) {
 						const libraryNamespace = libraryNamespaceMatch[1];
-						return moduleBundler({
+						return execModuleBundlerIfNeeded({
 							options: {
 								bundleDefinition: getBundleDefinition(libraryNamespace),
 								bundleOptions: {

--- a/lib/types/application/ApplicationBuilder.js
+++ b/lib/types/application/ApplicationBuilder.js
@@ -83,6 +83,12 @@ class ApplicationBuilder extends AbstractBuilder {
 			});
 		}
 
+		const bundles = project.builder && project.builder.bundles;
+		const customBundleNames =
+			bundles && bundles.map(
+				(bundle) => bundle.bundleDefinition && bundle.bundleDefinition.name
+			).filter(Boolean);
+
 		const componentPreload = project.builder && project.builder.componentPreload;
 		if (componentPreload) {
 			this.addTask("generateComponentPreload", async () => {
@@ -104,7 +110,8 @@ class ApplicationBuilder extends AbstractBuilder {
 					dependencies: resourceCollections.dependencies,
 					options: {
 						projectName: project.metadata.name,
-						namespaces: [project.metadata.namespace]
+						namespaces: [project.metadata.namespace],
+						customBundleNames
 					}
 				});
 			});
@@ -131,7 +138,6 @@ class ApplicationBuilder extends AbstractBuilder {
 			});
 		});
 
-		const bundles = project.builder && project.builder.bundles;
 		if (bundles) {
 			this.addTask("generateBundle", () => {
 				return Promise.all(bundles.map((bundle) => {

--- a/lib/types/library/LibraryBuilder.js
+++ b/lib/types/library/LibraryBuilder.js
@@ -102,6 +102,12 @@ class LibraryBuilder extends AbstractBuilder {
 			});
 		}
 
+		const bundles = project.builder && project.builder.bundles;
+		const customBundleNames =
+			bundles && bundles.map(
+				(bundle) => bundle.bundleDefinition && bundle.bundleDefinition.name
+			).filter(Boolean);
+
 		const componentPreload = project.builder && project.builder.componentPreload;
 		if (componentPreload) {
 			const generateComponentPreload = tasks.generateComponentPreload;
@@ -113,7 +119,8 @@ class LibraryBuilder extends AbstractBuilder {
 					options: {
 						projectName: project.metadata.name,
 						paths: componentPreload.paths,
-						namespaces: componentPreload.namespaces
+						namespaces: componentPreload.namespaces,
+						customBundleNames
 					}
 				});
 			});
@@ -150,12 +157,12 @@ class LibraryBuilder extends AbstractBuilder {
 				workspace: resourceCollections.workspace,
 				dependencies: resourceCollections.dependencies,
 				options: {
-					projectName: project.metadata.name
+					projectName: project.metadata.name,
+					customBundleNames
 				}
 			});
 		});
 
-		const bundles = project.builder && project.builder.bundles;
 		if (bundles) {
 			this.addTask("generateBundle", () => {
 				return bundles.reduce(function(sequence, bundle) {


### PR DESCRIPTION
When a custom bundle has the same name as a built-in bundle (e.g.
foo/bar/library-preload.js), then the creation of the built-in bundle
can be skipped.
