### PR TITLE
[FIX] Detect dynamic dependencies also when newer APIs are used

### DIFF
--- a/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -546,7 +546,7 @@ class JSModuleAnalyzer {
 						const requiredModuleName2 = ModuleName.fromUI5LegacyName( arg.alternate.value );
 						info.addDependency(requiredModuleName2, true);
 					} else {
-						log.verbose("jQuery.sap.require: cannot evaluate dynamic arguments: ", arg);
+						log.verbose("jQuery.sap.require: cannot evaluate dynamic arguments: ", arg && arg.type);
 						info.dynamicDependencies = true;
 					}
 				}
@@ -558,12 +558,16 @@ class JSModuleAnalyzer {
 			const nArgs = args.length;
 			const i = 0;
 
-			if ( i < nArgs && isString(args[i]) ) {
-				const moduleName = ModuleName.fromRequireJSName( args[i].value );
-				info.addDependency(moduleName, conditional);
+			if ( i < nArgs ) {
+				if ( isString(args[i]) ) {
+					const moduleName = ModuleName.fromRequireJSName( args[i].value );
+					info.addDependency(moduleName, conditional);
+				} else {
+					log.verbose("sap.ui.requireSync: cannot evaluate dynamic arguments: ", args[i] && args[i].type);
+					info.dynamicDependencies = true;
+				}
 			}
 		}
-
 
 		function onSapUiPredefine(predefineCall) {
 			const args = predefineCall.arguments;
@@ -622,6 +626,9 @@ class JSModuleAnalyzer {
 						requiredModule = ModuleName.resolveRelativeRequireJSName(name, item.value);
 					}
 					info.addDependency( requiredModule, conditional );
+				} else {
+					log.verbose("sap.ui.require/sap.ui.define: cannot evaluate dynamic argument: ", item && item.type);
+					info.dynamicDependencies = true;
 				}
 			});
 		}

--- a/test/fixtures/lbt/modules/amd_dynamic_require.js
+++ b/test/fixtures/lbt/modules/amd_dynamic_require.js
@@ -1,0 +1,11 @@
+sap.ui.define([], function() {
+	return {
+		load: function(modName) {
+			sap.ui.require([modName], function(modExport) {
+				// module was loaded
+			}, function(err) {
+				// error occurred
+			});
+		}
+	}
+});

--- a/test/fixtures/lbt/modules/amd_dynamic_require_sync.js
+++ b/test/fixtures/lbt/modules/amd_dynamic_require_sync.js
@@ -1,0 +1,7 @@
+sap.ui.define([], function() {
+	return {
+		load: function(modName) {
+			return sap.ui.requireSync(modName);
+		}
+	}
+});

--- a/test/fixtures/lbt/modules/declare_dynamic_require.js
+++ b/test/fixtures/lbt/modules/declare_dynamic_require.js
@@ -1,0 +1,5 @@
+jQuery.sap.declare("sap.ui.testmodule");
+
+sap.ui.testmodule.load = function(modName) {
+	jQuery.sap.require(modName);
+};

--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -96,7 +96,6 @@ function analyzeModule(
 		}
 		t.false(info.dynamicDependencies,
 			"no use of dynamic dependencies should have been detected");
-
 	}).then(() => t.end(), (e) => t.fail(`failed to analyze module with error: ${e.message}`));
 }
 

--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -94,6 +94,9 @@ function analyzeModule(
 				expectedSubmodules,
 				"submodules should match");
 		}
+		t.false(info.dynamicDependencies,
+			"no use of dynamic dependencies should have been detected");
+
 	}).then(() => t.end(), (e) => t.fail(`failed to analyze module with error: ${e.message}`));
 }
 
@@ -356,7 +359,31 @@ test("ES6 Syntax", (t) => {
 				"only dependencies to 'conditional/*' modules should be conditional");
 			t.is(info.isImplicitDependency(dep), !/^(?:conditional|static)\//.test(dep),
 				"all dependencies other than 'conditional/*' and 'static/*' should be implicit");
+			t.false(info.dynamicDependencies,
+				"no use of dynamic dependencies should have been detected");
 		});
 	});
 });
+
+test("Dynamic import (declare/require)", (t) => {
+	return analyze("modules/declare_dynamic_require.js").then((info) => {
+		t.true(info.dynamicDependencies,
+			"the use of dynamic dependencies should have been detected");
+	});
+});
+
+test("Dynamic import (define/require)", (t) => {
+	return analyze("modules/amd_dynamic_require.js").then((info) => {
+		t.true(info.dynamicDependencies,
+			"the use of dynamic dependencies should have been detected");
+	});
+});
+
+test("Dynamic import (define/requireSync)", (t) => {
+	return analyze("modules/amd_dynamic_require_sync.js").then((info) => {
+		t.true(info.dynamicDependencies,
+			"the use of dynamic dependencies should have been detected");
+	});
+});
+
 


### PR DESCRIPTION
So far, dynamic dependencies only had been detected for calls to
jQuery.sap.require. Now, calls to sap.ui.require and sap.ui.requireSync
are also checked.
