### PR TITLE
[FEATURE] Support writing 'bundles' config as part of a bundle

### DIFF
--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -483,6 +483,10 @@ class BundleBuilder {
 				if ( idx > 0 ) {
 					this.outW.writeln(",");
 				}
+
+				if (!section.name) {
+					throw new Error(`A 'bundleInfo' section is missing property 'name'`);
+				}
 				this.outW.write(`"${section.name}":[${section.modules.map(makeStringLiteral).join(",")}]`);
 			});
 			this.outW.writeln();

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -55,6 +55,14 @@ const UI5BundleFormat = {
 		outW.writeln(`}});`);
 	},
 
+	beforeBundleInfo(outW) {
+		outW.writeln("\"unsupported\"; /* Bundle format 'h2' not supported (requires ui5loader)");
+	},
+
+	afterBundleInfo(outW) {
+		outW.writeln("*/");
+	},
+
 	requireSync(outW, moduleName) {
 		outW.writeln(`sap.ui.requireSync("${ModuleName.toRequireJSName(moduleName)}");`);
 	},
@@ -75,6 +83,14 @@ const EVOBundleFormat = {
 			outW.write(`,"${section.name}"`);
 		}
 		outW.writeln(`);`);
+	},
+
+	beforeBundleInfo(outW) {
+		outW.writeln("sap.ui.loader.config({bundlesUI5:{");
+	},
+
+	afterBundleInfo(outW) {
+		outW.writeln("}});");
 	},
 
 	requireSync(outW, moduleName) {
@@ -141,12 +157,24 @@ class BundleBuilder {
 		// TODO is the following condition ok or should the availability of jquery.sap.global.js be configurable?
 		this.jqglobalAvailable = !resolvedModule.containsGlobal;
 		this.openModule(resolvedModule.name);
-
+		let bundleInfos = [];
 		// create all sections in sequence
 		for ( const section of resolvedModule.sections ) {
 			log.verbose("    adding section%s of type %s",
 				section.name ? " '" + section.name + "'" : "", section.mode);
-			await this.addSection(section);
+			if ( section.mode === SectionType.BundleInfo ) {
+				bundleInfos.push(section);
+			} else {
+				if ( bundleInfos.length > 0 ) {
+					await this.writeBundleInfos(bundleInfos);
+					bundleInfos = [];
+				}
+				await this.addSection(section);
+			}
+		}
+		if ( bundleInfos.length > 0 ) {
+			await this.writeBundleInfos(bundleInfos);
+			bundleInfos = [];
 		}
 
 		this.closeModule(resolvedModule);
@@ -204,6 +232,8 @@ class BundleBuilder {
 			return this.writeRaw(section);
 		case SectionType.Preload:
 			return this.writePreloadFunction(section);
+		case SectionType.BundleInfo:
+			return this.writeBundleInfos([section]);
 		case SectionType.Require:
 			return this.writeRequires(section);
 		default:
@@ -442,6 +472,22 @@ class BundleBuilder {
 			// Note: globalName can be assumed to be a valid identifier as it is used as variable name anyhow
 			this.outW.writeln(`this.${globalName}=${globalName};`);
 		});
+	}
+
+	writeBundleInfos(sections) {
+		this.outW.ensureNewLine();
+
+		if ( sections.length > 0 ) {
+			this.targetBundleFormat.beforeBundleInfo(this.outW);
+			sections.forEach((section, idx) => {
+				if ( idx > 0 ) {
+					this.outW.writeln(",");
+				}
+				this.outW.write(`"${section.name}":[${section.modules.map(makeStringLiteral).join(",")}]`);
+			});
+			this.outW.writeln();
+			this.targetBundleFormat.afterBundleInfo(this.outW);
+		}
 	}
 
 	writeRequires(section) {

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -485,7 +485,7 @@ class BundleBuilder {
 				}
 
 				if (!section.name) {
-					throw new Error(`A 'bundleInfo' section is missing property 'name'`);
+					throw new Error(`A 'bundleInfo' section is missing the mandatory 'name' property.` );
 				}
 				this.outW.write(`"${section.name}":[${section.modules.map(makeStringLiteral).join(",")}]`);
 			});

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -56,7 +56,7 @@ const UI5BundleFormat = {
 	},
 
 	beforeBundleInfo(outW) {
-		outW.writeln("\"unsupported\"; /* Bundle format 'h2' not supported (requires ui5loader)");
+		outW.writeln("\"unsupported\"; /* 'bundleInfo' section mode not supported (requires ui5loader)");
 	},
 
 	afterBundleInfo(outW) {

--- a/lib/lbt/bundle/BundleDefinition.js
+++ b/lib/lbt/bundle/BundleDefinition.js
@@ -18,7 +18,13 @@ const SectionType = {
 	Preload: "preload",
 
 	/**
-	 * For each module, a jQuery.sap.require call will be created.
+	 * Content information for another bundle is written.
+	 * Requires UI5 Evolution runtime.
+	 */
+	BundleInfo: "bundleInfo",
+
+	/**
+	 * For each module, a require call will be created.
 	 * Usually used as the last section in a merged module to enforce loading and
 	 * execution of some specific module or modules.
 	 */

--- a/lib/lbt/bundle/BundleDefinition.js
+++ b/lib/lbt/bundle/BundleDefinition.js
@@ -19,7 +19,8 @@ const SectionType = {
 
 	/**
 	 * Content information for another bundle is written.
-	 * Requires UI5 version 1.74.0 which adds support for the 'bundles' configuration.
+	 * Requires UI5 version 1.74.0 which adds runtime support for the 'bundles' and 'bundlesUI5'
+	 * ui5loader configuration.
 	 */
 	BundleInfo: "bundleInfo",
 

--- a/lib/lbt/bundle/BundleDefinition.js
+++ b/lib/lbt/bundle/BundleDefinition.js
@@ -19,7 +19,7 @@ const SectionType = {
 
 	/**
 	 * Content information for another bundle is written.
-	 * Requires UI5 Evolution runtime.
+	 * Requires UI5 version 1.74.0 which adds support for 'bundles'‚ configuration.
 	 */
 	BundleInfo: "bundleInfo",
 

--- a/lib/lbt/bundle/BundleDefinition.js
+++ b/lib/lbt/bundle/BundleDefinition.js
@@ -19,7 +19,7 @@ const SectionType = {
 
 	/**
 	 * Content information for another bundle is written.
-	 * Requires UI5 version 1.74.0 which adds support for 'bundles'‚ configuration.
+	 * Requires UI5 version 1.74.0 which adds support for the 'bundles' configuration.
 	 */
 	BundleInfo: "bundleInfo",
 

--- a/lib/processors/bundlers/moduleBundler.js
+++ b/lib/processors/bundlers/moduleBundler.js
@@ -4,8 +4,8 @@ const EvoResource = require("@ui5/fs").Resource;
 const log = require("@ui5/logger").getLogger("builder:processors:bundlers:moduleBundler");
 
 /**
- * A ModuleBundleDefinitionSection specifies the embedding mode ('provided', 'raw', 'preload' or 'require')
- * and lists the resources that should be in- or excluded from the section.
+ * A ModuleBundleDefinitionSection specifies the embedding mode ('provided', 'raw', 'preload', 'require'
+ * or 'bundleInfo') and lists the resources that should be in- or excluded from the section.
  * <p>
  * <b>Module bundle section modes</b><br>
  * <ul>
@@ -15,12 +15,12 @@ const log = require("@ui5/logger").getLogger("builder:processors:bundlers:module
  * which the bundle module is loaded.
  * 	</li>
  *	<li>
- *		<code>raw</code>: A raw section determines the set of modules that should be embedded, sorts them according
+ *		<code>raw</code>: A 'raw' section determines the set of modules that should be embedded, sorts them according
  *		to their dependencies and writes them out 1:1 without any transformation or wrapping (raw). Only JavaScript
  *		sources can be embedded in a raw section.
  *	</li>
  *	<li>
- *		<code>preload</code>: A preload section packages resources that should be stored in the preload cache in the
+ *		<code>preload</code>: A 'preload' section packages resources that should be stored in the preload cache in the
  *		client. They can embed any textual resource type (JavaScript, XML, JSON and .properties files) that the
  *		bundling supports. UI5 modules are wrapped into a 'sap.ui.predefine' call. Other JavaScript modules will be
  *		embedded into a 'jQuery.sap.registerPreload' call, unless the asynchronous ui5loader is used. With the
@@ -32,12 +32,18 @@ const log = require("@ui5/logger").getLogger("builder:processors:bundlers:module
  *		modules, a jQuery.sap.require will be created. In case the ui5loader is available, 'sap.ui.requireSync' is
  *		used instead.
  *	</li>
+ *	<li>
+ *		<code>bundleInfo</code>: A 'bundleInfo' section describes the content of another named bundle. This information
+ *		is transformed into a ui5loader-"bundlesUI5" configuration.
+ *		At runtime, if a module is known to be contained in a bundle, the loader will require that bundle before
+ *		the module itself is required.
+ *	</li>
  * </ul>
  * </p>
  *
  * @public
  * @typedef {object} ModuleBundleDefinitionSection
- * @property {string} mode The embedding mode. Either 'provided', 'raw', 'preload' or 'require'
+ * @property {string} mode The embedding mode. Either 'provided', 'raw', 'preload', 'require' or 'bundleInfo'
  * @property {string[]} filters List of modules declared as glob patterns (resource name patterns) that should be
  *		in- or excluded.
  * 		A pattern ending with a slash '/' will, similarly to the use of a single '*' or double '**' asterisk,

--- a/lib/processors/bundlers/moduleBundler.js
+++ b/lib/processors/bundlers/moduleBundler.js
@@ -4,7 +4,7 @@ const EvoResource = require("@ui5/fs").Resource;
 const log = require("@ui5/logger").getLogger("builder:processors:bundlers:moduleBundler");
 
 /**
- * A ModuleBundleDefinitionSection specifies the embedding mode ('provided', 'raw', 'preload', 'require'
+ * A ModuleBundleDefinitionSection specifies the embedding mode (either 'provided', 'raw', 'preload', 'require'
  * or 'bundleInfo') and lists the resources that should be in- or excluded from the section.
  * <p>
  * <b>Module bundle section modes</b><br>

--- a/lib/processors/bundlers/moduleBundler.js
+++ b/lib/processors/bundlers/moduleBundler.js
@@ -23,8 +23,8 @@ const log = require("@ui5/logger").getLogger("builder:processors:bundlers:module
  *		<code>preload</code>: A 'preload' section packages resources that should be stored in the preload cache in the
  *		client. They can embed any textual resource type (JavaScript, XML, JSON and .properties files) that the
  *		bundling supports. UI5 modules are wrapped into a 'sap.ui.predefine' call. Other JavaScript modules will be
- *		embedded into a 'jQuery.sap.registerPreload' call, unless the asynchronous ui5loader is used. With the
- *		ui5loader 'sap.ui.require.preload' is used for other modules.
+ *		embedded into a 'jQuery.sap.registerPreload' call, or in a "sap.ui.require.preload" call when
+ *      the ui5loader is available.
  *	</li>
  *	<li>
  *		<code>require</code>: A 'require' section is transformed into a sequence of jQuery.sap.require calls. The
@@ -36,7 +36,8 @@ const log = require("@ui5/logger").getLogger("builder:processors:bundlers:module
  *		<code>bundleInfo</code>: A 'bundleInfo' section describes the content of another named bundle. This information
  *		is transformed into a ui5loader-"bundlesUI5" configuration.
  *		At runtime, if a module is known to be contained in a bundle, the loader will require that bundle before
- *		the module itself is required. This requires UI5 version 1.74.0 or higher.
+ *		the module itself.
+ *		This requires the ui5loader to be available at build time and UI5 version 1.74.0 or higher at runtime.
  *	</li>
  * </ul>
  * </p>

--- a/lib/processors/bundlers/moduleBundler.js
+++ b/lib/processors/bundlers/moduleBundler.js
@@ -36,7 +36,7 @@ const log = require("@ui5/logger").getLogger("builder:processors:bundlers:module
  *		<code>bundleInfo</code>: A 'bundleInfo' section describes the content of another named bundle. This information
  *		is transformed into a ui5loader-"bundlesUI5" configuration.
  *		At runtime, if a module is known to be contained in a bundle, the loader will require that bundle before
- *		the module itself is required.
+ *		the module itself is required. This requires UI5 version 1.74.0 or higher.
  *	</li>
  * </ul>
  * </p>


### PR DESCRIPTION
When a bundle is created, sections can be added that will be written as
sap.ui.loader.config({bundlesUI5:{...}}) information. Each section of
type 'bundleInfo' represents one single bundle. The section name is the
bundle name, the modules in the section are the modules of the bundle.

It is currently not yet possible to reuse existing bundle definitions to
define the content of such a section.
