### PR TITLE
[FIX] Bundling: Dynamic preload calls should not emit warnings

### DIFF
--- a/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -607,7 +607,7 @@ class JSModuleAnalyzer {
 					info.addSubModule(moduleName);
 				});
 			} else {
-				log.warn("Cannot evaluate registerPreloadedModules: '%s'", modules && modules.type);
+				log.verbose("Cannot evaluate registerPreloadedModules: '%s'", modules && modules.type);
 			}
 		}
 


### PR DESCRIPTION
The UI5 core library contains dynamic calls to sap.ui.require.preload.
Those calls should not result into a warning in the build log, as they
are correct and should just be skipped.

This has been introducted with #341.

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [x] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
