### PR TITLE
[FIX] ApplicationBuilder: Fix pattern to glob for .library files

### DIFF
--- a/lib/types/application/ApplicationBuilder.js
+++ b/lib/types/application/ApplicationBuilder.js
@@ -174,7 +174,7 @@ class ApplicationBuilder extends AbstractBuilder {
 				dependencies: resourceCollections.dependencies,
 				options: {
 					rootProject: project,
-					pattern: "/**/.library"
+					pattern: "/resources/**/.library"
 				}
 			});
 		});


### PR DESCRIPTION
To generate the VersionInfo, the used glob pattern should only match .library files within the resource folder. Otherwise it is possible to find additional .library files, e.g. from unit tests.
