### PR TITLE
[INTERNAL] lbt/Resource: Use graceful-fs instead of native fs

### DIFF
--- a/lib/lbt/resources/Resource.js
+++ b/lib/lbt/resources/Resource.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const {promisify} = require("util");
-const fs = require("fs");
+const fs = require("graceful-fs");
 const readFile = promisify(fs.readFile);
 
 class Resource {


### PR DESCRIPTION
Was used since initial commit. Probably overlooked.