### PR TITLE
[INTERNAL] LibraryFormatter namespace detection: Add exception for SAP theme libraries

### DIFF
--- a/lib/types/library/LibraryFormatter.js
+++ b/lib/types/library/LibraryFormatter.js
@@ -7,6 +7,7 @@ const glob = require("globby");
 const slash = require("slash");
 const AbstractUi5Formatter = require("../AbstractUi5Formatter");
 
+const SAP_THEMES_NS_WHITELIST = ["themelib_sap_fiori_3", "themelib_sap_bluecrystal", "themelib_sap_belize"];
 
 class LibraryFormatter extends AbstractUi5Formatter {
 	/**
@@ -31,7 +32,20 @@ class LibraryFormatter extends AbstractUi5Formatter {
 				"Either no setting was provided or the path not found.");
 		}
 
-		project.metadata.namespace = await this.getNamespace();
+		try {
+			project.metadata.namespace = await this.getNamespace();
+		} catch (err) {
+			if (SAP_THEMES_NS_WHITELIST.includes(this._project.metadata.name)) {
+				// Exceptional handling for SAP theme libraries which used to be of type "library"
+				//	(today they use "theme-library").
+				// To allow use of OpenUI5 theme libraries in versions lower than 1.75 we must ignore
+				//	namespace detection errors.
+				log.verbose(`Ignoring failed namespace detection for whitelisted SAP theme library ` +
+					`${this._project.metadata.name}: ${err.message}`);
+			} else {
+				throw err;
+			}
+		}
 
 		try {
 			project.metadata.copyright = await this.getCopyright();


### PR DESCRIPTION
Add exceptional handling for SAP theme libraries which used to be of
type "library" (today they use "theme-library").

To allow use of OpenUI5 theme libraries in versions lower than 1.75 we
must ignore namespace.