### PR TITLE
[INTERNAL] Adapt tests to new project._isRoot flag

### DIFF
--- a/test/lib/builder/builder.js
+++ b/test/lib/builder/builder.js
@@ -601,6 +601,7 @@ const libraryDTree = {
 		}
 	],
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "library",
 	"metadata": {
@@ -709,6 +710,7 @@ const applicationATree = {
 		}
 	],
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {
@@ -733,6 +735,7 @@ const applicationATreeBadType = {
 	"version": "1.0.0",
 	"path": applicationAPath,
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "non existent",
 	"metadata": {
@@ -756,6 +759,7 @@ const applicationGTree = {
 	"version": "1.0.0",
 	"path": applicationGPath,
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {
@@ -791,6 +795,7 @@ const applicationGTreeWithExcludes = {
 	"version": "1.0.0",
 	"path": applicationGPath,
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {
@@ -827,6 +832,7 @@ const applicationGTreeComponentPreloadPaths = {
 	"version": "1.0.0",
 	"path": applicationGPath,
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {
@@ -860,6 +866,7 @@ const applicationHTree = {
 	"version": "1.0.0",
 	"path": applicationHPath,
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {
@@ -921,6 +928,7 @@ const applicationITree = {
 	"version": "1.0.0",
 	"path": applicationIPath,
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {
@@ -949,6 +957,7 @@ const applicationJTree = {
 	"version": "1.0.0",
 	"path": applicationJPath,
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {
@@ -1003,6 +1012,7 @@ const libraryETree = {
 		}
 	],
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "library",
 	"metadata": {
@@ -1056,6 +1066,7 @@ const libraryHTree = {
 		}
 	],
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "library",
 	"metadata": {
@@ -1142,6 +1153,7 @@ const libraryITree = {
 		cloneProjectTree(libraryDTree)
 	],
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "library",
 	"metadata": {
@@ -1169,6 +1181,7 @@ const libraryJTree = {
 	"path": libraryJPath,
 	"dependencies": [],
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "library",
 	"metadata": {
@@ -1194,6 +1207,7 @@ const themeJTree = {
 	"path": themeJPath,
 	"dependencies": [],
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "library",
 	"metadata": {

--- a/test/lib/tasks/bundlers/generateManifestBundle.integration.js
+++ b/test/lib/tasks/bundlers/generateManifestBundle.integration.js
@@ -94,6 +94,7 @@ const applicationBTree = {
 	"path": applicationBPath,
 	"dependencies": [],
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {
@@ -143,6 +144,7 @@ const libraryKTree = {
 		}
 	],
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "library",
 	"metadata": {

--- a/test/lib/tasks/bundlers/generateStandaloneAppBundle.integration.js
+++ b/test/lib/tasks/bundlers/generateStandaloneAppBundle.integration.js
@@ -190,6 +190,7 @@ const applicationBTree = {
 	],
 	"builder": {},
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {

--- a/test/lib/tasks/generateCachebusterInfo.js
+++ b/test/lib/tasks/generateCachebusterInfo.js
@@ -97,6 +97,7 @@ const applicationGTree = {
 	"dependencies": [],
 	"builder": {},
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {
@@ -127,6 +128,7 @@ const applicationGTreeWithCachebusterHash = {
 		}
 	},
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {

--- a/test/lib/types/AbstractBuilder.js
+++ b/test/lib/types/AbstractBuilder.js
@@ -26,6 +26,7 @@ const applicationBTree = {
 	dependencies: [],
 	builder: {},
 	_level: 0,
+	_isRoot: true,
 	specVersion: "0.1",
 	type: "application",
 	metadata: {

--- a/test/lib/types/application/ApplicationFormatter.js
+++ b/test/lib/types/application/ApplicationFormatter.js
@@ -17,6 +17,7 @@ const applicationBTree = {
 	path: applicationBPath,
 	dependencies: [],
 	_level: 0,
+	_isRoot: true,
 	specVersion: "2.0",
 	type: "application",
 	metadata: {
@@ -281,6 +282,7 @@ const applicationHTree = {
 	path: applicationHPath,
 	dependencies: [],
 	_level: 0,
+	_isRoot: true,
 	specVersion: "2.0",
 	type: "application",
 	metadata: {

--- a/test/lib/types/library/LibraryFormatter.js
+++ b/test/lib/types/library/LibraryFormatter.js
@@ -17,6 +17,7 @@ const libraryETree = {
 	path: libraryEPath,
 	dependencies: [],
 	_level: 0,
+	_isRoot: true,
 	specVersion: "2.0",
 	type: "library",
 	metadata: {
@@ -215,6 +216,7 @@ test("format: formats correctly", async (t) => {
 		path: libraryEPath,
 		dependencies: [],
 		_level: 0,
+		_isRoot: true,
 		specVersion: "2.0",
 		type: "library",
 		metadata: {
@@ -251,6 +253,7 @@ test("format: formats legacy specVersion correctly", async (t) => {
 		path: libraryEPath,
 		dependencies: [],
 		_level: 0,
+		_isRoot: true,
 		specVersion: "0.1",
 		type: "library",
 		metadata: {

--- a/test/lib/types/themeLibrary/ThemeLibraryFormatter.js
+++ b/test/lib/types/themeLibrary/ThemeLibraryFormatter.js
@@ -15,6 +15,7 @@ const themeLibraryETree = {
 	path: themeLibraryEPath,
 	dependencies: [],
 	_level: 0,
+	_isRoot: true,
 	specVersion: "1.1",
 	type: "theme-library",
 	metadata: {
@@ -152,6 +153,7 @@ test("format: formats correctly", async (t) => {
 		path: themeLibraryEPath,
 		dependencies: [],
 		_level: 0,
+		_isRoot: true,
 		specVersion: "1.1",
 		type: "theme-library",
 		metadata: {


### PR DESCRIPTION
Flag was added with https://github.com/SAP/ui5-project/pull/287
Tests are not failing. This is just for consistency reasons and to
prevent future issues.