### PR TITLE
[INTERNAL] lib/processors/jsdoc/lib/ui5 plugin.js: quote only empty s…

### DIFF
--- a/lib/processors/jsdoc/lib/ui5/plugin.js
+++ b/lib/processors/jsdoc/lib/ui5/plugin.js
@@ -1250,10 +1250,10 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 	function generateParamTag(n, type, description, defaultValue){
 		var s = "@param {" + info.type + "} ";
 
-		if (defaultValue !== null) {
+		if (defaultValue !== null){
 			s += "[" +  varname(n, type, true) + "=";
-			if (type === "string"){
-				defaultValue = "\"" + defaultValue + "\"";
+			if (defaultValue === ""){
+				defaultValue = "\"\"";
 			}
 			s += defaultValue + "]";
 


### PR DESCRIPTION
This PR removes the double quotes in the default value of the `@param` tag when a default values is of type string (e.g. enums) but has a non empty value.