### PR TITLE
[FIX] SmartTemplateAnalyzer: Do not throw in case missing dependency is expected

### DIFF
--- a/lib/lbt/analyzer/SmartTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/SmartTemplateAnalyzer.js
@@ -119,7 +119,7 @@ class TemplateComponentAnalyzer {
 			}
 		} catch (err) {
 			if (this._pool.getIgnoreMissingModules() && err.message.startsWith("resource not found in pool")) {
-				log.verbose("Ignoring missing module as per ResourcePoool configuration: " + err.message);
+				log.verbose("Ignoring missing module as per ResourcePool configuration: " + err.message);
 			} else {
 				throw err;
 			}

--- a/lib/lbt/analyzer/SmartTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/SmartTemplateAnalyzer.js
@@ -105,16 +105,24 @@ class TemplateComponentAnalyzer {
 
 	async _analyzeTemplateComponent(moduleName, pageConfig, appInfo) {
 		// console.log("analyzing template component %s", moduleName);
-		const resource = await this._pool.findResource(moduleName);
-		const code = await resource.buffer();
-		const ast = esprima.parseScript(code.toString());
-		const defaultTemplateName = this._analyzeAST(moduleName, ast);
-		const templateName = (pageConfig.component && pageConfig.component.settings &&
-								pageConfig.component.settings.templateName) || defaultTemplateName;
-		if ( templateName ) {
-			const templateModuleName = ModuleName.fromUI5LegacyName( templateName, ".view.xml" );
-			log.verbose("template app: add dependency to template view %s", templateModuleName);
-			appInfo.addDependency(templateModuleName);
+		try {
+			const resource = await this._pool.findResource(moduleName);
+			const code = await resource.buffer();
+			const ast = esprima.parseScript(code.toString());
+			const defaultTemplateName = this._analyzeAST(moduleName, ast);
+			const templateName = (pageConfig.component && pageConfig.component.settings &&
+									pageConfig.component.settings.templateName) || defaultTemplateName;
+			if ( templateName ) {
+				const templateModuleName = ModuleName.fromUI5LegacyName( templateName, ".view.xml" );
+				log.verbose("template app: add dependency to template view %s", templateModuleName);
+				appInfo.addDependency(templateModuleName);
+			}
+		} catch (err) {
+			if (this._pool.getIgnoreMissingModules() && err.message.startsWith("resource not found in pool")) {
+				log.verbose("Ignoring missing module as per ResourcePoool configuration: " + err.message);
+			} else {
+				throw err;
+			}
 		}
 	}
 

--- a/lib/lbt/resources/ResourcePool.js
+++ b/lib/lbt/resources/ResourcePool.js
@@ -112,7 +112,8 @@ async function determineDependencyInfo(resource, rawInfo, pool) {
 }
 
 class ResourcePool {
-	constructor() {
+	constructor({ignoreMissingModules} = {}) {
+		this._ignoreMissingModules = !!ignoreMissingModules;
 		// this._roots = [];
 		this._resources = [];
 		this._resourcesByName = new Map();
@@ -209,6 +210,10 @@ class ResourcePool {
 
 	get resources() {
 		return this._resources.slice();
+	}
+
+	getIgnoreMissingModules() {
+		return this._ignoreMissingModules;
 	}
 }
 

--- a/lib/lbt/resources/ResourcePool.js
+++ b/lib/lbt/resources/ResourcePool.js
@@ -176,6 +176,8 @@ class ResourcePool {
 	async findResource(name) {
 		const resource = this._resourcesByName.get(name);
 		if ( resource == null ) {
+			// TODO: Remove throw and return null to align with ui5-fs
+			//	This would require changes in most consuming classes
 			throw new Error("resource not found in pool: '" + name + "'");
 		}
 		return resource;

--- a/lib/processors/bundlers/moduleBundler.js
+++ b/lib/processors/bundlers/moduleBundler.js
@@ -23,8 +23,8 @@ class LocatorResource extends Resource {
 }
 
 class LocatorResourcePool extends ResourcePool {
-	constructor() {
-		super();
+	constructor({ignoreMissingModules}) {
+		super({ignoreMissingModules});
 	}
 
 	prepare(resources) {
@@ -112,16 +112,28 @@ class LocatorResourcePool extends ResourcePool {
  * @param {boolean} [parameters.options.bundleOptions.addTryCatchRestartWrapper=false] Whether to wrap bootable module bundles with a try/catch to filter out "Restart" errors
  * @param {boolean} [parameters.options.bundleOptions.usePredefineCalls=false] If set to 'true', sap.ui.predefine is used for UI5 modules
  * @param {number} [parameters.options.bundleOptions.numberOfParts=1] The number of parts the module bundle should be splitted
+ * @param {number} [parameters.options.bundleOptions.ignoreMissingModules] TODO name
  * @returns {Promise<module:@ui5/fs.Resource[]>} Promise resolving with module bundle resources
  */
 module.exports = function({resources, options}) {
 //	console.log("preloadBundler bundleDefinition:");
 //	console.log(JSON.stringify(options.bundleDefinition, null, 4));
 
-	const pool = new LocatorResourcePool();
+	const bundleOptions = options.bundleOptions || {};
+
+	// Apply default bundleOptions
+	if (bundleOptions.optimize === undefined) {
+		bundleOptions.optimize = true;
+	}
+	if (bundleOptions.decorateBootstrapModule === undefined) {
+		bundleOptions.decorateBootstrapModule = true;
+	}
+
+	const pool = new LocatorResourcePool({
+		ignoreMissingModules: bundleOptions.ignoreMissingModules
+	});
 	const builder = new BundleBuilder(pool);
 
-	const bundleOptions = options.bundleOptions || {optimize: true};
 
 	return pool.prepare( resources ).
 		then( () => builder.createBundle(options.bundleDefinition, bundleOptions) ).

--- a/lib/processors/bundlers/moduleBundler.js
+++ b/lib/processors/bundlers/moduleBundler.js
@@ -108,7 +108,7 @@ class LocatorResourcePool extends ResourcePool {
  * @param {ModuleBundleDefinitionSection[]} parameters.options.bundleDefinition.sections List of module bundle definition sections.
  * @param {object} parameters.options.bundleOptions Module bundle options
  * @param {boolean} [parameters.options.bundleOptions.optimize=false] If set to 'true' the module bundle gets minified
- * @param {boolean} [parameters.options.bundleOptions.decorateBootstrapModule=true] If set to 'false', the module won't be decorated with an optimization marker
+ * @param {boolean} [parameters.options.bundleOptions.decorateBootstrapModule=false] If set to 'false', the module won't be decorated with an optimization marker
  * @param {boolean} [parameters.options.bundleOptions.addTryCatchRestartWrapper=false] Whether to wrap bootable module bundles with a try/catch to filter out "Restart" errors
  * @param {boolean} [parameters.options.bundleOptions.usePredefineCalls=false] If set to 'true', sap.ui.predefine is used for UI5 modules
  * @param {number} [parameters.options.bundleOptions.numberOfParts=1] The number of parts the module bundle should be splitted
@@ -119,15 +119,8 @@ module.exports = function({resources, options}) {
 //	console.log("preloadBundler bundleDefinition:");
 //	console.log(JSON.stringify(options.bundleDefinition, null, 4));
 
-	const bundleOptions = options.bundleOptions || {};
-
-	// Apply default bundleOptions
-	if (bundleOptions.optimize === undefined) {
-		bundleOptions.optimize = true;
-	}
-	if (bundleOptions.decorateBootstrapModule === undefined) {
-		bundleOptions.decorateBootstrapModule = true;
-	}
+	// TODO 3.0: Fix defaulting behavior, align with JSDoc
+	const bundleOptions = options.bundleOptions || {optimize: true};
 
 	const pool = new LocatorResourcePool({
 		ignoreMissingModules: bundleOptions.ignoreMissingModules

--- a/lib/processors/bundlers/moduleBundler.js
+++ b/lib/processors/bundlers/moduleBundler.js
@@ -112,7 +112,7 @@ class LocatorResourcePool extends ResourcePool {
  * @param {boolean} [parameters.options.bundleOptions.addTryCatchRestartWrapper=false] Whether to wrap bootable module bundles with a try/catch to filter out "Restart" errors
  * @param {boolean} [parameters.options.bundleOptions.usePredefineCalls=false] If set to 'true', sap.ui.predefine is used for UI5 modules
  * @param {number} [parameters.options.bundleOptions.numberOfParts=1] The number of parts the module bundle should be splitted
- * @param {number} [parameters.options.bundleOptions.ignoreMissingModules] TODO name
+ * @param {number} [parameters.options.bundleOptions.ignoreMissingModules] When searching for modules which are optional for further processing, do not throw in case they are missing
  * @returns {Promise<module:@ui5/fs.Resource[]>} Promise resolving with module bundle resources
  */
 module.exports = function({resources, options}) {

--- a/lib/tasks/bundlers/generateComponentPreload.js
+++ b/lib/tasks/bundlers/generateComponentPreload.js
@@ -80,6 +80,9 @@ module.exports = function({workspace, dependencies, options}) {
 									renderer: false
 								}
 							]
+						},
+						bundleOptions: {
+							ignoreMissingModules: true
 						}
 					}
 				});

--- a/lib/tasks/bundlers/generateComponentPreload.js
+++ b/lib/tasks/bundlers/generateComponentPreload.js
@@ -82,7 +82,8 @@ module.exports = function({workspace, dependencies, options}) {
 							]
 						},
 						bundleOptions: {
-							ignoreMissingModules: true
+							ignoreMissingModules: true,
+							optimize: true
 						}
 					}
 				});

--- a/test/lib/lbt/resources/ResourcePool.js
+++ b/test/lib/lbt/resources/ResourcePool.js
@@ -60,6 +60,17 @@ test("resources", async (t) => {
 	t.deepEqual(resourcePool.resources, [resourceA], "resource a in pool");
 });
 
+test("getIgnoreMissingModules", async (t) => {
+	let resourcePool = new ResourcePool({});
+	t.deepEqual(resourcePool.getIgnoreMissingModules(), false, "returned expected value");
+
+	resourcePool = new ResourcePool({
+		ignoreMissingModules: true
+	});
+	t.deepEqual(resourcePool.getIgnoreMissingModules(), true, "returned expected value");
+});
+
+
 class ResourcePoolWithRejectingModuleInfo extends ResourcePool {
 	async getModuleInfo(name) {
 		throw new Error("myerror");


### PR DESCRIPTION
In some cases it can be expected that SmartTemplateAnalyzer does not
have access to second-degree dependencies. In such cases, no error
should be thrown. Currently this causes misleading error logs, for
example in case of component preload generation for a Fiori Elements
project where no framework dependencies are available.

Resolves https://github.com/SAP/ui5-builder/issues/404