### PR TITLE
[DEPENDENCY] Pin estraverse to v5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
 		"escodegen": "^1.14.3",
 		"escope": "^3.6.0",
 		"esprima": "^4.0.1",
-		"estraverse": "^5.1.0",
+		"estraverse": "5.1.0",
 		"globby": "^11.0.1",
 		"graceful-fs": "^4.2.4",
 		"jsdoc": "^3.6.5",


### PR DESCRIPTION
Since the "self-protection" mechanism of our JSModuleAnalyzer (see https://github.com/SAP/ui5-builder/issues/309#issuecomment-521108883) is
highly dependent on the set of possible node types provided by
estraverse, we often saw problems in consuming projects after new
releases of estraverse. With estraverse@5.2.0 this is yet again the
case.

This change forces consumers to use a version of estraverse that is
supported by JSModuleAnalyzer (currently 5.1.0). Version updates will
only happen through pull requests created by dependabot.