### PR TITLE
[INTERNAL] bundleBuilder: log verbose for json parse failure

### DIFF
--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -411,8 +411,7 @@ class BundleBuilder {
 				try {
 					fileContent = JSON.stringify( JSON.parse( fileContent) );
 				} catch (e) {
-					log.verbose("Ignoring compression of JSON content. " +
-						"Failed to parse JSON file %s.", module);
+					log.verbose("Failed to parse JSON file %s. Ignoring error, skipping compression.", module);
 					log.verbose(e);
 				}
 			}

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -411,7 +411,8 @@ class BundleBuilder {
 				try {
 					fileContent = JSON.stringify( JSON.parse( fileContent) );
 				} catch (e) {
-					log.error(e);
+					log.verbose("error while parsing JSON file %s", module);
+					log.verbose(e);
 				}
 			}
 			outW.write(makeStringLiteral(fileContent));

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -411,7 +411,8 @@ class BundleBuilder {
 				try {
 					fileContent = JSON.stringify( JSON.parse( fileContent) );
 				} catch (e) {
-					log.verbose("error while parsing JSON file %s", module);
+					log.verbose("Ignoring compression of JSON content. " +
+						"Failed to parse JSON file %s.", module);
 					log.verbose(e);
 				}
 			}

--- a/test/lib/lbt/bundle/Builder.js
+++ b/test/lib/lbt/bundle/Builder.js
@@ -1,7 +1,50 @@
 const test = require("ava");
+const sinon = require("sinon");
+const mock = require("mock-require");
 
 const Builder = require("../../../../lib/lbt/bundle/Builder");
 const ResourcePool = require("../../../../lib/lbt/resources/ResourcePool");
+
+test.afterEach.always((t) => {
+	mock.stopAll();
+	sinon.restore();
+});
+
+test.serial("writePreloadModule: with invalid json content", async (t) => {
+	const writeStub = sinon.stub();
+	const logger = require("@ui5/logger");
+	const verboseLogStub = sinon.stub();
+	const myLoggerInstance = {
+		verbose: verboseLogStub
+	};
+	sinon.stub(logger, "getLogger").returns(myLoggerInstance);
+	const BuilderWithStub = mock.reRequire("../../../../lib/lbt/bundle/Builder");
+	const invalidJsonContent = `{
+	"a": 47,
+	"b": {{include: asd}}
+	}`;
+
+	const builder = new BuilderWithStub({});
+	builder.optimize = true;
+	builder.outW = {
+		write: writeStub
+	};
+	const invalidJsonResource = {
+		buffer: async () => {
+			return invalidJsonContent;
+		}
+	};
+	const result = await builder.writePreloadModule("invalid.json", undefined, invalidJsonResource);
+
+
+	t.is(verboseLogStub.callCount, 2, "called 2 times");
+	t.is(verboseLogStub.firstCall.args[0], "error while parsing JSON file %s", "first verbose log argument 0 is correct");
+	t.is(verboseLogStub.firstCall.args[1], "invalid.json", "first verbose log argument 1 is correct");
+	t.deepEqual(verboseLogStub.secondCall.args[0], new SyntaxError("Unexpected token { in JSON at position 19"), "second verbose log");
+
+	t.true(result, "result is true");
+	t.is(writeStub.callCount, 1, "Writer is called once");
+});
 
 
 test("integration: createBundle EVOBundleFormat (ui5loader.js)", async (t) => {

--- a/test/lib/lbt/bundle/Builder.js
+++ b/test/lib/lbt/bundle/Builder.js
@@ -38,7 +38,7 @@ test.serial("writePreloadModule: with invalid json content", async (t) => {
 
 
 	t.is(verboseLogStub.callCount, 2, "called 2 times");
-	t.is(verboseLogStub.firstCall.args[0], "error while parsing JSON file %s", "first verbose log argument 0 is correct");
+	t.is(verboseLogStub.firstCall.args[0], "Ignoring compression of JSON content. Failed to parse JSON file %s.", "first verbose log argument 0 is correct");
 	t.is(verboseLogStub.firstCall.args[1], "invalid.json", "first verbose log argument 1 is correct");
 	t.deepEqual(verboseLogStub.secondCall.args[0], new SyntaxError("Unexpected token { in JSON at position 19"), "second verbose log");
 

--- a/test/lib/lbt/bundle/Builder.js
+++ b/test/lib/lbt/bundle/Builder.js
@@ -38,7 +38,7 @@ test.serial("writePreloadModule: with invalid json content", async (t) => {
 
 
 	t.is(verboseLogStub.callCount, 2, "called 2 times");
-	t.is(verboseLogStub.firstCall.args[0], "Ignoring compression of JSON content. Failed to parse JSON file %s.", "first verbose log argument 0 is correct");
+	t.is(verboseLogStub.firstCall.args[0], "Failed to parse JSON file %s. Ignoring error, skipping compression.", "first verbose log argument 0 is correct");
 	t.is(verboseLogStub.firstCall.args[1], "invalid.json", "first verbose log argument 1 is correct");
 	t.deepEqual(verboseLogStub.secondCall.args[0], new SyntaxError("Unexpected token { in JSON at position 19"), "second verbose log");
 


### PR DESCRIPTION
When JSON content is parsed for minification, errors are logged using verbose level.
TheJSON content is not relevant, only for minification.
