### PR TITLE
[INTERNAL] XMLTemplateAnalyzer: check expressions in coreRequire

### DIFF
--- a/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -150,6 +150,7 @@ class XMLTemplateAnalyzer {
 
 		this.info = info;
 		this.conditional = false;
+		this.templateTag = false;
 		this.promises = [];
 		this.busy = true;
 
@@ -214,11 +215,13 @@ class XMLTemplateAnalyzer {
 		const localName = node.$ns.local;
 
 		const oldConditional = this.conditional;
+		const oldTemplateTag = this.templateTag;
 
 		if ( namespace === TEMPLATING_NAMESPACE ) {
 			if ( TEMPLATING_CONDITONAL_TAGS.test(localName) ) {
 				this.conditional = true;
 			}
+			this.templateTag = true;
 		} else if ( namespace === XHTML_NAMESPACE || namespace === SVG_NAMESPACE ) {
 
 			// ignore XHTML and SVG nodes
@@ -298,36 +301,17 @@ class XMLTemplateAnalyzer {
 
 		this._analyzeChildren(node);
 
-		// restore conditional state of the outer block
+		// restore conditional and templateTag state of the outer block
 		this.conditional = oldConditional;
+		this.templateTag = oldTemplateTag;
 	}
 
 	_analyzeChildren(node) {
 		if ( Array.isArray(node.$$) ) {
 			node.$$.forEach( (child) => {
-				// add parentNode reference to child to be able to walk up the parent chain
-				child.$parentNode = node;
 				return this._analyzeNode( child);
 			});
 		}
-	}
-
-	/**
-	 * Walks up the parent chain until fnMatch returns either <code>true</code> or there is no more parent
-	 *
-	 * @param {object} node xml node
-	 * @param {Function} fnMatch matcher function, gets node as argument and returns whether or not the current node matches
-	 * @returns {boolean} <code>true</code> if fnMatch finds a match, <code>false</code> otherwise
-	 * @private
-	 */
-	_findInParentChain(node, fnMatch) {
-		if (fnMatch(node)) {
-			return true;
-		}
-		if (node.$parentNode) {
-			return this._findInParentChain(node.$parentNode, fnMatch);
-		}
-		return false;
 	}
 
 	_analyzeCoreRequire(node) {
@@ -336,11 +320,7 @@ class XMLTemplateAnalyzer {
 		if ( coreRequire ) {
 			// expression evaluation
 			if (coreRequire.startsWith("{=")) {
-				// check if parent chain contains a "template" node
-				const fnMatch = (node) => {
-					return node.$ns.uri === TEMPLATING_NAMESPACE;
-				};
-				if (this._findInParentChain(node, fnMatch)) {
+				if (this.templateTag) {
 					log.verbose("Ignoring core:require: Attribute contains an expression but is within a 'template' Node ", node.$ns.local);
 					log.verbose(coreRequire);
 					return;

--- a/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -323,7 +323,7 @@ class XMLTemplateAnalyzer {
 			// represent an expression binding which needs to be evaluated before analysis
 			// e.g. "{= '{Handler: \'' + ${myActions > handlerModule} + '\'}'}"
 			if ((coreRequire.startsWith("{=") || coreRequire.startsWith("{:=")) && this.templateTag) {
-				log.verbose("Ignoring core:require: Attribute contains an expression but is within a 'template' Node ", node.$ns.local);
+				log.verbose(`Ignoring core:require: Attribute of Node ${node.$ns.local} contains an expression binding and is within a 'template' Node`);
 				log.verbose(coreRequire);
 				return;
 			}

--- a/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -318,20 +318,16 @@ class XMLTemplateAnalyzer {
 		const coreRequire = getAttributeNS(node, XMLVIEW_CORE_REQUIRE_ATTRIBUTE_NS);
 		let requireContext;
 		if ( coreRequire ) {
-			// expression evaluation
-			if (coreRequire.startsWith("{=")) {
-				if (this.templateTag) {
-					log.verbose("Ignoring core:require: Attribute contains an expression but is within a 'template' Node ", node.$ns.local);
-					log.verbose(coreRequire);
-					return;
-				}
-			}
-
 			try {
 				requireContext = JSTokenizer.parseJS(coreRequire);
 			} catch (e) {
-				log.error("Ignoring core:require: Attribute can't be parsed on Node ", node.$ns.local);
-				log.error(coreRequire);
+				if (this.templateTag) {
+					log.verbose("Ignoring core:require: Attribute contains an expression but is within a 'template' Node ", node.$ns.local);
+					log.verbose(coreRequire);
+				} else {
+					log.error("Ignoring core:require: Attribute can't be parsed on Node ", node.$ns.local);
+					log.error(coreRequire);
+				}
 			}
 			if ( requireContext ) {
 				Object.keys(requireContext).forEach((key) => {

--- a/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -318,16 +318,21 @@ class XMLTemplateAnalyzer {
 		const coreRequire = getAttributeNS(node, XMLVIEW_CORE_REQUIRE_ATTRIBUTE_NS);
 		let requireContext;
 		if ( coreRequire ) {
+			// expression binding syntax within coreRequire and a template parent node
+			// These expressions cannot be parsed using parseJS and if within a template tag
+			// represent an expression binding which needs to be evaluated before analysis
+			// e.g. "{= '{Handler: \'' + ${myActions > handlerModule} + '\'}'}"
+			if ((coreRequire.startsWith("{=") || coreRequire.startsWith("{:=")) && this.templateTag) {
+				log.verbose("Ignoring core:require: Attribute contains an expression but is within a 'template' Node ", node.$ns.local);
+				log.verbose(coreRequire);
+				return;
+			}
+
 			try {
 				requireContext = JSTokenizer.parseJS(coreRequire);
 			} catch (e) {
-				if (this.templateTag) {
-					log.verbose("Ignoring core:require: Attribute contains an expression but is within a 'template' Node ", node.$ns.local);
-					log.verbose(coreRequire);
-				} else {
-					log.error("Ignoring core:require: Attribute can't be parsed on Node ", node.$ns.local);
-					log.error(coreRequire);
-				}
+				log.error("Ignoring core:require: Attribute can't be parsed on Node ", node.$ns.local);
+				log.error(coreRequire);
 			}
 			if ( requireContext ) {
 				Object.keys(requireContext).forEach((key) => {

--- a/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -304,14 +304,49 @@ class XMLTemplateAnalyzer {
 
 	_analyzeChildren(node) {
 		if ( Array.isArray(node.$$) ) {
-			node.$$.forEach( (child) => this._analyzeNode( child ) );
+			node.$$.forEach( (child) => {
+				// add parentNode reference to child to be able to walk up the parent chain
+				child.$parentNode = node;
+				return this._analyzeNode( child);
+			});
 		}
+	}
+
+	/**
+	 * Walks up the parent chain until fnMatch returns either <code>true</code> or there is no more parent
+	 *
+	 * @param {object} node xml node
+	 * @param {Function} fnMatch matcher function, gets node as argument and returns whether or not the current node matches
+	 * @returns {boolean} <code>true</code> if fnMatch finds a match, <code>false</code> otherwise
+	 * @private
+	 */
+	_findInParentChain(node, fnMatch) {
+		if (fnMatch(node)) {
+			return true;
+		}
+		if (node.$parentNode) {
+			return this._findInParentChain(node.$parentNode, fnMatch);
+		}
+		return false;
 	}
 
 	_analyzeCoreRequire(node) {
 		const coreRequire = getAttributeNS(node, XMLVIEW_CORE_REQUIRE_ATTRIBUTE_NS);
 		let requireContext;
 		if ( coreRequire ) {
+			// expression evaluation
+			if (coreRequire.startsWith("{=")) {
+				// check if parent chain contains a "template" node
+				const fnMatch = (node) => {
+					return node.$ns.uri === TEMPLATING_NAMESPACE;
+				};
+				if (this._findInParentChain(node, fnMatch)) {
+					log.verbose("Ignoring core:require: Attribute contains an expression but is within a 'template' Node ", node.$ns.local);
+					log.verbose(coreRequire);
+					return;
+				}
+			}
+
 			try {
 				requireContext = JSTokenizer.parseJS(coreRequire);
 			} catch (e) {

--- a/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -3,6 +3,14 @@ const XMLTemplateAnalyzer = require("../../../../lib/lbt/analyzer/XMLTemplateAna
 const ModuleInfo = require("../../../../lib/lbt/resources/ModuleInfo");
 const sinon = require("sinon");
 
+const mock = require("mock-require");
+
+test.afterEach.always((t) => {
+	mock.stopAll();
+	sinon.restore();
+});
+
+
 const fakeMockPool = {
 	findResource: () => Promise.resolve()
 };
@@ -51,6 +59,54 @@ test("integration: Analysis of an xml view with data binding in properties", asy
 		], "Dependencies should come from the XML template");
 	t.true(moduleInfo.isImplicitDependency("sap/ui/core/mvc/XMLView.js"),
 		"Implicit dependency should be added since an XMLView is analyzed");
+});
+
+test.serial("integration: Analysis of an xml view with core:require from databinding", async (t) => {
+	const logger = require("@ui5/logger");
+	const verboseLogStub = sinon.stub();
+	const myLoggerInstance = {
+		verbose: verboseLogStub
+	};
+	sinon.stub(logger, "getLogger").returns(myLoggerInstance);
+	const XMLTemplateAnalyzerWithStubbedLogger = mock.reRequire("../../../../lib/lbt/analyzer/XMLTemplateAnalyzer");
+
+	const xml = `<mvc:View
+	xmlns="sap.m"
+	xmlns:mvc="sap.ui.core.mvc"
+	xmlns:core="sap.ui.core"
+	xmlns:template="http://schemas.sap.com/sapui5/extension/sap.ui.core.template/1"
+	controllerName="my.lib.theController"
+	>
+		<template:with path="entitySet>$Type" var="entityType">
+			<template:if test="{myCtx>myActions}">
+				<template:repeat list="{myCtx>myActions}" var="myAction">
+					<Button
+						core:require="{= '{Handler: \\'' + \${myActions > handlerModule} + '\\'}'}"
+						id="myID"
+						text="{myAction>text}"
+						press="myMethod"
+					/>
+				</template:repeat>
+			</template:if>
+		</template:with>
+	</mvc:View>`;
+
+	const moduleInfo = new ModuleInfo();
+
+	const analyzer = new XMLTemplateAnalyzerWithStubbedLogger(fakeMockPool);
+	await analyzer.analyzeView(xml, moduleInfo);
+	t.deepEqual(moduleInfo.dependencies,
+		[
+			"sap/ui/core/mvc/XMLView.js",
+			"my/lib/theController.controller.js",
+			"sap/m/Button.js"
+		], "Dependencies should come from the XML template");
+	t.true(moduleInfo.isImplicitDependency("sap/ui/core/mvc/XMLView.js"),
+		"Implicit dependency should be added since an XMLView is analyzed");
+
+	t.is(verboseLogStub.callCount, 2, "should be called 2 times");
+	t.is(verboseLogStub.getCall(0).args[0], "Ignoring core:require: Attribute contains an expression but is within a 'template' Node ", "first argument");
+	t.is(verboseLogStub.getCall(0).args[1], "Button", "first argument");
 });
 
 test("integration: Analysis of an xml view with core:require", async (t) => {

--- a/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -154,8 +154,7 @@ test.serial("integration: Analysis of an xml view with core:require from databin
 		"Implicit dependency should be added since an XMLView is analyzed");
 
 	t.is(verboseLogStub.callCount, 2, "should be called 2 times");
-	t.is(verboseLogStub.getCall(0).args[0], "Ignoring core:require: Attribute contains an expression but is within a 'template' Node ", "first argument");
-	t.is(verboseLogStub.getCall(0).args[1], "Button", "second argument");
+	t.is(verboseLogStub.getCall(0).args[0], "Ignoring core:require: Attribute of Node Button contains an expression binding and is within a 'template' Node", "first argument");
 });
 
 test.serial("integration: Analysis of an xml view with core:require from expression binding in template", async (t) => {
@@ -196,8 +195,7 @@ test.serial("integration: Analysis of an xml view with core:require from express
 		"Implicit dependency should be added since an XMLView is analyzed");
 
 	t.is(verboseLogStub.callCount, 2, "should be called 2 times");
-	t.is(verboseLogStub.getCall(0).args[0], "Ignoring core:require: Attribute contains an expression but is within a 'template' Node ", "first argument");
-	t.is(verboseLogStub.getCall(0).args[1], "Button", "second argument");
+	t.is(verboseLogStub.getCall(0).args[0], "Ignoring core:require: Attribute of Node Button contains an expression binding and is within a 'template' Node", "first argument");
 });
 
 test("integration: Analysis of an xml view with core:require", async (t) => {

--- a/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -63,6 +63,57 @@ test("integration: Analysis of an xml view with data binding in properties", asy
 
 test.serial("integration: Analysis of an xml view with core:require from databinding", async (t) => {
 	const logger = require("@ui5/logger");
+	const errorLogStub = sinon.stub();
+	const myLoggerInstance = {
+		error: errorLogStub
+	};
+	sinon.stub(logger, "getLogger").returns(myLoggerInstance);
+	const XMLTemplateAnalyzerWithStubbedLogger = mock.reRequire("../../../../lib/lbt/analyzer/XMLTemplateAnalyzer");
+
+	const xml = `<mvc:View
+	xmlns="sap.m"
+	xmlns:mvc="sap.ui.core.mvc"
+	xmlns:core="sap.ui.core"
+	xmlns:template="http://schemas.sap.com/sapui5/extension/sap.ui.core.template/1"
+	controllerName="my.lib.theController"
+	>
+		<HBox>
+			<template:with path="entitySet>$Type" var="entityType">
+				<template:if test="{myCtx>myActions}">
+				</template:if>
+			</template:with>
+		</HBox>
+		<HBox>
+			<Button
+					core:require="{= '{Handler: \\'' + \${myActions > handlerModule} + '\\'}'}"
+					id="myID"
+					text="{myAction>text}"
+					press="myMethod"
+				/>
+		</HBox>
+	</mvc:View>`;
+
+	const moduleInfo = new ModuleInfo();
+
+	const analyzer = new XMLTemplateAnalyzerWithStubbedLogger(fakeMockPool);
+	await analyzer.analyzeView(xml, moduleInfo);
+	t.deepEqual(moduleInfo.dependencies,
+		[
+			"sap/ui/core/mvc/XMLView.js",
+			"my/lib/theController.controller.js",
+			"sap/m/HBox.js",
+			"sap/m/Button.js"
+		], "Dependencies should come from the XML template");
+	t.true(moduleInfo.isImplicitDependency("sap/ui/core/mvc/XMLView.js"),
+		"Implicit dependency should be added since an XMLView is analyzed");
+
+	t.is(errorLogStub.callCount, 2, "should be called 2 times");
+	t.is(errorLogStub.getCall(0).args[0], "Ignoring core:require: Attribute can't be parsed on Node ", "first argument");
+	t.is(errorLogStub.getCall(0).args[1], "Button", "second argument");
+});
+
+test.serial("integration: Analysis of an xml view with core:require from databinding in template", async (t) => {
+	const logger = require("@ui5/logger");
 	const verboseLogStub = sinon.stub();
 	const myLoggerInstance = {
 		verbose: verboseLogStub
@@ -106,7 +157,7 @@ test.serial("integration: Analysis of an xml view with core:require from databin
 
 	t.is(verboseLogStub.callCount, 2, "should be called 2 times");
 	t.is(verboseLogStub.getCall(0).args[0], "Ignoring core:require: Attribute contains an expression but is within a 'template' Node ", "first argument");
-	t.is(verboseLogStub.getCall(0).args[1], "Button", "first argument");
+	t.is(verboseLogStub.getCall(0).args[1], "Button", "second argument");
 });
 
 test("integration: Analysis of an xml view with core:require", async (t) => {
@@ -164,7 +215,7 @@ test("integration: Analysis of an xml view with core:require (invalid module nam
 		"Implicit dependency should be added since an XMLView is analyzed");
 });
 
-test("integration: Analysis of an xml view with core:require (parsing error)", async (t) => {
+test("integration: Analysis of an xml view with core:require (missing comma, parsing error)", async (t) => {
 	const xml = `<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core" xmlns="sap.m"
 		controllerName="myController"
 		core:require="{


### PR DESCRIPTION
If a `core:require` statement in a node contains an expression
e.g. `core:require="{= '{Handler: \'' + ${myActions > handlerModule} + '\'}'}"`
it is checked if the node resides within a `template` node.
If so the error will be logged with `verbose`.