### PR TITLE
[INTERNAL] LocatorResourcePool: pass through constructor arguments

### DIFF
--- a/lib/lbt/resources/LocatorResourcePool.js
+++ b/lib/lbt/resources/LocatorResourcePool.js
@@ -1,12 +1,7 @@
 const ResourcePool = require("./ResourcePool");
 const LocatorResource = require("./LocatorResource");
 
-
 class LocatorResourcePool extends ResourcePool {
-	constructor(parameters) {
-		super(parameters);
-	}
-
 	prepare(resources) {
 		resources = resources.filter( (res) => !res.getStatInfo().isDirectory() );
 		return Promise.all(

--- a/lib/lbt/resources/LocatorResourcePool.js
+++ b/lib/lbt/resources/LocatorResourcePool.js
@@ -3,8 +3,8 @@ const LocatorResource = require("./LocatorResource");
 
 
 class LocatorResourcePool extends ResourcePool {
-	constructor() {
-		super();
+	constructor(parameters) {
+		super(parameters);
 	}
 
 	prepare(resources) {

--- a/test/lib/lbt/resources/LocatorResourcePool.js
+++ b/test/lib/lbt/resources/LocatorResourcePool.js
@@ -1,0 +1,8 @@
+const test = require("ava");
+const LocatorResourcePool = require("../../../../lib/lbt/resources/LocatorResourcePool");
+
+test("getIgnoreMissingModules", async (t) => {
+	const resourcePool = new LocatorResourcePool({ignoreMissingModules: true});
+	t.true(resourcePool.getIgnoreMissingModules(), "ignoreMissingModules is true");
+});
+


### PR DESCRIPTION
`ignoreMissingModules` parameter is passed along now when creating
a `new LocatorResourcePool`

works in combination with #479 and #481