### PR TITLE
[FEATURE] ApplicationFormatter: Implement manifest.appdescr_variant fallback

### DIFF
--- a/lib/types/application/ApplicationFormatter.js
+++ b/lib/types/application/ApplicationFormatter.js
@@ -53,6 +53,8 @@ class ApplicationFormatter extends AbstractUi5Formatter {
 		// check for a proper sap.app/id in manifest.json to determine namespace
 		if (manifest["sap.app"] && manifest["sap.app"].id) {
 			appId = manifest["sap.app"].id;
+		} else if (manifest.id) {
+			appId = manifest.id;
 		} else {
 			throw new Error(
 				`No sap.app/id configuration found in manifest.json of project ${this._project.metadata.name}`);
@@ -72,7 +74,7 @@ class ApplicationFormatter extends AbstractUi5Formatter {
 	}
 
 	/**
-	 * Reads the projects manifest.json
+	 * Reads the projects manifest.json, with a fallback to manifest.appdescr_variant if present
 	 *
 	 * @returns {Promise<object>} resolves with an object containing the <code>content</code> (as JSON) and
 	 * 							<code>fsPath</code> (as string) of the manifest.json file
@@ -81,8 +83,24 @@ class ApplicationFormatter extends AbstractUi5Formatter {
 		if (this._pManifest) {
 			return this._pManifest;
 		}
-		const fsPath = path.join(this.getSourceBasePath(), "manifest.json");
+		let fsPath = path.join(this.getSourceBasePath(), "manifest.json");
 		return this._pManifest = readFile(fsPath)
+			.catch(async (err) => {
+				if (err.code === "ENOENT") {
+					// No manifest.json present
+					// => Try fallback to manifest.appdescr_variant
+					fsPath = path.join(this.getSourceBasePath(), "manifest.appdescr_variant");
+					try {
+						return await readFile(fsPath);
+					} catch (fallbackErr) {
+						if (err.code === "ENOENT") {
+							throw err;
+						}
+						throw fallbackErr;
+					}
+				}
+				throw err;
+			})
 			.then((content) => {
 				return {
 					content: JSON.parse(content),
@@ -91,7 +109,8 @@ class ApplicationFormatter extends AbstractUi5Formatter {
 			})
 			.catch((err) => {
 				throw new Error(
-					`Failed to read manifest.json for project ${this._project.metadata.name}: ${err.message}`);
+					`Failed to read manifest.json or manifest.appdescr_variant for project ` +
+					`${this._project.metadata.name}: ${err.message}`);
 			});
 	}
 

--- a/lib/types/application/ApplicationFormatter.js
+++ b/lib/types/application/ApplicationFormatter.js
@@ -8,6 +8,16 @@ const AbstractUi5Formatter = require("../AbstractUi5Formatter");
 
 class ApplicationFormatter extends AbstractUi5Formatter {
 	/**
+	 * Constructor
+	 *
+	 * @param {object} parameters
+	 * @param {object} parameters.project Project
+	 */
+	constructor(parameters) {
+		super(parameters);
+		this._pManifests = {};
+	}
+	/**
 	 * Formats and validates the project
 	 *
 	 * @returns {Promise}
@@ -41,20 +51,49 @@ class ApplicationFormatter extends AbstractUi5Formatter {
 	}
 
 	/**
+	 * Determine application namespace either based on a project`s
+	 * manifest.json or manifest.appdescr_variant (fallback if present)
+	 *
+	 * @returns {string} Namespace of the project
+	 * @throws {Error} if namespace can not be determined
+	 */
+	async getNamespace() {
+		try {
+			return await this.getNamespaceFromManifestJson();
+		} catch (manifestJsonError) {
+			if (manifestJsonError.code !== "ENOENT") {
+				throw manifestJsonError;
+			}
+			// No manifest.json present
+			// => attempt fallback to manifest.appdescr_variant
+			try {
+				return await this.getNamespaceFromManifestAppDescVariant();
+			} catch (appDescVarError) {
+				if (appDescVarError.code === "ENOENT") {
+					// Fallback not possible: No manifest.appdescr_variant present
+					// => Throw error indicating missing manifest.json (do not mention manifest.appdescr_variant)
+					throw new Error(
+						`Could not find required manifest.json for project ` +
+						`${this._project.metadata.name}: ${manifestJsonError.message}`);
+				}
+				throw appDescVarError;
+			}
+		}
+	}
+
+	/**
 	 * Determine application namespace by checking manifest.json.
 	 * Any maven placeholders are resolved from the projects pom.xml
 	 *
 	 * @returns {string} Namespace of the project
 	 * @throws {Error} if namespace can not be determined
 	 */
-	async getNamespace() {
-		const {content: manifest} = await this.getManifest();
+	async getNamespaceFromManifestJson() {
+		const {content: manifest} = await this.getJson("manifest.json");
 		let appId;
 		// check for a proper sap.app/id in manifest.json to determine namespace
 		if (manifest["sap.app"] && manifest["sap.app"].id) {
 			appId = manifest["sap.app"].id;
-		} else if (manifest.id) {
-			appId = manifest.id;
 		} else {
 			throw new Error(
 				`No sap.app/id configuration found in manifest.json of project ${this._project.metadata.name}`);
@@ -69,38 +108,48 @@ class ApplicationFormatter extends AbstractUi5Formatter {
 			}
 		}
 		const namespace = appId.replace(/\./g, "/");
-		log.verbose(`Namespace of project ${this._project.metadata.name} is ${namespace}`);
+		log.verbose(
+			`Namespace of project ${this._project.metadata.name} is ${namespace} (from manifest.appdescr_variant)`);
 		return namespace;
 	}
 
 	/**
-	 * Reads the projects manifest.json, with a fallback to manifest.appdescr_variant if present
+	 * Determine application namespace by checking manifest.json.
+	 * Any maven placeholders are resolved from the projects pom.xml
 	 *
-	 * @returns {Promise<object>} resolves with an object containing the <code>content</code> (as JSON) and
-	 * 							<code>fsPath</code> (as string) of the manifest.json file
+	 * @returns {string} Namespace of the project
+	 * @throws {Error} if namespace can not be determined
 	 */
-	async getManifest() {
-		if (this._pManifest) {
-			return this._pManifest;
+	async getNamespaceFromManifestAppDescVariant() {
+		const {content: manifest} = await this.getJson("manifest.appdescr_variant");
+		let appId;
+		// check for a proper sap.app/id in manifest.json to determine namespace
+		if (manifest && manifest.id) {
+			appId = manifest.id;
+		} else {
+			throw new Error(
+				`No "id" property found in manifest.appdescr_variant of project ${this._project.metadata.name}`);
 		}
-		let fsPath = path.join(this.getSourceBasePath(), "manifest.json");
-		return this._pManifest = readFile(fsPath)
-			.catch(async (err) => {
-				if (err.code === "ENOENT") {
-					// No manifest.json present
-					// => Try fallback to manifest.appdescr_variant
-					fsPath = path.join(this.getSourceBasePath(), "manifest.appdescr_variant");
-					try {
-						return await readFile(fsPath);
-					} catch (fallbackErr) {
-						if (err.code === "ENOENT") {
-							throw err;
-						}
-						throw fallbackErr;
-					}
-				}
-				throw err;
-			})
+
+		const namespace = appId.replace(/\./g, "/");
+		log.verbose(
+			`Namespace of project ${this._project.metadata.name} is ${namespace} (from manifest.appdescr_variant)`);
+		return namespace;
+	}
+
+	/**
+	 * Reads and parses a JSON file with the provided name from the projects source directory
+	 *
+	 * @param {string} fileName Name of the JSON file to read. Typically "manifest.json" or "manifest.appdescr_variant"
+	 * @returns {Promise<object>} resolves with an object containing the <code>content</code> (as JSON) and
+	 * 							<code>fsPath</code> (as string) of the requested file
+	 */
+	async getJson(fileName) {
+		if (this._pManifests[fileName]) {
+			return this._pManifests[fileName];
+		}
+		const fsPath = path.join(this.getSourceBasePath(), fileName);
+		return this._pManifests[fileName] = readFile(fsPath)
 			.then((content) => {
 				return {
 					content: JSON.parse(content),
@@ -108,8 +157,11 @@ class ApplicationFormatter extends AbstractUi5Formatter {
 				};
 			})
 			.catch((err) => {
+				if (err.code === "ENOENT") {
+					throw err;
+				}
 				throw new Error(
-					`Failed to read manifest.json or manifest.appdescr_variant for project ` +
+					`Failed to read ${fileName} for project ` +
 					`${this._project.metadata.name}: ${err.message}`);
 			});
 	}

--- a/lib/types/application/ApplicationFormatter.js
+++ b/lib/types/application/ApplicationFormatter.js
@@ -65,13 +65,15 @@ class ApplicationFormatter extends AbstractUi5Formatter {
 				throw manifestJsonError;
 			}
 			// No manifest.json present
-			// => attempt fallback to manifest.appdescr_variant
+			// => attempt fallback to manifest.appdescr_variant (typical for App Variants)
 			try {
 				return await this.getNamespaceFromManifestAppDescVariant();
 			} catch (appDescVarError) {
 				if (appDescVarError.code === "ENOENT") {
 					// Fallback not possible: No manifest.appdescr_variant present
-					// => Throw error indicating missing manifest.json (do not mention manifest.appdescr_variant)
+					// => Throw error indicating missing manifest.json
+					// 	(do not mention manifest.appdescr_variant since it is only
+					// 	relevant for the rather "uncommon" App Variants)
 					throw new Error(
 						`Could not find required manifest.json for project ` +
 						`${this._project.metadata.name}: ${manifestJsonError.message}`);
@@ -114,8 +116,7 @@ class ApplicationFormatter extends AbstractUi5Formatter {
 	}
 
 	/**
-	 * Determine application namespace by checking manifest.json.
-	 * Any maven placeholders are resolved from the projects pom.xml
+	 * Determine application namespace by checking manifest.appdescr_variant.
 	 *
 	 * @returns {string} Namespace of the project
 	 * @throws {Error} if namespace can not be determined
@@ -123,7 +124,7 @@ class ApplicationFormatter extends AbstractUi5Formatter {
 	async getNamespaceFromManifestAppDescVariant() {
 		const {content: manifest} = await this.getJson("manifest.appdescr_variant");
 		let appId;
-		// check for a proper sap.app/id in manifest.json to determine namespace
+		// check for the id property in manifest.appdescr_variant to determine namespace
 		if (manifest && manifest.id) {
 			appId = manifest.id;
 		} else {

--- a/test/lib/types/application/ApplicationFormatter.js
+++ b/test/lib/types/application/ApplicationFormatter.js
@@ -187,48 +187,129 @@ test("format", async (t) => {
 	t.deepEqual(getNamespaceStub.callCount, 1, "getNamespace called once");
 });
 
-
-test("getNamespace: No 'sap.app' configuration found", async (t) => {
+test("getNamespaceFromManifestJson: No 'sap.app' configuration found", async (t) => {
 	const project = createMockProject();
 	const applicationFormatter = new ApplicationFormatter({project});
-	sinon.stub(applicationFormatter, "getManifest").resolves({content: {}, fsPath: {}});
+	sinon.stub(applicationFormatter, "getJson").resolves({content: {}, fsPath: {}});
 
-	const error = await t.throwsAsync(applicationFormatter.getNamespace());
+	const error = await t.throwsAsync(applicationFormatter.getNamespaceFromManifestJson());
 	t.deepEqual(error.message, "No sap.app/id configuration found in manifest.json of project projectName",
 		"Rejected with correct error message");
 });
 
-test("getNamespace: No application id in 'sap.app' configuration found", async (t) => {
+test("getNamespaceFromManifestJson: No application id in 'sap.app' configuration found", async (t) => {
 	const project = createMockProject();
 	const applicationFormatter = new ApplicationFormatter({project});
-	sinon.stub(applicationFormatter, "getManifest").resolves({content: {"sap.app": {}}});
+	sinon.stub(applicationFormatter, "getJson").resolves({content: {"sap.app": {}}});
 
-	const error = await t.throwsAsync(applicationFormatter.getNamespace());
+	const error = await t.throwsAsync(applicationFormatter.getNamespaceFromManifestJson());
 	t.deepEqual(error.message, "No sap.app/id configuration found in manifest.json of project projectName");
 });
 
-test("getNamespace: set namespace to id", async (t) => {
+test("getNamespaceFromManifestJson: set namespace to id", async (t) => {
 	const project = createMockProject();
 	const applicationFormatter = new ApplicationFormatter({project});
-	sinon.stub(applicationFormatter, "getManifest").resolves({content: {"sap.app": {id: "my.id"}}});
+	sinon.stub(applicationFormatter, "getJson").resolves({content: {"sap.app": {id: "my.id"}}});
+
+	const namespace = await applicationFormatter.getNamespaceFromManifestJson();
+	t.deepEqual(namespace, "my/id", "Returned correct namespace");
+});
+
+test("getNamespaceFromManifestAppDescVariant: No 'id' property found", async (t) => {
+	const project = createMockProject();
+	const applicationFormatter = new ApplicationFormatter({project});
+	sinon.stub(applicationFormatter, "getJson").resolves({content: {}, fsPath: {}});
+
+	const error = await t.throwsAsync(applicationFormatter.getNamespaceFromManifestAppDescVariant());
+	t.deepEqual(error.message, `No "id" property found in manifest.appdescr_variant of project projectName`,
+		"Rejected with correct error message");
+});
+
+test("getNamespaceFromManifestAppDescVariant: set namespace to id", async (t) => {
+	const project = createMockProject();
+	const applicationFormatter = new ApplicationFormatter({project});
+	sinon.stub(applicationFormatter, "getJson").resolves({content: {id: "my.id"}});
+
+	const namespace = await applicationFormatter.getNamespaceFromManifestAppDescVariant();
+	t.deepEqual(namespace, "my/id", "Returned correct namespace");
+});
+
+test("getNamespace: Correct fallback to manifest.appdescr_variant if manifest.json is missing", async (t) => {
+	const project = createMockProject();
+	const applicationFormatter = new ApplicationFormatter({project});
+	const getJsonStub = sinon.stub(applicationFormatter, "getJson")
+		.onFirstCall().rejects({code: "ENOENT"})
+		.onSecondCall().resolves({content: {id: "my.id"}});
 
 	const namespace = await applicationFormatter.getNamespace();
-	t.deepEqual(namespace, "my/id",
-		"Returned correct namespace since getManifest provides the correct object structure");
+	t.deepEqual(namespace, "my/id", "Returned correct namespace");
+	t.is(getJsonStub.callCount, 2, "getJson called exactly twice");
+	t.is(getJsonStub.getCall(0).args[0], "manifest.json", "getJson called for manifest.json first");
+	t.is(getJsonStub.getCall(1).args[0], "manifest.appdescr_variant",
+		"getJson called for manifest.appdescr_variant in fallback");
 });
 
-test("getManifest: reads correctly", async (t) => {
+test("getNamespace: Correct error message if fallback to manifest.appdescr_variant failed", async (t) => {
+	const project = createMockProject();
+	const applicationFormatter = new ApplicationFormatter({project});
+	const getJsonStub = sinon.stub(applicationFormatter, "getJson")
+		.onFirstCall().rejects({code: "ENOENT"})
+		.onSecondCall().rejects(new Error("EPON: Pony Error"));
+
+	const error = await t.throwsAsync(applicationFormatter.getNamespace());
+	t.deepEqual(error.message, "EPON: Pony Error",
+		"Rejected with correct error message");
+	t.is(getJsonStub.callCount, 2, "getJson called exactly twice");
+	t.is(getJsonStub.getCall(0).args[0], "manifest.json", "getJson called for manifest.json first");
+	t.is(getJsonStub.getCall(1).args[0], "manifest.appdescr_variant",
+		"getJson called for manifest.appdescr_variant in fallback");
+});
+
+test("getNamespace: Correct error message if fallback to manifest.appdescr_variant is not possible", async (t) => {
+	const project = createMockProject();
+	const applicationFormatter = new ApplicationFormatter({project});
+	const getJsonStub = sinon.stub(applicationFormatter, "getJson")
+		.onFirstCall().rejects({message: "No such stable or directory: manifest.json", code: "ENOENT"})
+		.onSecondCall().rejects({code: "ENOENT"}); // both files are missing
+
+	const error = await t.throwsAsync(applicationFormatter.getNamespace());
+	t.deepEqual(error.message,
+		"Could not find required manifest.json for project projectName: " +
+		"No such stable or directory: manifest.json",
+		"Rejected with correct error message");
+
+	t.is(getJsonStub.callCount, 2, "getJson called exactly twice");
+	t.is(getJsonStub.getCall(0).args[0], "manifest.json", "getJson called for manifest.json first");
+	t.is(getJsonStub.getCall(1).args[0], "manifest.appdescr_variant",
+		"getJson called for manifest.appdescr_variant in fallback");
+});
+
+test("getNamespace: No fallback if manifest.json is present but failed to parse", async (t) => {
+	const project = createMockProject();
+	const applicationFormatter = new ApplicationFormatter({project});
+	const getJsonStub = sinon.stub(applicationFormatter, "getJson")
+		.onFirstCall().rejects(new Error("EPON: Pony Error"));
+
+	const error = await t.throwsAsync(applicationFormatter.getNamespace());
+	t.deepEqual(error.message, "EPON: Pony Error",
+		"Rejected with correct error message");
+
+	t.is(getJsonStub.callCount, 1, "getJson called exactly once");
+	t.is(getJsonStub.getCall(0).args[0], "manifest.json", "getJson called for manifest.json only");
+});
+
+test("getJson: reads correctly", async (t) => {
 	const myProject = clone(applicationBTree);
 
 	const libraryFormatter = new ApplicationFormatter({project: myProject});
 
-	const {content, fsPath} = await libraryFormatter.getManifest();
+	const {content, fsPath} = await libraryFormatter.getJson("manifest.json");
 	t.deepEqual(content._version, "1.1.0", "manifest.json content has been read");
 	const expectedPath = path.join(applicationBPath, "webapp", "manifest.json");
 	t.deepEqual(fsPath, expectedPath, "Correct manifest.json path returned");
 });
 
-test.serial("getManifest: invalid JSON", async (t) => {
+test.serial("getJson: invalid JSON", async (t) => {
 	const myProject = clone(applicationBTree);
 
 	const readFileStub = sinon.stub(fs, "readFile").callsArgWithAsync(1, undefined, "pony");
@@ -236,7 +317,7 @@ test.serial("getManifest: invalid JSON", async (t) => {
 	const ApplicationFormatter = mock.reRequire("../../../../lib/types/application/ApplicationFormatter");
 	const libraryFormatter = new ApplicationFormatter({project: myProject});
 
-	const error = await t.throwsAsync(libraryFormatter.getManifest());
+	const error = await t.throwsAsync(libraryFormatter.getJson("manifest.json"));
 	t.deepEqual(error.message,
 		"Failed to read manifest.json for project application.b: " +
 		"Unexpected token p in JSON at position 0",
@@ -246,7 +327,7 @@ test.serial("getManifest: invalid JSON", async (t) => {
 	t.deepEqual(readFileStub.getCall(0).args[0], expectedPath, "fs.read got called with the correct argument");
 });
 
-test.serial("getManifest: fs read error", async (t) => {
+test.serial("getJson: fs read error", async (t) => {
 	const myProject = clone(applicationBTree);
 
 	const readFileStub = sinon.stub(fs, "readFile").callsArgWithAsync(1, new Error("EPON: Pony Error"));
@@ -254,7 +335,7 @@ test.serial("getManifest: fs read error", async (t) => {
 	const ApplicationFormatter = mock.reRequire("../../../../lib/types/application/ApplicationFormatter");
 	const libraryFormatter = new ApplicationFormatter({project: myProject});
 
-	const error = await t.throwsAsync(libraryFormatter.getManifest());
+	const error = await t.throwsAsync(libraryFormatter.getJson("manifest.json"));
 	t.deepEqual(error.message,
 		"Failed to read manifest.json for project application.b: " +
 		"EPON: Pony Error",
@@ -264,7 +345,7 @@ test.serial("getManifest: fs read error", async (t) => {
 	t.deepEqual(readFileStub.getCall(0).args[0], expectedPath, "fs.read got called with the correct argument");
 });
 
-test.serial("getManifest: result is cached", async (t) => {
+test.serial("getJson: result is cached", async (t) => {
 	const myProject = clone(applicationBTree);
 
 	const readFileStub = sinon.stub(fs, "readFile").callsArgWithAsync(1, undefined,
@@ -273,84 +354,79 @@ test.serial("getManifest: result is cached", async (t) => {
 	const ApplicationFormatter = mock.reRequire("../../../../lib/types/application/ApplicationFormatter");
 	const libraryFormatter = new ApplicationFormatter({project: myProject});
 	const expectedPath = path.join(applicationBPath, "webapp", "manifest.json");
+	const expectedPath2 = path.join(applicationBPath, "webapp", "otherfile.json");
 
-	const {content, fsPath} = await libraryFormatter.getManifest();
+	const {content, fsPath} = await libraryFormatter.getJson("manifest.json");
 	t.deepEqual(content, {pony: "no unicorn"}, "Correct result on first call");
 	t.deepEqual(fsPath, expectedPath, "Correct manifest.json path returned on first call");
 
-	const {content: content2, fsPath: fsPath2} = await libraryFormatter.getManifest();
+	const {content: content2, fsPath: fsPath2} = await libraryFormatter.getJson("otherfile.json");
 	t.deepEqual(content2, {pony: "no unicorn"}, "Correct result on second call");
-	t.deepEqual(fsPath2, expectedPath, "Correct manifest.json path returned on second call");
+	t.deepEqual(fsPath2, expectedPath2, "Correct otherfile.json path returned on second call");
 
-	t.deepEqual(readFileStub.callCount, 1, "fs.read got called exactly once (and then cached)");
+	t.deepEqual(readFileStub.callCount, 2, "fs.read got called exactly twice (and then cached)");
 });
 
-test("getManifest - appdescr_variant fallback: reads correctly", async (t) => {
+test.serial("getJson: Alternative file names", async (t) => {
 	const myProject = clone(applicationBTree);
 
-	const libraryFormatter = new ApplicationFormatter({project: myProject});
-
-	const {content, fsPath} = await libraryFormatter.getManifest();
-	t.deepEqual(content._version, "1.1.0", "manifest.json content has been read");
-	const expectedPath = path.join(applicationBPath, "webapp", "manifest.json");
-	t.deepEqual(fsPath, expectedPath, "Correct manifest.json path returned");
-});
-
-test.serial("getManifest - appdescr_variant fallback: invalid JSON", async (t) => {
-	const myProject = clone(applicationBTree);
-
-	const readFileStub = sinon.stub(fs, "readFile").callsArgWithAsync(1, undefined, "pony");
+	const readFileStub = sinon.stub(fs, "readFile").callsArgWithAsync(1, undefined,
+		`{"pony": "no unicorn"}`);
 
 	const ApplicationFormatter = mock.reRequire("../../../../lib/types/application/ApplicationFormatter");
 	const libraryFormatter = new ApplicationFormatter({project: myProject});
+	const expectedPath = path.join(applicationBPath, "webapp", "manifest.appdescr_variant");
+	const expectedPath2 = path.join(applicationBPath, "webapp", "pony.json");
 
-	const error = await t.throwsAsync(libraryFormatter.getManifest());
-	t.deepEqual(error.message,
-		"Failed to read manifest.json for project application.b: " +
-		"Unexpected token p in JSON at position 0",
-		"Rejected with correct error message");
-	t.deepEqual(readFileStub.callCount, 1, "fs.read got called once");
-	const expectedPath = path.join(applicationBPath, "webapp", "manifest.json");
-	t.deepEqual(readFileStub.getCall(0).args[0], expectedPath, "fs.read got called with the correct argument");
+	const {content, fsPath} = await libraryFormatter.getJson("manifest.appdescr_variant");
+	t.deepEqual(content, {pony: "no unicorn"}, "Correct result on first call");
+	t.deepEqual(fsPath, expectedPath, "Correct manifest.appdescr_variant path returned on first call");
+
+	const {content: content2, fsPath: fsPath2} = await libraryFormatter.getJson("pony.json");
+	t.deepEqual(content2, {pony: "no unicorn"}, "Correct result on second call");
+	t.deepEqual(fsPath2, expectedPath2, "Correct pony.json path returned on second call");
+
+	t.deepEqual(readFileStub.callCount, 2, "fs.read got called exactly twice");
 });
 
-test.serial("getManifest - appdescr_variant fallback: fs read error", async (t) => {
+test.serial("getJson: Caches successes and failures", async (t) => {
 	const myProject = clone(applicationBTree);
 
-	const readFileStub = sinon.stub(fs, "readFile").callsArgWithAsync(1, new Error("EPON: Pony Error"));
+	const readFileStub = sinon.stub(fs, "readFile")
+		.onFirstCall().callsArgWithAsync(1, new Error("EPON: Pony Error"))
+		.onSecondCall().callsArgWithAsync(1, undefined, `{"pony": "no unicorn"}`);
 
 	const ApplicationFormatter = mock.reRequire("../../../../lib/types/application/ApplicationFormatter");
 	const libraryFormatter = new ApplicationFormatter({project: myProject});
+	const expectedPath = path.join(applicationBPath, "webapp", "manifest.json");
+	const expectedPath2 = path.join(applicationBPath, "webapp", "manifest.appdescr_variant");
 
-	const error = await t.throwsAsync(libraryFormatter.getManifest());
+	const error = await t.throwsAsync(libraryFormatter.getJson("manifest.json"));
 	t.deepEqual(error.message,
 		"Failed to read manifest.json for project application.b: " +
 		"EPON: Pony Error",
 		"Rejected with correct error message");
-	t.deepEqual(readFileStub.callCount, 1, "fs.read got called once");
-	const expectedPath = path.join(applicationBPath, "webapp", "manifest.json");
-	t.deepEqual(readFileStub.getCall(0).args[0], expectedPath, "fs.read got called with the correct argument");
-});
 
-test.serial("getManifest - appdescr_variant fallback: result is cached", async (t) => {
-	const myProject = clone(applicationBTree);
+	const {content, fsPath} = await libraryFormatter.getJson("manifest.appdescr_variant");
+	t.deepEqual(content, {pony: "no unicorn"}, "Correct result on second call");
+	t.deepEqual(fsPath, expectedPath2, "Correct manifest.appdescr_variant path returned on second call");
 
-	const readFileStub = sinon.stub(fs, "readFile").callsArgWithAsync(1, undefined,
-		`{"pony": "no unicorn"}`);
+	const error2 = await t.throwsAsync(libraryFormatter.getJson("manifest.json"));
+	t.deepEqual(error2.message,
+		"Failed to read manifest.json for project application.b: " +
+		"EPON: Pony Error",
+		"From cache: Rejected with correct error message");
 
-	const ApplicationFormatter = mock.reRequire("../../../../lib/types/application/ApplicationFormatter");
-	const libraryFormatter = new ApplicationFormatter({project: myProject});
-	const expectedPath = path.join(applicationBPath, "webapp", "manifest.json");
+	const {content: content2, fsPath: fsPath2} = await libraryFormatter.getJson("manifest.appdescr_variant");
+	t.deepEqual(content2, {pony: "no unicorn"}, "From cache: Correct result on first call");
+	t.deepEqual(fsPath2, expectedPath2, "From cache: Correct manifest.appdescr_variant path returned on first call");
 
-	const {content, fsPath} = await libraryFormatter.getManifest();
-	t.deepEqual(content, {pony: "no unicorn"}, "Correct result on first call");
-	t.deepEqual(fsPath, expectedPath, "Correct manifest.json path returned on first call");
-
-	const {content: content2, fsPath: fsPath2} = await libraryFormatter.getManifest();
-	t.deepEqual(content2, {pony: "no unicorn"}, "Correct result on second call");
-	t.deepEqual(fsPath2, expectedPath, "Correct manifest.json path returned on second call");
-
-	t.deepEqual(readFileStub.callCount, 1, "fs.read got called exactly once (and then cached)");
+	t.deepEqual(readFileStub.callCount, 2,
+		"fs.read got called exactly twice (and then cached)");
+	t.deepEqual(readFileStub.getCall(0).args[0], expectedPath,
+		"manifest.json: fs.read got called with the correct argument");
+	t.deepEqual(readFileStub.getCall(1).args[0], expectedPath2,
+		"manifest.appdescr_variant: fs.read got called with the correct argument");
 });
 
 const applicationHPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.h");
@@ -382,7 +458,7 @@ test("namespace: detect namespace from pom.xml via ${project.artifactId}", async
 
 	await applicationFormatter.format();
 	t.deepEqual(myProject.metadata.namespace, "application/h",
-		"namespace was successfully set since getManifest provides the correct object structure");
+		"namespace was successfully set since getJson provides the correct object structure");
 });
 
 test("namespace: detect namespace from pom.xml via ${componentName} from properties", async (t) => {
@@ -392,7 +468,7 @@ test("namespace: detect namespace from pom.xml via ${componentName} from propert
 
 	await applicationFormatter.format();
 	t.deepEqual(myProject.metadata.namespace, "application/h",
-		"namespace was successfully set since getManifest provides the correct object structure");
+		"namespace was successfully set since getJson provides the correct object structure");
 });
 
 test("namespace: detect namespace from pom.xml via ${appId} from properties", async (t) => {


### PR DESCRIPTION
App Variants typically do not have a manifest.json (they only add that [during the build](https://github.com/SAP/ui5-task-adaptation)) but a manifest.appdescr_variant.

During the project namespace detection, in case no manifest.json is present (error ENOENT), we now attempt a fallback to manifest.appdescr_variant (if present).

For more information see:
* https://help.sap.com/viewer/a7b390faab1140c087b8926571e942b7/202009.000/en-US/af47058ad66144579db6a990f3b7b919.html
* https://blogs.sap.com/2020/07/15/adaptation-project-your-one-stop-tool-for-extending-sapui5-applications

JIRA: CPOUI5FOUNDATION-284