### PR TITLE
[FIX] JSModuleAnalyzer: Properly handle jQuery.sap.registerPreloadedModules calls

### DIFF
--- a/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -650,9 +650,11 @@ class JSModuleAnalyzer {
 				modules = args[0];
 			} else {
 				const obj = args[0];
-				const version = findOwnProperty(obj, "version");
-				namesUseLegacyNotation = !(version && isString(version) && parseFloat(version.value) >= 2.0);
-				modules = findOwnProperty(obj, "modules");
+				if (obj && obj.type === Syntax.ObjectExpression) {
+					const version = findOwnProperty(obj, "version");
+					namesUseLegacyNotation = !(version && isString(version) && parseFloat(version.value) >= 2.0);
+					modules = findOwnProperty(obj, "modules");
+				}
 			}
 			if ( modules && modules.type == Syntax.ObjectExpression ) {
 				modules.properties.forEach( function(property) {

--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -620,3 +620,54 @@ sap.ui.testmodule.load = function(modName) {
 	t.deepEqual(info.subModules, [],
 		"no submodules");
 });
+
+test("jQuery.sap.registerPreloadedModules (with Identifier)", (t) => {
+	const content = `
+var data = {};
+jQuery.sap.registerPreloadedModules(data);
+`;
+	const info = analyzeString(content, "modules/registerPreloadedModules-Identifier.js");
+	t.deepEqual(info.subModules, [],
+		"no submodules");
+});
+
+test("jQuery.sap.registerPreloadedModules (with ObjectExpression)", (t) => {
+	const content = `
+jQuery.sap.registerPreloadedModules({
+	"modules": {
+		"foo.bar": ""
+	}
+});
+`;
+	const info = analyzeString(content, "modules/registerPreloadedModules-ObjectExpression.js");
+	t.deepEqual(info.subModules, ["foo/bar.js"],
+		"submodule from jQuery.sap.registerPreloadedModules");
+});
+
+test("jQuery.sap.registerPreloadedModules (with ObjectExpression, version 1.0)", (t) => {
+	const content = `
+jQuery.sap.registerPreloadedModules({
+	"modules": {
+		"foo.bar": ""
+	},
+	"version": "1.0"
+});
+`;
+	const info = analyzeString(content, "modules/registerPreloadedModules-ObjectExpression.js");
+	t.deepEqual(info.subModules, ["foo/bar.js"],
+		"submodule from jQuery.sap.registerPreloadedModules");
+});
+
+test("jQuery.sap.registerPreloadedModules (with ObjectExpression, version 2.0)", (t) => {
+	const content = `
+jQuery.sap.registerPreloadedModules({
+	"modules": {
+		"foo/bar.js": ""
+	},
+	"version": "2.0"
+});
+`;
+	const info = analyzeString(content, "modules/registerPreloadedModules-ObjectExpression.js");
+	t.deepEqual(info.subModules, ["foo/bar.js"],
+		"submodule from jQuery.sap.registerPreloadedModules");
+});


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-builder/issues/544