### PR TITLE
[FEATURE] manifestCreator: enrich manifest with supportedLocales in i18n (for libraries)

### DIFF
--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -567,7 +567,8 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 	 *
 	 * @param {string} i18n bundle url, e.g. "messagebundle.properties"
 	 * @param {Map<string, Set<string>>} i18nToSupportedLocales cache to determine the supportedLocales only once
-	 * @returns {{bundleUrl: string, supportedLocales: string[]}|null|string}  json structure with bundleUrl and supportedLocales or the i18n String if not a ".properties" file.
+	 * @returns {{bundleUrl: string, supportedLocales: string[]}|null|string} json structure with bundleUrl and
+	 *   supportedLocales or the i18n String if not a ".properties" file.
 	 *   <code>null</code> if given i18n String is <code>null</code>
 	 */
 	function createI18nSection(i18n, i18nToSupportedLocales) {

--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -592,13 +592,15 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 			if (libBundle.findResource(i18n) != null) {
 				supportedLocales.add("");
 			}
-			const i18nPatternStr = i18n.substring(0, i18n.length - ".properties".length) + "_";
+			const i18nPathPrefix = i18n.substring(0, i18n.length - ".properties".length) + "_";
+			// e.g. i18n/i18n_
 
 			libBundle.getResources().forEach((resource) => {
 				const resPath = resource.getPath();
-				const i18nLastIndex = resPath.lastIndexOf(i18nPatternStr);
-				if (resPath.endsWith(".properties") && i18nLastIndex >= 0) {
-					const i18nPath = resPath.substring(i18nLastIndex + i18nPatternStr.length,
+				// e.g. sap/ui/mine/i18n/i18n_en.properties
+				const indexOfI18nPathPrefix = resPath.lastIndexOf(i18nPathPrefix);
+				if (resPath.endsWith(".properties") && indexOfI18nPathPrefix >= 0) {
+					const i18nPath = resPath.substring(indexOfI18nPathPrefix + i18nPathPrefix.length,
 						resPath.length - ".properties".length);
 					if (!i18nPath.includes(".")) {
 						supportedLocales.add(i18nPath.replace(/_/g, "-"));

--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -606,7 +606,7 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 			i18nToSupportedLocales.set(i18n, supportedLocales);
 		}
 
-		const supportedLocalesArray = [...supportedLocales];
+		const supportedLocalesArray = Array.from(supportedLocales);
 		supportedLocalesArray.sort();
 		return {
 			bundleUrl: i18n,

--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -505,11 +505,7 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 						return false;
 					}
 				}
-				// i18n can be an empty string therefore check for not being null
-				if (i18n !== null) {
-					return createI18nSection(i18n, i18nToSupportedLocales);
-				}
-				return false;
+				return createI18nSection(i18n, i18nToSupportedLocales);
 			}
 
 			// css:

--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -21,6 +21,7 @@ const APP_DESCRIPTOR_V3_SECTION_SAP_APP = new Version("1.2.0");
 const APP_DESCRIPTOR_V3_OTHER_SECTIONS = new Version("1.1.0");
 const APP_DESCRIPTOR_V5 = new Version("1.4.0");
 const APP_DESCRIPTOR_V10 = new Version("1.9.0");
+const APP_DESCRIPTOR_V22 = new Version("1.21.0");
 
 // namespaces used in .library files
 const XMLNS_UILIB = "http://www.sap.com/sap.ui.library.xsd";
@@ -123,13 +124,30 @@ class Library {
 
 
 class LibraryBundle {
+	/**
+	 *
+	 * @param {string} prefix
+	 * @param {module:@ui5/fs.Resource[]} resources
+	 */
 	constructor(prefix, resources) {
 		this.prefix = prefix;
 		this.resources = resources.filter((res) => res.getPath().startsWith(prefix));
 	}
+
+	/**
+	 *
+	 * @param {string} name
+	 * @returns {module:@ui5/fs.Resource}
+	 */
 	findResource(name) {
 		return this.resources.find((res) => res.getPath() === this.prefix + name);
 	}
+
+	/**
+	 *
+	 * @param {RegExp} pattern
+	 * @returns {module:@ui5/fs.Resource[]}
+	 */
 	getResources(pattern) {
 		return this.resources.filter((res) => pattern == null || pattern.test(res.getPath()));
 	}
@@ -144,6 +162,13 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 
 	// collect information from library.js file
 	const libraryJSInfo = await analyzeLibraryJS(libBundle.findResource("library.js"));
+	const includeSupportedLocalesInformation = descriptorVersion.compare(APP_DESCRIPTOR_V22) >= 0;
+	/**
+	 * cache for supported locales
+	 *
+	 * @see createI18nSection
+	 */
+	const i18nToSupportedLocales = new Map();
 
 	const manifestAppData = library.getAppData("manifest", XMLNS_MANIFEST);
 	const sapFioriAppData = findChild(manifestAppData, "sap.fiori");
@@ -322,13 +347,19 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 
 			return osComponents.length > 0 ? osComponents : undefined;
 		}
-
+		const i18nAppData = findChild(manifestAppData, "i18n");
+		let i18n;
+		if (i18nAppData) {
+			const i18nText = i18nAppData._; // text content
+			i18n = createI18nSection(i18nText, i18nToSupportedLocales);
+			log.verbose(`sap.app/i18n taken from .library appData: '%s'`, i18nText);
+		}
 		const sapApp = {
 			_version: sectionVersion(APP_DESCRIPTOR_V3_SECTION_SAP_APP),
 			id: library.getName(),
 			type: "library",
 			embeds: await findEmbeddedComponents(),
-			i18n: getChildTextContent(manifestAppData, "i18n"),
+			i18n,
 			applicationVersion: {
 				version: isValid(library.getVersion()) ? library.getVersion() : getProjectVersion()
 			},
@@ -457,24 +488,28 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 			// - from library resources (if "messagebundle.properties" exists)
 			function i18n() {
 				const i18nElement = findChild(libraryAppData, "i18n");
+				let i18n = null;
 				if ( i18nElement ) {
-					const i18n = i18nElement._;
+					i18n = i18nElement._; // text content
 					if ( i18n === "false" ) {
 						return false;
 					} else if ( i18n === "true" ) {
-						return "messagebundle.properties";
-					} else {
-						return i18n;
+						i18n = "messagebundle.properties";
 					}
 					// log.verbose("  sap.ui5/library/i18n property taken from .library appData: '%s'", library.i18n);
 				} else {
 					if ( libBundle.findResource("messagebundle.properties") != null ) {
 						// log.verbose("  sap.ui5/library/i18n property determined from resources: '%s'", library.i18n);
-						return "messagebundle.properties";
+						i18n = "messagebundle.properties";
 					} else {
 						return false;
 					}
 				}
+				// i18n can be an empty string therefore check for not being null
+				if (i18n !== null) {
+					return createI18nSection(i18n, i18nToSupportedLocales);
+				}
+				return false;
 			}
 
 			// css:
@@ -523,6 +558,60 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 		};
 
 		return sapUI5;
+	}
+
+	/**
+	 * Creates an i18n section:
+	 * - either using bundleUrl and supportedLocales
+	 * - or the i18n String
+	 *
+	 * @param {string} i18n bundle url, e.g. "messagebundle.properties"
+	 * @param {Map<string, Set<string>>} i18nToSupportedLocales cache to determine the supportedLocales only once
+	 * @returns {{bundleUrl: string, supportedLocales: string[]}|null|string}  json structure with bundleUrl and supportedLocales or the i18n String if not a ".properties" file.
+	 *   <code>null</code> if given i18n String is <code>null</code>
+	 */
+	function createI18nSection(i18n, i18nToSupportedLocales) {
+		if (!i18n) {
+			return null;
+		}
+		if (!i18n.endsWith(".properties")) {
+			return i18n;
+		}
+
+		// if the supported locales information should not be included use i18n text
+		if (!includeSupportedLocalesInformation) {
+			return i18n;
+		}
+
+		let supportedLocales = i18nToSupportedLocales.get(i18n);
+
+		if (!supportedLocales) {
+			supportedLocales = new Set();
+
+			if (libBundle.findResource(i18n) != null) {
+				supportedLocales.add("");
+			}
+			const i18nPatternStr = i18n.substring(0, i18n.length - ".properties".length);
+			const i18nRegexp = new RegExp(i18nPatternStr + "_([^.]+)\\.properties$");
+
+
+			libBundle.getResources().forEach((resource) => {
+				const resPath = resource.getPath();
+				const result = i18nRegexp.exec(resPath);
+
+				if (result) {
+					supportedLocales.add(result[1].replace(/_/g, "-"));
+				}
+			});
+			i18nToSupportedLocales.set(i18n, supportedLocales);
+		}
+
+		const supportedLocalesArray = [...supportedLocales];
+		supportedLocalesArray.sort();
+		return {
+			bundleUrl: i18n,
+			supportedLocales: supportedLocalesArray
+		};
 	}
 
 	function createSapFiori() {
@@ -613,7 +702,7 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 module.exports = function({libraryResource, resources, options}) {
 	// merge options with defaults
 	options = Object.assign({
-		descriptorVersion: APP_DESCRIPTOR_V10,
+		descriptorVersion: APP_DESCRIPTOR_V22,
 		include3rdParty: true,
 		prettyPrint: true
 	}, options);

--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -347,10 +347,9 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 
 			return osComponents.length > 0 ? osComponents : undefined;
 		}
-		const i18nAppData = findChild(manifestAppData, "i18n");
+		const i18nText = getChildTextContent(manifestAppData, "i18n");
 		let i18n;
-		if (i18nAppData) {
-			const i18nText = i18nAppData._; // text content
+		if (typeof i18nText === "string") {
 			i18n = createI18nSection(i18nText, i18nToSupportedLocales);
 			log.verbose(`sap.app/i18n taken from .library appData: '%s'`, i18nText);
 		}
@@ -487,10 +486,8 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 			// - from .library/appData/manifest/sap.ui5/library/i18n
 			// - from library resources (if "messagebundle.properties" exists)
 			function i18n() {
-				const i18nElement = findChild(libraryAppData, "i18n");
-				let i18n = null;
-				if ( i18nElement ) {
-					i18n = i18nElement._; // text content
+				let i18n = getChildTextContent(libraryAppData, "i18n");
+				if ( typeof i18n === "string") {
 					if ( i18n === "false" ) {
 						return false;
 					} else if ( i18n === "true" ) {
@@ -504,6 +501,9 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 					} else {
 						return false;
 					}
+				}
+				if (i18n === undefined) {
+					return false;
 				}
 				return createI18nSection(i18n, i18nToSupportedLocales);
 			}
@@ -568,8 +568,8 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 	 *   <code>null</code> if given i18n String is <code>null</code>
 	 */
 	function createI18nSection(i18n, i18nToSupportedLocales) {
-		if (!i18n) {
-			return null;
+		if (i18n === undefined) {
+			return undefined;
 		}
 		if (!i18n.endsWith(".properties")) {
 			return i18n;

--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -115,6 +115,7 @@ class Library {
 			parser.parseString(content, (err, xml) => {
 				if ( err ) {
 					reject(err);
+					return;
 				}
 				resolve(new Library(xml.library));
 			});

--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -500,11 +500,9 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 						// log.verbose("  sap.ui5/library/i18n property determined from resources: '%s'", library.i18n);
 						i18n = "messagebundle.properties";
 					} else {
+						// i18n not defined and no messagebundle.properties
 						return false;
 					}
-				}
-				if (i18n === undefined) {
-					return false;
 				}
 				return createI18nSection(i18n, i18nToSupportedLocales);
 			}

--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -592,16 +592,17 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 			if (libBundle.findResource(i18n) != null) {
 				supportedLocales.add("");
 			}
-			const i18nPatternStr = i18n.substring(0, i18n.length - ".properties".length);
-			const i18nRegexp = new RegExp(i18nPatternStr + "_([^.]+)\\.properties$");
-
+			const i18nPatternStr = i18n.substring(0, i18n.length - ".properties".length) + "_";
 
 			libBundle.getResources().forEach((resource) => {
 				const resPath = resource.getPath();
-				const result = i18nRegexp.exec(resPath);
-
-				if (result) {
-					supportedLocales.add(result[1].replace(/_/g, "-"));
+				const i18nLastIndex = resPath.lastIndexOf(i18nPatternStr);
+				if (resPath.endsWith(".properties") && i18nLastIndex >= 0) {
+					const i18nPath = resPath.substring(i18nLastIndex + i18nPatternStr.length,
+						resPath.length - ".properties".length);
+					if (!i18nPath.includes(".")) {
+						supportedLocales.add(i18nPath.replace(/_/g, "-"));
+					}
 				}
 			});
 			i18nToSupportedLocales.set(i18n, supportedLocales);

--- a/test/expected/build/library.d/dest/resources/library/d/manifest.json
+++ b/test/expected/build/library.d/dest/resources/library/d/manifest.json
@@ -1,5 +1,5 @@
 {
-  "_version": "1.9.0",
+  "_version": "1.21.0",
   "sap.app": {
     "id": "library.d",
     "type": "library",

--- a/test/expected/build/library.h/dest-resources-json/resources/library/h/manifest.json
+++ b/test/expected/build/library.h/dest-resources-json/resources/library/h/manifest.json
@@ -1,5 +1,5 @@
 {
-  "_version": "1.9.0",
+  "_version": "1.21.0",
   "sap.app": {
     "id": "library.h",
     "type": "library",

--- a/test/expected/build/library.h/dest-resources-json/resources/library/h/resources.json
+++ b/test/expected/build/library.h/dest-resources-json/resources/library/h/resources.json
@@ -133,7 +133,7 @@
 		{
 			"name": "manifest.json",
 			"module": "library/h/manifest.json",
-			"size": 613
+			"size": 614
 		},
 		{
 			"name": "not.js",

--- a/test/expected/build/library.h/dest/resources/library/h/manifest.json
+++ b/test/expected/build/library.h/dest/resources/library/h/manifest.json
@@ -1,5 +1,5 @@
 {
-  "_version": "1.9.0",
+  "_version": "1.21.0",
   "sap.app": {
     "id": "library.h",
     "type": "library",

--- a/test/expected/build/library.i/dest/resources/library/i/manifest.json
+++ b/test/expected/build/library.i/dest/resources/library/i/manifest.json
@@ -1,5 +1,5 @@
 {
-  "_version": "1.9.0",
+  "_version": "1.21.0",
   "sap.app": {
     "id": "library.i",
     "type": "library",

--- a/test/expected/build/library.k/dest/resources/library/k/manifest-bundle/manifest.json
+++ b/test/expected/build/library.k/dest/resources/library/k/manifest-bundle/manifest.json
@@ -1,5 +1,5 @@
 {
-  "_version": "1.9.0",
+  "_version": "1.21.0",
   "sap.app": {
     "id": "library.k",
     "type": "library",
@@ -22,7 +22,14 @@
       "libs": {}
     },
     "library": {
-      "i18n": "messagebundle.properties",
+      "i18n": {
+        "bundleUrl": "messagebundle.properties",
+        "supportedLocales": [
+          "",
+          "de",
+          "en"
+        ]
+      },
       "content": {
         "controls": [
           "library.k.AnyControl"

--- a/test/expected/build/library.k/dest/resources/library/k/manifest.json
+++ b/test/expected/build/library.k/dest/resources/library/k/manifest.json
@@ -1,5 +1,5 @@
 {
-  "_version": "1.9.0",
+  "_version": "1.21.0",
   "sap.app": {
     "id": "library.k",
     "type": "library",

--- a/test/expected/build/library.ø/dest/resources/library/ø/library-preload.js
+++ b/test/expected/build/library.ø/dest/resources/library/ø/library-preload.js
@@ -1,6 +1,6 @@
 //@ui5-bundle library/ø/library-preload.js
 sap.ui.require.preload({
-	"library/ø/manifest.json":'{"_version":"1.9.0","sap.app":{"id":"library.ø","type":"library","embeds":[],"applicationVersion":{"version":"1.0.0"},"title":"Library Ø","description":"Library Ø","resources":"resources.json","offline":true},"sap.ui":{"technology":"UI5","supportedThemes":["цветя"]},"sap.ui5":{"dependencies":{"minUI5Version":"1.0","libs":{}},"library":{"i18n":false}}}',
+	"library/ø/manifest.json":'{"_version":"1.21.0","sap.app":{"id":"library.ø","type":"library","embeds":[],"applicationVersion":{"version":"1.0.0"},"title":"Library Ø","description":"Library Ø","resources":"resources.json","offline":true},"sap.ui":{"technology":"UI5","supportedThemes":["цветя"]},"sap.ui5":{"dependencies":{"minUI5Version":"1.0","libs":{}},"library":{"i18n":false}}}',
 	"library/ø/some.js":function(){/*!
  * Some fancy copyright
  */

--- a/test/expected/build/library.ø/dest/resources/library/ø/manifest.json
+++ b/test/expected/build/library.ø/dest/resources/library/ø/manifest.json
@@ -1,5 +1,5 @@
 {
-  "_version": "1.9.0",
+  "_version": "1.21.0",
   "sap.app": {
     "id": "library.ø",
     "type": "library",

--- a/test/lib/processors/manifestCreator.js
+++ b/test/lib/processors/manifestCreator.js
@@ -137,6 +137,52 @@ test.serial("default manifest creation", async (t) => {
 	t.is(await result.getString(), expectedManifestContent, "Correct result returned");
 });
 
+test.serial("default manifest creation i18n empty string", async (t) => {
+	const {manifestCreator, errorLogStub} = t.context;
+	const prefix = "/resources/sap/ui/mine/";
+	const libraryResource = {
+		getPath: () => {
+			return prefix + ".library";
+		},
+		getString: async () => {
+			return `<?xml version="1.0" encoding="UTF-8" ?>
+				<library xmlns="http://www.sap.com/sap.ui.library.xsd" >
+					<name>library.e</name>
+					<vendor>SAP SE</vendor>
+					<copyright>my copyright</copyright>
+					<version>1.0.0</version>
+					<documentation>Library E</documentation>
+				
+					<dependencies>
+					    <dependency>
+					      <libraryName>sap.ui.core</libraryName>
+					    </dependency>
+					</dependencies>
+					
+					<appData>
+						<manifest xmlns="http://www.sap.com/ui5/buildext/manifest">
+							<i18n></i18n>
+						</manifest>
+					</appData>
+				</library>`;
+		},
+		_project: {
+			dependencies: [{
+				metadata: {
+					name: "sap.ui.core"
+				}
+			}]
+		}
+	};
+
+	t.is(errorLogStub.callCount, 0);
+	const expectedManifestContentObjectModified = expectedManifestContentObject();
+	expectedManifestContentObjectModified["sap.app"]["i18n"] = "";
+	const expectedManifestContent = JSON.stringify(expectedManifestContentObjectModified, null, 2);
+	const result = await manifestCreator({libraryResource, resources: [], options: {}});
+	t.is(await result.getString(), expectedManifestContent, "Correct result returned");
+});
+
 test.serial("default manifest creation with special characters", async (t) => {
 	const {manifestCreator, errorLogStub} = t.context;
 	const prefix = "/resources/sap/ui/mine/";

--- a/test/lib/processors/manifestCreator.js
+++ b/test/lib/processors/manifestCreator.js
@@ -142,24 +142,27 @@ test.serial("manifest creation for sap/apf", async (t) => {
 		};
 	});
 	resources.push(componentResource);
-	const result = await manifestCreator({libraryResource, resources: [componentResource], options: {}});
+	const result = await manifestCreator({libraryResource, resources, options: {}});
 	t.is(await result.getString(), expectedManifestContent, "Correct result returned");
 
 	t.is(errorLogStub.callCount, 0);
 
-	t.is(verboseLogStub.callCount, 9);
+	t.is(verboseLogStub.callCount, 10);
 	t.is(verboseLogStub.getCall(0).args[0], "sap.app/i18n taken from .library appData: '%s'");
 	t.is(verboseLogStub.getCall(1).args[0],
+		"checking component at %s");
+	t.is(verboseLogStub.getCall(1).args[1], "/resources/sap/apf");
+	t.is(verboseLogStub.getCall(2).args[0],
 		"Package %s contains both '*.library' and 'Component.js'. " +
 		"This is a known issue but can't be solved due to backward compatibility.");
-	t.is(verboseLogStub.getCall(1).args[1], "/resources/sap/apf");
+	t.is(verboseLogStub.getCall(2).args[1], "/resources/sap/apf");
 });
 
 test.serial("manifest creation with .library / Component.js at same namespace", async (t) => {
 	const {manifestCreator, errorLogStub, verboseLogStub} = t.context;
 
 	const expectedManifestContent = JSON.stringify({
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			"id": "sap.lib1",
 			"type": "library",
@@ -232,7 +235,7 @@ test.serial("manifest creation with embedded component", async (t) => {
 	const {manifestCreator, errorLogStub, verboseLogStub} = t.context;
 
 	const expectedManifestContent = JSON.stringify({
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			"id": "sap.lib1",
 			"type": "library",
@@ -322,7 +325,7 @@ test.serial("manifest creation with embedded component (Missing 'embeddedBy')", 
 	const {manifestCreator, errorLogStub, verboseLogStub} = t.context;
 
 	const expectedManifestContent = JSON.stringify({
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			"id": "sap.lib1",
 			"type": "library",
@@ -406,7 +409,7 @@ test.serial("manifest creation with embedded component ('embeddedBy' doesn't poi
 	const {manifestCreator, errorLogStub, verboseLogStub} = t.context;
 
 	const expectedManifestContent = JSON.stringify({
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			"id": "sap.lib1",
 			"type": "library",
@@ -495,7 +498,7 @@ test.serial("manifest creation with embedded component ('embeddedBy' absolute pa
 	const {manifestCreator, errorLogStub, verboseLogStub} = t.context;
 
 	const expectedManifestContent = JSON.stringify({
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			"id": "sap.lib1",
 			"type": "library",
@@ -584,7 +587,7 @@ test.serial("manifest creation with embedded component ('embeddedBy' empty strin
 	const {manifestCreator, errorLogStub} = t.context;
 
 	const expectedManifestContent = JSON.stringify({
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			"id": "sap.lib1",
 			"type": "library",
@@ -669,7 +672,7 @@ test.serial("manifest creation with embedded component ('embeddedBy' object)", a
 	const {manifestCreator, errorLogStub} = t.context;
 
 	const expectedManifestContent = JSON.stringify({
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			"id": "sap.lib1",
 			"type": "library",
@@ -757,7 +760,7 @@ test.serial("manifest creation with embedded component (no manifest.json)", asyn
 	const {manifestCreator, errorLogStub, verboseLogStub} = t.context;
 
 	const expectedManifestContent = JSON.stringify({
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			"id": "sap.lib1",
 			"type": "library",
@@ -833,7 +836,7 @@ test.serial("manifest creation with embedded component (invalid manifest.json)",
 	const {manifestCreator, errorLogStub} = t.context;
 
 	const expectedManifestContent = JSON.stringify({
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			"id": "sap.lib1",
 			"type": "library",

--- a/test/lib/processors/manifestCreator.js
+++ b/test/lib/processors/manifestCreator.js
@@ -158,6 +158,71 @@ test.serial("manifest creation for sap/apf", async (t) => {
 	t.is(verboseLogStub.getCall(2).args[1], "/resources/sap/apf");
 });
 
+test.serial("manifest creation for sap/ui/core", async (t) => {
+	const {manifestCreator, errorLogStub, verboseLogStub} = t.context;
+
+	const expectedManifestContent = JSON.stringify({
+		"_version": "1.21.0",
+		"sap.app": {
+			"id": "sap.ui.core",
+			"type": "library",
+			"embeds": [],
+			"applicationVersion": {
+				"version": "1.0.0"
+			},
+			"title": "sap.ui.core",
+			"resources": "resources.json",
+			"offline": true
+		},
+		"sap.ui": {
+			"technology": "UI5",
+			"supportedThemes": []
+		},
+		"sap.ui5": {
+			"dependencies": {
+				"libs": {}
+			},
+			"library": {
+				"i18n": false
+			}
+		}
+	}, null, 2);
+
+	const libraryResource = {
+		getPath: () => {
+			return "/resources/sap/ui/core/.library";
+		},
+		getString: async () => {
+			return `<?xml version="1.0" encoding="UTF-8" ?>
+			<library xmlns="http://www.sap.com/sap.ui.library.xsd" >
+				<name>sap.ui.core</name>
+				<version>1.0.0</version>
+			</library>`;
+		},
+		_project: {
+			metadata: {
+				name: "sap.ui.core"
+			}
+		}
+	};
+
+	const componentResource = {
+		getPath: () => {
+			return "/resources/sap/ui/core/Component.js";
+		}
+	};
+
+	const result = await manifestCreator({libraryResource, resources: [componentResource], options: {}});
+	t.is(await result.getString(), expectedManifestContent, "Correct result returned");
+
+	t.is(errorLogStub.callCount, 0);
+
+	t.is(verboseLogStub.callCount, 8);
+	t.is(verboseLogStub.getCall(1).args[0],
+		"  sap.app/id taken from .library: '%s'");
+	t.is(verboseLogStub.getCall(1).args[1], "sap.ui.core");
+});
+
 test.serial("manifest creation with .library / Component.js at same namespace", async (t) => {
 	const {manifestCreator, errorLogStub, verboseLogStub} = t.context;
 

--- a/test/lib/processors/manifestCreator.js
+++ b/test/lib/processors/manifestCreator.js
@@ -1129,3 +1129,26 @@ test.serial("manifest creation with embedded component (invalid manifest.json)",
 	]);
 	t.true(errorLogStub.getCall(0).args[2].startsWith("SyntaxError: Unexpected token"));
 });
+
+test.serial("manifest creation for invalid .library content", async (t) => {
+	const {manifestCreator} = t.context;
+
+	const libraryResource = {
+		getPath: () => {
+			return "/resources/sap/lib1/.library";
+		},
+		getString: async () => {
+			return `<?xml version="1.0" encoding="UTF-8" ?>
+			<<>`;
+		}
+	};
+
+	const error = await t.throwsAsync(manifestCreator({
+		libraryResource,
+		resources: []
+	}));
+	t.deepEqual(error.message, `Unencoded <
+Line: 1
+Column: 5
+Char: <`, "error message for unencoded <");
+});

--- a/test/lib/tasks/generateLibraryManifest.js
+++ b/test/lib/tasks/generateLibraryManifest.js
@@ -79,7 +79,7 @@ test("integration: Library without i18n bundle file", async (t) => {
 	}));
 
 	await assertCreatedManifest(t, {
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			applicationVersion: {
 				version: "2.0.0",
@@ -137,7 +137,7 @@ test("integration: Library with i18n bundle file (messagebundle.properties)", as
 	}));
 
 	await assertCreatedManifest(t, {
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			applicationVersion: {
 				version: "2.0.0",
@@ -160,7 +160,10 @@ test("integration: Library with i18n bundle file (messagebundle.properties)", as
 				minUI5Version: "1.0",
 			},
 			library: {
-				i18n: "messagebundle.properties",
+				i18n: {
+					bundleUrl: "messagebundle.properties",
+					supportedLocales: [""]
+				}
 			}
 		},
 	});
@@ -198,9 +201,13 @@ test("integration: Library with i18n=true declared in .library", async (t) => {
 		`,
 		project: t.context.workspace._project
 	}));
+	t.context.resources.push(resourceFactory.createResource({
+		path: "/resources/test/lib/messagebundle.properties",
+		project: t.context.workspace._project
+	}));
 
 	await assertCreatedManifest(t, {
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			applicationVersion: {
 				version: "2.0.0",
@@ -223,7 +230,10 @@ test("integration: Library with i18n=true declared in .library", async (t) => {
 				minUI5Version: "1.0",
 			},
 			library: {
-				i18n: "messagebundle.properties",
+				i18n: {
+					bundleUrl: "messagebundle.properties",
+					supportedLocales: [""]
+				}
 			}
 		},
 	});
@@ -263,7 +273,7 @@ test("integration: Library with i18n=false declared in .library", async (t) => {
 	}));
 
 	await assertCreatedManifest(t, {
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			applicationVersion: {
 				version: "2.0.0",
@@ -325,8 +335,12 @@ test("integration: Library with i18n=foo.properties declared in .library", async
 		project: t.context.workspace._project
 	}));
 
+	t.context.resources.push(resourceFactory.createResource({
+		path: "/resources/test/lib/foo.properties",
+		project: t.context.workspace._project
+	}));
 	await assertCreatedManifest(t, {
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			applicationVersion: {
 				version: "2.0.0",
@@ -349,7 +363,10 @@ test("integration: Library with i18n=foo.properties declared in .library", async
 				minUI5Version: "1.0",
 			},
 			library: {
-				i18n: "foo.properties"
+				i18n: {
+					bundleUrl: "foo.properties",
+					supportedLocales: [""]
+				}
 			}
 		},
 	});
@@ -389,7 +406,7 @@ test("integration: Library with css=true declared in .library", async (t) => {
 	}));
 
 	await assertCreatedManifest(t, {
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			applicationVersion: {
 				version: "2.0.0",
@@ -452,7 +469,7 @@ test("integration: Library with css=false declared in .library", async (t) => {
 	}));
 
 	await assertCreatedManifest(t, {
-		"_version": "1.9.0",
+		"_version": "1.21.0",
 		"sap.app": {
 			applicationVersion: {
 				version: "2.0.0",


### PR DESCRIPTION
With app descriptor v22 (1.21.0) the i18n sections in the manifest can be an object
with:
* bundleUrl
* supportedLocales

This change reads the provided properties files and automatically creates the supportedLocales
array based on this information.

### e.g.
**files:**
- i18n/i18n.properties
- i18n/i18n_de.properties
- i18n/i18n_en.properties

**snippet in manifest.json**
```json
"i18n": {
      "bundleUrl": "i18n/i18n.properties",
      "supportedLocales": [
        "",
        "de",
        "en"
      ]
    },

```