### PR TITLE
[FIX] Theme Build: Only process themes within library namespace

### DIFF
--- a/lib/tasks/generateThemeDesignerResources.js
+++ b/lib/tasks/generateThemeDesignerResources.js
@@ -101,7 +101,16 @@ module.exports = async function({workspace, dependencies, options: {projectName,
 		return;
 	}
 
-	const librarySourceLessResources = await workspace.byGlob("/resources/**/themes/*/library.source.less");
+	let librarySourceLessPattern;
+	if (namespace) {
+		// In case of a library only check for themes directly below the namespace
+		librarySourceLessPattern = `/resources/${namespace}/themes/*/library.source.less`;
+	} else {
+		// In case of a theme-library check for all "themes"
+		librarySourceLessPattern = `/resources/**/themes/*/library.source.less`;
+	}
+
+	const librarySourceLessResources = await workspace.byGlob(librarySourceLessPattern);
 
 	const hasThemes = librarySourceLessResources.length > 0;
 

--- a/lib/types/library/LibraryBuilder.js
+++ b/lib/types/library/LibraryBuilder.js
@@ -152,6 +152,10 @@ class LibraryBuilder extends AbstractBuilder {
 		}
 
 		this.addTask("buildThemes", async () => {
+			// Only compile themes directly below the lib namespace to be in sync with the theme support at runtime
+			// which only loads themes from that folder.
+			const inputPattern = `/resources/${project.metadata.namespace}/themes/*/library.source.less`;
+
 			return getTask("buildThemes").task({
 				workspace: resourceCollections.workspace,
 				dependencies: resourceCollections.dependencies,
@@ -159,7 +163,7 @@ class LibraryBuilder extends AbstractBuilder {
 					projectName: project.metadata.name,
 					librariesPattern: !taskUtil.isRootProject() ? "/resources/**/*.library" : undefined,
 					themesPattern: !taskUtil.isRootProject() ? "/resources/sap/ui/core/themes/*" : undefined,
-					inputPattern: "/resources/**/themes/*/library.source.less"
+					inputPattern
 				}
 			});
 		});

--- a/lib/types/library/LibraryBuilder.js
+++ b/lib/types/library/LibraryBuilder.js
@@ -154,7 +154,8 @@ class LibraryBuilder extends AbstractBuilder {
 		this.addTask("buildThemes", async () => {
 			// Only compile themes directly below the lib namespace to be in sync with the theme support at runtime
 			// which only loads themes from that folder.
-			const inputPattern = `/resources/${project.metadata.namespace}/themes/*/library.source.less`;
+			// TODO 3.0: Remove fallback in case of missing namespace
+			const inputPattern = `/resources/${project.metadata.namespace || "**"}/themes/*/library.source.less`;
 
 			return getTask("buildThemes").task({
 				workspace: resourceCollections.workspace,

--- a/test/lib/tasks/buildThemes.integration.js
+++ b/test/lib/tasks/buildThemes.integration.js
@@ -51,7 +51,7 @@ test("integration: simple", (t) => {
 			workspace: duplexCollection,
 			dependencies: dependencies,
 			options: {
-				inputPattern: "/resources/**/themes/**/library.source.less"
+				inputPattern: "/resources/super/duper/looper/themes/**/library.source.less"
 			}
 		}).then(() => {
 			return Promise.all([
@@ -133,7 +133,7 @@ test("integration: imports", (t) => {
 			workspace: duplexCollection,
 			dependencies: dependencies,
 			options: {
-				inputPattern: "/resources/**/themes/**/library.source.less"
+				inputPattern: "/resources/super/duper/looper/themes/**/library.source.less"
 			}
 		}).then(() => {
 			return Promise.all([

--- a/test/lib/tasks/generateThemeDesignerResources.js
+++ b/test/lib/tasks/generateThemeDesignerResources.js
@@ -67,7 +67,7 @@ test.serial("generateThemeDesignerResources: Library", async (t) => {
 
 	const workspace = {
 		byGlob: sinon.stub().callsFake(async (globPattern) => {
-			if (globPattern === "/resources/**/themes/*/library.source.less") {
+			if (globPattern === "/resources/sap/ui/demo/lib/themes/*/library.source.less") {
 				return [librarySourceLessResource1, librarySourceLessResource2, librarySourceLessResource3];
 			} else {
 				return [];
@@ -185,7 +185,7 @@ test.serial("generateThemeDesignerResources: Library sap.ui.core", async (t) => 
 
 	const workspace = {
 		byGlob: sinon.stub().callsFake(async (globPattern) => {
-			if (globPattern === "/resources/**/themes/*/library.source.less") {
+			if (globPattern === "/resources/sap/ui/core/themes/*/library.source.less") {
 				return [librarySourceLessResource];
 			} else {
 				return [];
@@ -418,7 +418,7 @@ test.serial("generateThemeDesignerResources: .theming file missing in sap.ui.cor
 
 	const workspace = {
 		byGlob: sinon.stub().callsFake(async (globPattern) => {
-			if (globPattern === "/resources/**/themes/*/library.source.less") {
+			if (globPattern === "/resources/sap/ui/core/themes/*/library.source.less") {
 				return [librarySourceLessResource];
 			} else {
 				return [];


### PR DESCRIPTION
Themes are expected to be within a "themes" folder directly below the
library namespace.
Other "themes" folders (e.g. within sub-directories) should be ignored
and not compiled/processed.
