### PR TITLE
[FEATURE] Align JSDoc template & plugin with OpenUI5 1.87.0

### DIFF
--- a/lib/processors/jsdoc/lib/createIndexFiles.js
+++ b/lib/processors/jsdoc/lib/createIndexFiles.js
@@ -1,7 +1,7 @@
 /*
  * Node script to create cross-library API index files for use in the UI5 SDKs.
  *
- * (c) Copyright 2009-2020 SAP SE or an SAP affiliate company.
+ * (c) Copyright 2009-2021 SAP SE or an SAP affiliate company.
  * Licensed under the Apache License, Version 2.0 - see LICENSE.txt.
  */
 
@@ -247,7 +247,7 @@ function createIndexFiles(versionInfoFile, unpackedTestresourcesRoot, targetFile
 	function convertListToTree(symbols) {
 		let aTree = [];
 
-		// Filter out black list libraries
+		// Filter out excluded libraries
 		symbols = symbols.filter(({lib}) => ["sap.ui.documentation"].indexOf(lib) === -1);
 
 		// Create treeName and displayName

--- a/lib/processors/jsdoc/lib/transformApiJson.js
+++ b/lib/processors/jsdoc/lib/transformApiJson.js
@@ -1,7 +1,7 @@
 /*
  * Node script to preprocess api.json files for use in the UI5 SDKs.
  *
- * (c) Copyright 2009-2020 SAP SE or an SAP affiliate company.
+ * (c) Copyright 2009-2021 SAP SE or an SAP affiliate company.
  * Licensed under the Apache License, Version 2.0 - see LICENSE.txt.
  */
 
@@ -35,9 +35,10 @@ const log = (function() {
  * @param {string} sLibraryFile Path to the .library file of the library, used to extract further documentation information
  * @param {string|string[]} vDependencyAPIFiles Path of folder that contains api.json files of predecessor libs or
  *                 an array of paths of those files
+ * @param {string} sFAQDir Path to the directory containing the sources for the FAQ section in APiRef
  * @returns {Promise} A Promise that resolves after the transformation has been completed
  */
-function transformer(sInputFile, sOutputFile, sLibraryFile, vDependencyAPIFiles, options) {
+function transformer(sInputFile, sOutputFile, sLibraryFile, vDependencyAPIFiles, sFAQDir, options) {
 	const fs = options && options.fs || require("fs");
 	const returnOutputFiles = options && !!options.returnOutputFiles;
 
@@ -46,6 +47,7 @@ function transformer(sInputFile, sOutputFile, sLibraryFile, vDependencyAPIFiles,
 	log.info("  output file: " + sOutputFile);
 	log.info("  library file: " + sLibraryFile);
 	log.info("  dependency dir: " + vDependencyAPIFiles);
+	log.info("  FAQ src dir: " + sFAQDir);
 	if (options && options.fs) {
 		log.info("Using custom fs.");
 	}
@@ -786,6 +788,25 @@ function transformer(sInputFile, sOutputFile, sLibraryFile, vDependencyAPIFiles,
 	}
 
 	/**
+	 * Check for existence of FAQ data
+	 * (FAQ data must be defined as *.md files in the <code>sFAQDir</code>)
+	 * and add a boolean flag in case it exists
+	 *
+	 * @param oChainObject chain object
+	 */
+	function addFlagsForFAQData(oChainObject) {
+		if (!sFAQDir) {
+			return oChainObject;
+		}
+		oChainObject.fileData.symbols.forEach(function(symbol) {
+			if (fs.existsSync(path.join(sFAQDir, symbol.basename + ".md"))) {
+				symbol.hasFAQ = true;
+			}
+		});
+		return oChainObject;
+	}
+
+	/**
 	 * Create api.json from parsed data
 	 * @param oChainObject chain object
 	 */
@@ -946,6 +967,7 @@ function transformer(sInputFile, sOutputFile, sLibraryFile, vDependencyAPIFiles,
 		_sTopicId: "",
 		_oTopicData: {},
 		_baseTypes: [
+			// TODO this list URGENTLY needs to be replaced by the Type parser and a much smaller list
 			"sap.ui.core.any",
 			"sap.ui.core.object",
 			"sap.ui.core.function",
@@ -969,7 +991,9 @@ function transformer(sInputFile, sOutputFile, sLibraryFile, vDependencyAPIFiles,
 			"object[]",
 			"object|object[]",
 			"[object Object][]",
+			"Array<[object Object]>",
 			"Array.<[object Object]>",
+			"Object<string,string>",
 			"Object.<string,string>",
 			"function",
 			"float",
@@ -1299,7 +1323,7 @@ function transformer(sInputFile, sOutputFile, sLibraryFile, vDependencyAPIFiles,
 
 		handleExternalUrl: function (sTarget, sText) {
 			// Check if the external domain is SAP hosted
-			let bSAPHosted = /^https?:\/\/(?:www.)?[\w.]*(?:sap|hana\.ondemand|sapfioritrial)\.com/.test(sTarget);
+			let bSAPHosted = /^https?:\/\/([\w.]*\.)?(?:sap|hana\.ondemand|sapfioritrial)\.com/.test(sTarget);
 
 			return `<a target="_blank" rel="noopener" href="${sTarget}">${sText}</a>
 <img src="./resources/sap/ui/documentation/sdk/images/${bSAPHosted ? 'link-sap' : 'link-external'}.png"
@@ -2016,6 +2040,7 @@ title="Information published on ${bSAPHosted ? '' : 'non '}SAP site" class="sapU
 		.then(getAPIJSONPromise)
 		.then(loadDependencyLibraryFiles)
 		.then(transformApiJson)
+		.then(addFlagsForFAQData)
 		.then(createApiRefApiJson);
 	return p;
 

--- a/lib/processors/jsdoc/lib/ui5/plugin.js
+++ b/lib/processors/jsdoc/lib/ui5/plugin.js
@@ -1,7 +1,7 @@
 /*
  * JSDoc3 plugin for UI5 documentation generation.
  *
- * (c) Copyright 2009-2020 SAP SE or an SAP affiliate company.
+ * (c) Copyright 2009-2021 SAP SE or an SAP affiliate company.
  * Licensed under the Apache License, Version 2.0 - see LICENSE.txt.
  */
 
@@ -199,6 +199,22 @@ function error(msg) {
 	args[0] = "**** error: " + args[0];
 	console.log.apply(console, args);
 }
+
+/* errors that might fail the build in future */
+function future(msg) {
+	if ( pendingMessageHeader && !env.opts.verbose && !env.opts.debug ) {
+		if ( !env.opts.verbose && !env.opts.debug  ) {
+			console.log(pendingMessageHeader);
+		} else {
+			console.log("");
+		}
+		pendingMessageHeader = null;
+	}
+	var args = Array.prototype.slice.apply(arguments);
+	args[0] = "**** future error (ignored for now): " + args[0];
+	console.log.apply(console, args);
+}
+
 /* eslint-enable no-console */
 
 //---- path handling ---------------------------------------------------------
@@ -302,7 +318,8 @@ function collectShortcuts(body) {
 	function checkAssignment(name, valueNode) {
 		if ( valueNode.type === Syntax.Literal ) {
 			currentModule.localNames[name] = {
-				value: valueNode.value
+				value: valueNode.value,
+				raw: valueNode.raw
 			};
 			debug("compile time constant found ", name, valueNode.value);
 		} else if ( valueNode.type === Syntax.MemberExpression ) {
@@ -566,14 +583,28 @@ function getResolvedObjectName(node) {
 	return name;
 }
 
-function convertValue(node, type, propertyName) {
+/*
+ * Analyzes the given AST node that represents a value and returns an object
+ * with two properties:
+ * - 'value' contains the runtime representation of the value (e.g. a number or a string)
+ * - 'raw' contains a source code representation of the value (always string)
+ *
+ * @param {ASTNode} node Node to analyze
+ * @param {string} [type] A type name that might help to analyze the value
+ * @param {string} [propertyName] Name of the property for which the anylsis i done, only used for logging
+ * @returns {{value:any,raw:string}} An object with a runtime and a source code representation of the value
+ */
+function convertValueWithRaw(node, type, propertyName) {
 
 	var value;
 
 	if ( node.type === Syntax.Literal ) {
 
 		// 'string' or number or true or false
-		return node.value;
+		return {
+			value: node.value,
+			raw: node.raw
+		};
 
 	} else if ( node.type === Syntax.UnaryExpression
 		&& node.prefix
@@ -583,7 +614,10 @@ function convertValue(node, type, propertyName) {
 
 		// -n or +n
 		value = node.argument.value;
-		return node.operator === '-' ? -value : value;
+		return {
+			value: node.operator === '-' ? -value : value,
+			raw: node.operator + node.argument.raw
+		};
 
 	} else if ( node.type === Syntax.MemberExpression && type ) {
 
@@ -591,43 +625,74 @@ function convertValue(node, type, propertyName) {
 		value = getResolvedObjectName(node);
 		if ( value.indexOf(type + ".") === 0 ) {
 			// starts with fully qualified enum name -> cut off name
-			return value.slice(type.length + 1);
+			value = value.slice(type.length + 1);
+			return {
+				value: value,
+				raw: value
+			};
 //		} else if ( value.indexOf(type.split(".").slice(-1)[0] + ".") === 0 ) {
 //			// unqualified name might be a local name (just a guess - would need static code analysis for proper solution)
 //			return value.slice(type.split(".").slice(-1)[0].length + 1);
 		} else {
 			warning("did not understand default value '%s'%s, falling back to source", value, propertyName ? " of property '" + propertyName + "'" : "");
-			return value;
+			var raw = value;
+			if ( currentSource && node.range ) {
+				raw = currentSource.slice( node.range[0], node.range[1] );
+			}
+			return {
+				value: value,
+				raw: raw
+			};
 		}
 
 	} else if ( node.type === Syntax.Identifier ) {
 		if ( node.name === 'undefined') {
-			// undefined
-			return undefined;
+			return {
+				value: undefined,
+				raw: node.name
+			};
 		}
 		var local = currentModule.localNames[node.name];
 		if ( typeof local === 'object' && 'value' in local ) {
+			// a locally defined constant
 			// TODO check type
-			return local.value;
+			return {
+				value: local.value,
+				raw: local.raw
+			};
 		}
 	} else if ( node.type === Syntax.ArrayExpression ) {
 
 		if ( node.elements.length === 0 ) {
 			// empty array literal
-			return "[]"; // TODO return this string or an empty array
+			return {
+				value: [],
+				raw: "[]"
+			};
 		}
 
 		if ( type && type.slice(-2) === "[]" ) {
 			var componentType = type.slice(0,-2);
-			return node.elements.map( function(elem) {
-				return convertValue(elem, componentType, propertyName);
+			var array = node.elements.map( function(elem) {
+				return convertValueWithRaw(elem, componentType, propertyName);
 			});
+			return {
+				value: array.map(function(value) {
+					return value.value;
+				}),
+				raw: "[" + array.map(function(value) {
+					return value.raw;
+				}).join(", ") + "]"
+			};
 		}
 
 	} else if ( node.type === Syntax.ObjectExpression ) {
 
 		if ( node.properties.length === 0 && (type === 'object' || type === 'any') ) {
-			return {};
+			return {
+				value: {},
+				raw: "{}"
+			};
 		}
 
 	}
@@ -636,8 +701,19 @@ function convertValue(node, type, propertyName) {
 	if ( currentSource && node.range ) {
 		value = currentSource.slice( node.range[0], node.range[1] );
 	}
-	error("unexpected type of default value (type='%s', source='%s')%s, falling back to '%s'", node.type, node.toString(), propertyName ? " of property '" + propertyName + "'" : "", value);
-	return value;
+	warning("cannot understand default value%s (type='%s', source='%s'), falling back to '%s'",
+		propertyName ? " of property '" + propertyName + "'" : "",
+		node.type,
+		node.toString(), value);
+
+	return {
+		value: value,
+		raw: value
+	};
+}
+
+function convertValue(node, type, propertyName, includeRaw) {
+	return convertValueWithRaw(node, type, propertyName).value;
 }
 
 function convertStringArray(node) {
@@ -798,7 +874,7 @@ function collectClassInfo(extendCall, classDoclet) {
 				experimental : doclet && doclet.experimental,
 				visibility : (settings.visibility && settings.visibility.value.value) || "public",
 				type : (type = settings.type ? settings.type.value.value : "string"),
-				defaultValue : settings.defaultValue ? convertValue(settings.defaultValue.value, type, n) : null,
+				defaultValue : settings.defaultValue ? convertValueWithRaw(settings.defaultValue.value, type, n) : null,
 				group : settings.group ? settings.group.value.value : 'Misc',
 				bindable : settings.bindable ? !!convertValue(settings.bindable.value) : false,
 				methods: (methods = {
@@ -893,6 +969,7 @@ function collectClassInfo(extendCall, classDoclet) {
 				experimental : doclet && doclet.experimental,
 				visibility : /* (settings.visibility && settings.visibility.value.value) || */ "public",
 				allowPreventDefault : !!(settings.allowPreventDefault && settings.allowPreventDefault.value.value),
+				enableEventBubbling : !!(settings.enableEventBubbling && settings.enableEventBubbling.value.value),
 				parameters : {},
 				methods: {
 					"attach": "attach" + N,
@@ -1134,7 +1211,7 @@ function collectDataTypeInfo(extendCall, classDoclet) {
 
 var rEmptyLine = /^\s*$/;
 
-function createAutoDoc(oClassInfo, classComment, node, parser, filename, commentAlreadyProcessed) {
+function createAutoDoc(oClassInfo, classComment, doclet, node, parser, filename, commentAlreadyProcessed) {
 
 	var newStyle = !!pluginConfig.newStyle,
 		includeSettings = !!pluginConfig.includeSettingsInConstructor,
@@ -1185,6 +1262,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 	function newJSDoc(lines) {
 		//console.log("add completely new jsdoc comment to prog " + node.type + ":" + node.nodeId + ":" + Object.keys(node));
 
+		lines = Array.prototype.concat.apply([], lines); // flatten
 		lines = removeDuplicateEmptyLines(lines);
 		lines.push("@synthetic");
 
@@ -1214,9 +1292,9 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 			s = s + "|" + aggr.altTypes.join("|");
 		}
 		if ( !componentTypeOnly && aggr.cardinality === "0..n" ) {
-			// if multiple types are allowed, use Array.<> for proper grouping
+			// if multiple types are allowed, use Array<...> for proper grouping
 			if ( aggr.altTypes ) {
-				s = "Array.<" + s + ">";
+				s = "Array<" + s + ">";
 			} else {
 				s = s + "[]";
 			}
@@ -1227,6 +1305,17 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 //	function shortname(s) {
 //		return s.slice(s.lastIndexOf('.') + 1);
 //	}
+
+	function createVisibilityTags(doclet) {
+		var access = (doclet && doclet.access) || "public";
+		if ( access === "restricted" ) {
+			return [
+				"@private",
+				"@ui5-restricted" + (doclet.__ui5 && Array.isArray(doclet.__ui5.stakeholders) ? " " + doclet.__ui5.stakeholders.join(", ") : "")
+			];
+		}
+		return "@" + access;
+	}
 
 	var HUNGARIAN_PREFIXES = {
 		'int' : 'i',
@@ -1250,19 +1339,14 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 	function generateParamTag(n, type, description, defaultValue){
 		var s = "@param {" + info.type + "} ";
 
-		if (defaultValue !== null) {
-			s += "[" +  varname(n, type, true) + "=";
-			if (type === "string"){
-				defaultValue = "\"" + defaultValue + "\"";
-			}
-			s += defaultValue + "]";
-
+		if (defaultValue !== null){
+			s += "[" +  varname(n, type, true) + "=" + defaultValue.raw + "]";
 		} else {
 			s += varname(n, type, true);
 		}
 
 		s += " " + description;
-		
+
 		return s;
 	}
 
@@ -1273,6 +1357,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 	var m = /(?:^|\r\n|\n|\r)[ \t]*\**[ \t]*@[a-zA-Z]/.exec(rawClassComment);
 	p = m ? m.index : -1;
 	var hasSettingsDocs = rawClassComment.indexOf("The supported settings are:") >= 0;
+	var visibility = createVisibilityTags(doclet);
 
 	// heuristic to recognize a ManagedObject
 	var isManagedObject = (
@@ -1318,7 +1403,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 					lines.push("<li>Properties");
 					lines.push("<ul>");
 					for (n in oClassInfo.properties) {
-						lines.push("<li>{@link " + rname("get", n) + " " + n + "} : " + oClassInfo.properties[n].type + (oClassInfo.properties[n].defaultValue !== null ? " (default: " + oClassInfo.properties[n].defaultValue + ")" : "") + (oClassInfo.defaultProperty == n ? " (default)" : "") + "</li>");
+						lines.push("<li>{@link " + rname("get", n) + " " + n + "} : " + oClassInfo.properties[n].type + (oClassInfo.properties[n].defaultValue !== null && oClassInfo.properties[n].defaultValue.value !== null ? " (default: " + oClassInfo.properties[n].defaultValue.raw + ")" : "") + (oClassInfo.defaultProperty == n ? " (default)" : "") + "</li>");
 					}
 					lines.push("</ul>");
 					lines.push("</li>");
@@ -1397,7 +1482,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 		"Returns a metadata object for class " + oClassInfo.name + ".",
 		"",
 		"@returns {sap.ui.base.Metadata} Metadata object describing this class",
-		"@public",
+		visibility,
 		"@static",
 		"@name " + name("getMetadata", "", true),
 		"@function"
@@ -1414,7 +1499,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 			"@param {object} [oClassInfo] Object literal with information about the class",
 			"@param {function} [FNMetaImpl] Constructor function for the metadata object; if not given, it defaults to the metadata implementation used by this class",
 			"@returns {function} Created class / constructor function",
-			"@public",
+			visibility,
 			"@static",
 			"@name " + name("extend", "", true),
 			"@function"
@@ -1433,12 +1518,14 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 			"",
 			!newStyle && info.doc ? info.doc : "",
 			"",
-			info.defaultValue !== null ? "Default value is <code>" + (info.defaultValue === "" ? "empty string" : info.defaultValue) + "</code>." : "",
+			info.defaultValue !== null && info.defaultValue.value !== null
+				? "Default value is <code>" + (info.defaultValue.value === "" ? "empty string" : info.defaultValue.raw) + "</code>."
+				: "",
 			"@returns {" + info.type + "} Value of property <code>" + n + "</code>",
 			info.since ? "@since " + info.since : "",
 			info.deprecation ? "@deprecated " + info.deprecation : "",
 			info.experimental ? "@experimental " + info.experimental : "",
-			"@public",
+			visibility,
 			"@name " + name("get",n),
 			"@function"
 		]);
@@ -1449,13 +1536,15 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 			"",
 			"When called with a value of <code>null</code> or <code>undefined</code>, the default value of the property will be restored.",
 			"",
-			info.defaultValue !== null ? "Default value is <code>" + (info.defaultValue === "" ? "empty string" : info.defaultValue) + "</code>." : "",
+			info.defaultValue !== null && info.defaultValue.value !== null
+				? "Default value is <code>" + (info.defaultValue.value === "" ? "empty string" : info.defaultValue.raw) + "</code>."
+				: "",
 			generateParamTag(n, info.type, "New value for property <code>" + n + "</code>", info.defaultValue),
 			"@returns {" + oClassInfo.name + "} Reference to <code>this</code> in order to allow method chaining",
 			info.since ? "@since " + info.since : "",
 			info.deprecation ? "@deprecated " + info.deprecation : "",
 			info.experimental ? "@experimental " + info.experimental : "",
-			"@public",
+			visibility,
 			"@name " + name("set",n),
 			"@function"
 		]);
@@ -1470,7 +1559,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("bind",n),
 				"@function"
 			]);
@@ -1480,7 +1569,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("unbind",n),
 				"@function"
 			]);
@@ -1504,7 +1593,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 			info.since ? "@since " + info.since : "",
 			info.deprecation ? "@deprecated " + info.deprecation : "",
 			info.experimental ? "@experimental " + info.experimental : "",
-			"@public",
+			visibility,
 			"@name " + name("get",n),
 			"@function"
 		]);
@@ -1524,7 +1613,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("insert",n1),
 				"@function"
 			]);
@@ -1537,7 +1626,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("add",n1),
 				"@function"
 			]);
@@ -1549,7 +1638,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("remove", n1),
 				"@function"
 			]);
@@ -1561,7 +1650,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("removeAll", n),
 				"@function"
 			]);
@@ -1574,7 +1663,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("indexOf", n1),
 				"@function"
 			]);
@@ -1586,7 +1675,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("set", n),
 				"@function"
 			]);
@@ -1597,7 +1686,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 			info.since ? "@since " + info.since : "",
 			info.deprecation ? "@deprecated " + info.deprecation : "",
 			info.experimental ? "@experimental " + info.experimental : "",
-			"@public",
+			visibility,
 			"@name " + name("destroy", n),
 			"@function"
 		]);
@@ -1612,7 +1701,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("bind",n),
 				"@function"
 			]);
@@ -1622,7 +1711,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("unbind",n),
 				"@function"
 			]);
@@ -1647,7 +1736,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 			info.since ? "@since " + info.since : "",
 			info.deprecation ? "@deprecated " + info.deprecation : "",
 			info.experimental ? "@experimental " + info.experimental : "",
-			"@public",
+			visibility,
 			"@name " + name("get",n),
 			"@function"
 		]);
@@ -1661,7 +1750,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("add",n1),
 				"@function"
 			]);
@@ -1672,7 +1761,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("remove", n1),
 				"@function"
 			]);
@@ -1682,7 +1771,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("removeAll", n),
 				"@function"
 			]);
@@ -1694,7 +1783,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				info.since ? "@since " + info.since : "",
 				info.deprecation ? "@deprecated " + info.deprecation : "",
 				info.experimental ? "@experimental " + info.experimental : "",
-				"@public",
+				visibility,
 				"@name " + name("set", n),
 				"@function"
 			]);
@@ -1708,6 +1797,10 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 
 		lines = [
 			info.doc ? info.doc : "",
+			"",
+			info.allowPreventDefault ? "Listeners may prevent the default action of this event by calling the <code>preventDefault</code> method on the event object." : "",
+			"",
+			info.enableEventBubbling ? "This event bubbles up the control hierarchy." : "",
 			"",
 			"@name " + oClassInfo.name + "#" + n,
 			"@event",
@@ -1723,7 +1816,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 				"@param {" + (info.parameters[pName].type || "") + "} oControlEvent.getParameters." + pName + " " + (info.parameters[pName].doc || "")
 			);
 		}
-		lines.push("@public");
+		lines.push(visibility);
 		newJSDoc(lines);
 
 		newJSDoc([
@@ -1742,7 +1835,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 			"           [oListener] Context object to call the event handler with. Defaults to this <code>" + oClassInfo.name + "</code> itself",
 			"",
 			"@returns {" + oClassInfo.name + "} Reference to <code>this</code> in order to allow method chaining",
-			"@public",
+			visibility,
 			info.since ? "@since " + info.since : "",
 			info.deprecation ? "@deprecated " + info.deprecation : "",
 			info.experimental ? "@experimental " + info.experimental : "",
@@ -1762,7 +1855,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 			info.since ? "@since " + info.since : "",
 			info.deprecation ? "@deprecated " + info.deprecation : "",
 			info.experimental ? "@experimental " + info.experimental : "",
-			"@public",
+			visibility,
 			"@name " + name("detach", n),
 			"@function"
 		]);
@@ -1774,7 +1867,8 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 		if ( info.allowPreventDefault ) {
 			lines.push(
 			"",
-			"Listeners may prevent the default action of this event by using the <code>preventDefault</code>-method on the event object.",
+			"Listeners may prevent the default action of this event by calling the <code>preventDefault</code> method on the event object.",
+			"The return value of this method indicates whether the default action should be executed.",
 			"");
 		}
 		lines.push(
@@ -1795,7 +1889,7 @@ function createAutoDoc(oClassInfo, classComment, node, parser, filename, comment
 			lines.push("@returns {" + oClassInfo.name + "} Reference to <code>this</code> in order to allow method chaining");
 		}
 		lines.push(
-			"@protected",
+			visibility === "@public" ? "@protected" : visibility,
 			info.since ? "@since " + info.since : "",
 			info.deprecation ? "@deprecated " + info.deprecation : "",
 			info.experimental ? "@experimental " + info.experimental : "",
@@ -2084,11 +2178,19 @@ exports.defineTags = function(dictionary) {
 		onTagged: function(doclet, tag) {
 			doclet.access = 'restricted';
 			if ( tag.value ) {
-				ui5data(doclet).stakeholders = tag.value.trim().split(/(?:\s*,\s*|\s+)/);
+				ui5data(doclet).stakeholders = tag.value.trim().split(/\s*,\s*/);
 			}
 		}
 	});
-	dictionary.defineSynonym('ui5-restricted', 'sap-restricted');
+	dictionary.defineTag('sap-restricted', {
+		onTagged: function(doclet, tag) {
+			future("Tag @sap-restricted has been deprecated, use @ui5-restricted instead");
+			doclet.access = 'restricted';
+			if ( tag.value ) {
+				ui5data(doclet).stakeholders = tag.value.trim().split(/\s*,\s*/);
+			}
+		}
+	});
 
 	/**
 	 * Mark a doclet as synthetic.
@@ -2121,6 +2223,16 @@ exports.defineTags = function(dictionary) {
 		mustNotHaveValue: true,
 		onTagged: function(doclet, tag) {
 			doclet.hideconstructor = true;
+		}
+	});
+
+	/**
+	 * A first-class member with this tag has no module export.
+	 */
+	dictionary.defineTag("ui5-global-only", {
+		mustNotHaveValue: true,
+		onTagged: function(doclet, tag) {
+			ui5data(doclet).globalOnly = true;
 		}
 	});
 };
@@ -2205,7 +2317,7 @@ exports.handlers = {
 
 		// JSDoc 3 has a bug when it encounters a property in an object literal with an empty string as name
 		// (e.g. { "" : something } will result in a doclet without longname
-		if ( !e.doclet.longname ) {
+		if ( !e.doclet.longname && !e.doclet.undocumented ) {
 			if ( e.doclet.memberof ) {
 				e.doclet.longname = e.doclet.memberof + "." + e.doclet.name; // TODO '.' depends on scope?
 				warning("found doclet without longname, derived longname: " + e.doclet.longname + " " + location(e.doclet));
@@ -2396,7 +2508,7 @@ exports.astNodeVisitor = {
 			var doclet = comment && new Doclet(getRawComment(comment), {});
 			var classInfo = collectClassInfo(extendCall, doclet);
 			if ( classInfo ) {
-				createAutoDoc(classInfo, comment, extendCall, parser, currentSourceName, commentAlreadyProcessed);
+				createAutoDoc(classInfo, comment, doclet, extendCall, parser, currentSourceName, commentAlreadyProcessed);
 			}
 		}
 

--- a/lib/processors/jsdoc/lib/ui5/template/publish.js
+++ b/lib/processors/jsdoc/lib/ui5/template/publish.js
@@ -3793,9 +3793,25 @@ function createAPIXML(symbols, filename, options) {
 		return !!symbol && symbol.kind === "enum";
 	}
 
+	var replacement = {
+		"\t": "\\t",
+		"\n": "\\n",
+		"\r": "\\r",
+		"\"": "\\\"",
+		"\\": "\\\\"
+	};
+
+	/**
+	 * Converts the given value into its JavaScript source code format.
+	 *
+	 * Strings will be enclosed in double quotes with special chars being escaped,
+	 * all other values will be used 'literally'.
+	 */
 	function toRaw(value, type) {
 		if ( typeof value === "string" && !isEnum(type) ) {
-			value = "\"" + value.replace(/"/g, "\\\"") + "\"";
+			return "\"" + value.replace(/[\u0000-\u001f"\\]/g, function(c) {
+				return replacement[c] || "\\u" + c.charCodeAt(0).toString(16).padStart(4, "0");
+			}) + "\"";
 		}
 		return value;
 	}

--- a/lib/processors/jsdoc/lib/ui5/template/publish.js
+++ b/lib/processors/jsdoc/lib/ui5/template/publish.js
@@ -1,7 +1,7 @@
 /*
  * JSDoc3 template for UI5 documentation generation.
  *
- * (c) Copyright 2009-2020 SAP SE or an SAP affiliate company.
+ * (c) Copyright 2009-2021 SAP SE or an SAP affiliate company.
  * Licensed under the Apache License, Version 2.0 - see LICENSE.txt.
  */
 
@@ -92,6 +92,13 @@ function error(msg) {
 	console.log.apply(console, args);
 }
 
+/* errors that might fail the build in future */
+function future(msg) {
+	var args = Array.prototype.slice.apply(arguments);
+	args[0] = "**** future error (ignored for now): " + args[0];
+	console.log.apply(console, args);
+}
+
 function debug() {
 	if ( env.opts.debug ) {
 		console.log.apply(console, arguments);
@@ -144,7 +151,11 @@ function loadExternalSymbols(apiJsonFolder) {
 	try {
 		files = fs.readdirSync(templateConf.apiJsonFolder);
 	} catch (e) {
-		error("failed to list symbol files in folder '" + apiJsonFolder + "': " + (e.message || e));
+		if ( e.code === "ENOENT" ) {
+			warning("folder with external symbols does not exist (ignored)");
+		} else {
+			error("failed to list symbol files in folder '" + apiJsonFolder + "': " + (e.message || e));
+		}
 		return;
 	}
 
@@ -431,7 +442,8 @@ function publish(symbolSet) {
 			var v = {
 				resource: value.resource,
 				module: value.module,
-				stakeholders: value.stakeholders
+				stakeholders: value.stakeholders,
+				globalOnly: value.globalOnly
 			};
 			if ( value.derived ) {
 				v.derived = value.derived.map(function($) { return $.longname; });
@@ -1310,7 +1322,7 @@ function processTemplate(sTemplateName, data) {
 	} catch (e) {
 		if ( e.source ) {
 			var filename = path.join(env.opts.destination, sTemplateName + ".js");
-			error("**** failed to process template, source written to " + filename);
+			error("failed to process template, source written to " + filename);
 			fs.mkPath(path.dirname(filename));
 			fs.writeFileSync(filename, e.source, 'utf8');
 		}
@@ -1658,7 +1670,7 @@ function groupByContributors(symbol, aBorrowedMembers) {
 				mContributors[$.memberof].items.push($);
 			}
 		} else {
-			error("symbol '" + borrowed.longname + "' has 'inherited' flag set,"
+			future("symbol '" + borrowed.longname + "' has 'inherited' flag set,"
 				+ " but inherits missing symbol '" + borrowed.inherits + "' (skipped)");
 		}
 	});
@@ -2009,7 +2021,7 @@ TypeParser.LinkBuilder.prototype = {
 		if ( componentType.needsParenthesis || componentType.simpleComponent === false ) {
 			return {
 				simpleComponent: false,
-				str: "Array.<" + this.safe(componentType) + ">"
+				str: "Array" + this.lt + this.safe(componentType) + this.gt
 			};
 		}
 		return {
@@ -2020,24 +2032,24 @@ TypeParser.LinkBuilder.prototype = {
 		if ( keyType.synthetic ) {
 			return {
 				simpleComponent: false,
-				str: "Object." + this.lt + this.safe(valueType) + this.gt
+				str: "Object" + this.lt + this.safe(valueType) + this.gt
 			};
 		}
 		return {
 			simpleComponent: false,
-			str: "Object." + this.lt + this.safe(keyType) + "," + this.safe(valueType) + this.gt
+			str: "Object" + this.lt + this.safe(keyType) + "," + this.safe(valueType) + this.gt
 		};
 	},
 	set: function(elementType) {
 		return {
 			simpleComponent: false,
-			str: 'Set.' + this.lt + this.safe(elementType) + this.gt
+			str: 'Set' + this.lt + this.safe(elementType) + this.gt
 		};
 	},
 	promise: function(fulfillmentType) {
 		return {
 			simpleComponent: false,
-			str: 'Promise.' + this.lt + this.safe(fulfillmentType) + this.gt
+			str: 'Promise' + this.lt + this.safe(fulfillmentType) + this.gt
 		};
 	},
 	"function": function(paramTypes, returnType) {
@@ -2122,7 +2134,7 @@ function _processTypeString(type, builder) {
 		try {
 			return typeParser.parse( type, builder ).str;
 		} catch (e) {
-			error("failed to parse type string '" + type + "': " + e);
+			future("failed to parse type string '" + type + "': " + e);
 			return type;
 		}
 	}
@@ -2145,7 +2157,7 @@ function isArrayType(type) {
 			var ast = typeParser.parse( type, TypeParser.ASTBuilder );
 			return ( ast.type === 'array' || (ast.type === 'union' && ast.types.some( function(subtype) { return subtype.type === 'array'; })) );
 		} catch (e) {
-			error("failed to parse type string '" + type + "': " + e);
+			future("failed to parse type string '" + type + "': " + e);
 		}
 	}
 	return false;
@@ -2248,6 +2260,8 @@ function createAPIJSON(symbols, filename) {
 	info("  apiJson saved as " + filename);
 }
 
+var GLOBAL_ONLY = {};
+
 function createAPIJSON4Symbol(symbol, omitDefaults) {
 
 	var obj = [];
@@ -2310,6 +2324,17 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 			curr[name] = true;
 		} else {
 			curr[name] = raw ? value : String(value);
+		}
+	}
+
+	function attribSince(since) {
+		if ( since ) {
+			var version = extractVersion(since);
+			if ( version ) {
+				attrib("since", version);
+			} else {
+				future("**** since information not parsable: '" + since + "'");
+			}
 		}
 	}
 
@@ -2386,6 +2411,13 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 		}
 	}
 
+	function stakeholders($) {
+		if ( $.access === 'restricted' ) {
+			return $.__ui5.stakeholders;
+		}
+		// return undefined
+	}
+
 	function exceptions(symbol) {
 		var array = symbol.exceptions,
 			j, exception;
@@ -2412,6 +2444,12 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 		endCollection("throws");
 	}
 
+	function stakeholderList(tagname, stakeholders) {
+		if ( Array.isArray(stakeholders) && stakeholders.length > 0 ) {
+			curr[tagname] = stakeholders.slice();
+		}
+	}
+
 	function methodList(tagname, methods) {
 		methods = methods && Object.keys(methods).map(function(key) { return methods[key]; });
 		if ( methods != null && methods.length > 0 ) {
@@ -2432,7 +2470,7 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 		if ( $.augments && $.augments.length > 0 ) {
 			var baseSymbol = $.augments[0];
 			if ( visited.hasOwnProperty(baseSymbol) ) {
-				error("detected cyclic inheritance when looking at " + $.longname + ": " + JSON.stringify(visited));
+				future("detected cyclic inheritance when looking at " + $.longname + ": " + JSON.stringify(visited));
 				return false;
 			}
 			visited[baseSymbol] = true;
@@ -2471,9 +2509,7 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 				attrib("name", special.name);
 				attrib("type", special.type);
 				attrib("visibility", special.visibility, 'public');
-				if ( special.since ) {
-					attrib("since", extractVersion(special.since));
-				}
+				attribSince(special.since);
 				tag("description", normalizeWS(special.doc), true);
 				tagWithSince("experimental", special.experimental);
 				tagWithSince("deprecated", special.deprecation);
@@ -2487,15 +2523,18 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 			collection("properties");
 			for ( n in metadata.properties ) {
 				var prop = metadata.properties[n];
+				var defaultValue = prop.defaultValue != null ? prop.defaultValue.value : null;
+				// JSON can't transport a value of undefined, so represent it as string
+				if ( defaultValue === undefined ) {
+					defaultValue = String(defaultValue);
+				}
 				tag("property");
 				attrib("name", prop.name);
 				attrib("type", prop.type, 'string');
-				attrib("defaultValue", prop.defaultValue, null, /* raw = */true);
+				attrib("defaultValue", defaultValue, null, /* raw = */true);
 				attrib("group", prop.group, 'Misc');
 				attrib("visibility", prop.visibility, 'public');
-				if ( prop.since ) {
-					attrib("since", extractVersion(prop.since));
-				}
+				attribSince(prop.since);
 				if ( prop.bindable ) {
 					attrib("bindable", prop.bindable, false, /* raw = */true);
 				}
@@ -2529,9 +2568,7 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 				}
 				attrib("cardinality", aggr.cardinality, '0..n');
 				attrib("visibility", aggr.visibility, 'public');
-				if ( aggr.since ) {
-					attrib("since", extractVersion(aggr.since));
-				}
+				attribSince(aggr.since);
 				if ( aggr.bindable ) {
 					attrib("bindable", aggr.bindable, false, /* raw = */true);
 				}
@@ -2561,9 +2598,7 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 				attrib("type", assoc.type, 'sap.ui.core.Control');
 				attrib("cardinality", assoc.cardinality, '0..1');
 				attrib("visibility", assoc.visibility, 'public');
-				if ( assoc.since ) {
-					attrib("since", extractVersion(assoc.since));
-				}
+				attribSince(assoc.since);
 				tag("description", normalizeWS(assoc.doc), true);
 				tagWithSince("experimental", assoc.experimental);
 				tagWithSince("deprecated", assoc.deprecation);
@@ -2580,9 +2615,13 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 				tag("event");
 				attrib("name", event.name);
 				attrib("visibility", event.visibility, 'public');
-				if ( event.since ) {
-					attrib("since", extractVersion(event.since));
+				if ( event.allowPreventDefault ) {
+					attrib("allowPreventDefault", event.allowPreventDefault, false, /* raw = */true);
 				}
+				if ( event.enableEventBubbling ) {
+					attrib("enableEventBubbling", event.enableEventBubbling, false, /* raw = */true);
+				}
+				attribSince(event.since);
 				tag("description", normalizeWS(event.doc), true);
 				tagWithSince("experimental", event.experimental);
 				tagWithSince("deprecated", event.deprecation);
@@ -2594,9 +2633,7 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 							tag(pn);
 							attrib("name", pn);
 							attrib("type", param.type);
-							if ( param.since ) {
-								attrib("since", extractVersion(param.since));
-							}
+							attribSince(param.since);
 							tag("description", normalizeWS(param.doc), true);
 							tagWithSince("experimental", param.experimental);
 							tagWithSince("deprecated", param.deprecation);
@@ -2626,9 +2663,7 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 				if ( anno.appliesTo && anno.appliesTo.length > 0 ) {
 					curr.appliesTo = anno.appliesTo.slice();
 				}
-				if ( anno.since ) {
-					attrib("since", extractVersion(anno.since));
-				}
+				attribSince(anno.since);
 				tag("description", normalizeWS(anno.doc), true);
 				tagWithSince("deprecated", anno.deprecation);
 				closeTag("annotation");
@@ -2679,9 +2714,7 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 			if ( params[i].defaultvalue !== undefined ) {
 				attrib("defaultValue", params[i].defaultvalue, undefined, /* raw = */true);
 			}
-			if ( params[i].since ) {
-				attrib("since", extractVersion(params[i].since));
-			}
+			attribSince(params[i].since);
 
 			writeParameterProperties(params[i], params);
 
@@ -2732,9 +2765,7 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 				if ( param.defaultvalue !== undefined ) {
 					attrib("defaultValue", param.defaultvalue, undefined, /* raw = */true);
 				}
-				if ( param.since ) {
-					attrib("since", extractVersion(param.since));
-				}
+				attribSince(param.since);
 				writeParameterProperties(param, member.params);
 				tag("description", normalizeWS(param.description), true);
 				tagWithSince("experimental", param.experimental);
@@ -2758,15 +2789,16 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 		attrib("name", name || member.name);
 		if ( member.__ui5.module && member.__ui5.module !== symbol.__ui5.module ) {
 			attrib("module", member.__ui5.module);
-			attrib("export", undefined, '', true);
+			attrib("export", member.__ui5.globalOnly ? GLOBAL_ONLY : undefined, '', true);
 		}
 		attrib("visibility", visibility(member), 'public');
+		if ( stakeholders(member) ) {
+			stakeholderList("allowedFor", stakeholders(member));
+		}
 		if ( member.scope === 'static' ) {
 			attrib("static", true, false, /* raw = */true);
 		}
-		if ( member.since ) {
-			attrib("since", extractVersion(member.since));
-		}
+		attribSince(member.since);
 		if ( member.tags && member.tags.some(function(tag) { return tag.title === 'ui5-metamodel'; }) ) {
 			attrib('ui5-metamodel', true, false, /* raw = */true);
 		}
@@ -2832,7 +2864,7 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 	}
 	if ( symbol.__ui5.module ) {
 		attrib("module", symbol.__ui5.module);
-		attrib("export", undefined, '', true);
+		attrib("export", symbol.__ui5.globalOnly ? GLOBAL_ONLY : undefined, '', true);
 	}
 	if ( /* TODO (kind === 'class') && */ symbol.virtual ) {
 		// Note reg. the TODO: only one unexpected occurrence found in DragSession (DragAndDrop.js)
@@ -2846,9 +2878,10 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 		attrib("static", true, false, /* raw = */true);
 	}
 	attrib("visibility", visibility(symbol), 'public');
-	if ( symbol.since ) {
-		attrib("since", extractVersion(symbol.since));
+	if ( stakeholders(symbol) ) {
+		stakeholderList("allowedFor", stakeholders(symbol));
 	}
+	attribSince(symbol.since);
 	/* TODO if ( kind === 'class' || kind === 'interface' ) { */
 		// Note reg. the TODO: some objects document that they extend other objects. JSDoc seems to support this use case
 		// (properties show up as 'borrowed') and the borrowed entities also show up in the SDK (but not the 'extends' relationship itself)
@@ -2896,6 +2929,9 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 
 			tag("constructor");
 			attrib("visibility", visibility(symbol));
+			if ( stakeholders(symbol) ) {
+				stakeholderList("allowedFor", stakeholders(symbol));
+			}
 			methodSignature(symbol, /* suppressReturnValue = */ true);
 
 			tag("description", normalizeWS(symbol.description), true);
@@ -2941,6 +2977,9 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 				attrib("name", prop.name);
 				attrib("type", listTypes(prop.type));
 				attrib("visibility", visibility(symbol), 'public'); // properties inherit visibility of typedef
+				if ( stakeholders(symbol) ) {
+					stakeholderList("allowedFor", stakeholders(symbol));
+				}
 				tag("description", normalizeWS(prop.description), true);
 				closeTag("property");
 			});
@@ -2967,18 +3006,19 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 				attrib("name", member.name);
 				if ( member.__ui5.module && member.__ui5.module !== symbol.__ui5.module ) {
 					attrib("module", member.__ui5.module);
-					attrib("export", undefined, '', true);
+					attrib("export", member.__ui5.globalOnly ? GLOBAL_ONLY : undefined, '', true);
 				}
 				if ( kind === 'enum' && !standardEnum && member.__ui5.value !== undefined ) {
 					attrib("value", member.__ui5.value, undefined, /* raw = */true);
 				}
 				attrib("visibility", visibility(member), 'public');
+				if ( stakeholders(member) ) {
+					stakeholderList("allowedFor", stakeholders(member));
+				}
 				if ( member.scope === 'static' ) {
 					attrib("static", true, false, /* raw = */true);
 				}
-				if ( member.since ) {
-					attrib("since", extractVersion(member.since));
-				}
+				attribSince(member.since);
 				attrib("type", listTypes(member.type));
 				tag("description", normalizeWS(member.description), true);
 				tagWithSince("experimental", member.experimental);
@@ -3002,15 +3042,16 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 				attrib("name", member.name);
 				if ( member.__ui5.module && member.__ui5.module !== symbol.__ui5.module ) {
 					attrib("module", member.__ui5.module);
-					attrib("export", undefined, '', true);
+					attrib("export", member.__ui5.globalOnly ? GLOBAL_ONLY : undefined, '', true);
 				}
 				attrib("visibility", visibility(member), 'public');
+				if ( stakeholders(member) ) {
+					stakeholderList("allowedFor", stakeholders(member));
+				}
 				if ( member.scope === 'static' ) {
 					attrib("static", true, false, /* raw = */true);
 				}
-				if ( member.since ) {
-					attrib("since", extractVersion(member.since));
-				}
+				attribSince(member.since);
 
 				if ( member.params && member.params.length > 0 ) {
 					collection("parameters");
@@ -3060,7 +3101,7 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 					member.__ui5.members.forEach(function($) {
 						if ( $.kind === 'function' && $.scope === 'static'
 							 && conf.filter($) && !$.inherited ) {
-							error("exporting nested function '" + member.name + "." + $.name + "'");
+							future("exporting nested function '" + member.name + "." + $.name + "'");
 							writeMethod($, member.name + "." + $.name);
 						}
 					});
@@ -3122,6 +3163,9 @@ function postProcessAPIJSON(api) {
 
 	function guessExports(moduleName, symbols) {
 
+		// a non-stringifiable special value for unresolved exports
+		var UNRESOLVED = function() {};
+
 		symbols = symbols.sort(function(a,b) {
 			if ( a.name === b.name ) {
 				return 0;
@@ -3141,10 +3185,11 @@ function postProcessAPIJSON(api) {
 			defaultExport = moduleName.replace(/\/library$/, "").replace(/\//g, ".");
 		}
 
+		// Pass 1: determine exports where possible, mark others with UNRESOLVED
 		symbols.forEach(function(symbol) {
 			// debug("check ", symbol.name, "against", defaultExport, "and", moduleNamePath);
-			if ( symbol.symbol.kind === "typedef" || symbol.symbol.kind === "interface" ) {
-				// type definitions and interfaces have no representation on module level
+			if ( symbol.symbol.kind === "typedef" || symbol.symbol.kind === "interface" || symbol.symbol.export === GLOBAL_ONLY ) {
+				// type definitions, interfaces and symbols marked with @ui5-global-only have no representation on module level
 				symbol.symbol.export = undefined;
 			} else if ( symbol.name === moduleNamePath ) {
 				// symbol name is the same as the module namepath -> symbol is the default export
@@ -3162,11 +3207,24 @@ function postProcessAPIJSON(api) {
 				//debug("    " + symbol.name.slice(defaultExport.length + 1) + ":" + symbol.name);
 			} else {
 				// default export is not a prefix of the symbol name -> no way to access it in AMD
+				symbol.symbol.export = UNRESOLVED;
+			}
+		});
+
+		// Pass 2: check whether unresolved exports are critical or not
+		symbols.forEach(function(symbol) {
+			if ( symbol.symbol.export === UNRESOLVED ) {
 				symbol.symbol.export = undefined;
+				// an export is expected when a symbol is not a namespace or
+				// when a namespace has children from the same module that are also lacking an export
 				if ( symbol.symbol.kind !== "namespace"
-					 || (symbol.symbol.properties && symbol.symbol.properties.length > 0)
-					 || (symbol.symbol.methods && symbol.symbol.methods.length > 0) ) {
-					error("could not identify export name of '" + symbol.name + "', contained in module '" + moduleName + "'");
+					 || (symbol.symbol.properties && symbol.symbol.properties.some(function(prop) {
+						 return prop.module === symbol.symbol.module && prop.export == null;
+					 }) )
+					 || (symbol.symbol.methods && symbol.symbol.methods.some(function(method) {
+						 return method.module === symbol.symbol.module && method.export == null;
+					 }) ) ) {
+					future("could not identify export name of '" + symbol.name + "', contained in module '" + moduleName + "'");
 				} else {
 					debug("could not identify export name of " + symbol.symbol.kind + " '" + symbol.name + "', contained in module '" + moduleName + "'");
 				}
@@ -3406,7 +3464,7 @@ function validateAPIJSON(api) {
 			var ast = typeParser.parse(type.type);
 			_check(ast);
 		} catch (e) {
-			error(e);
+			future(e);
 			reportError(type.type, "failed to parse type of " + hint);
 		}
 	}
@@ -3441,7 +3499,7 @@ function validateAPIJSON(api) {
 		if ( oIntfAPI.methods ) {
 			oIntfAPI.methods.forEach(function(intfMethod) {
 				// search for method implementation
-				var implMethod = symbol.methods.find(function(candidateMethod) {
+				var implMethod = symbol.methods && symbol.methods.find(function(candidateMethod) {
 					return candidateMethod.name === intfMethod.name && !candidateMethod.static;
 				});
 				if ( !implMethod ) {
@@ -3479,7 +3537,9 @@ function validateAPIJSON(api) {
 	}
 
 	function checkEnum(symbol) {
-		if ( symbol["ui5-metamodel"] && !(symbol["ui5-metadata"] && symbol["ui5-metadata"].stereotype === "enum") ) {
+		if ( symbol["ui5-metamodel"]
+			 && !(symbol["ui5-metadata"] && symbol["ui5-metadata"].stereotype === "enum")
+			 && Array.isArray(symbol.properties) && symbol.properties.length > 0 ) {
 			reportError(symbol.name, "enum is metamodel relevant but keys and values differ");
 		}
 		checkCompoundName(symbol.name, "name of " + symbol.name);
@@ -3548,21 +3608,21 @@ function validateAPIJSON(api) {
 	});
 
 	if ( Object.keys(missing).length > 0 || Object.keys(naming).length > 0 ) {
-		error("API validation errors:");
+		future("API validation errors:");
 
 		Object.keys(missing).forEach(function(type) {
 			if ( Array.isArray(missing[type]) ) {
-				error("type '" + type + "'");
+				future("type '" + type + "'");
 				missing[type].forEach(function(usage) {
-					error("  " + usage);
+					future("  " + usage);
 				});
 			}
 		});
 		Object.keys(naming).forEach(function(name) {
 			if ( Array.isArray(naming[name]) ) {
-				error("invalid name '" + name + "'");
+				future("invalid name '" + name + "'");
 				naming[name].forEach(function(usage) {
-					error("  " + usage);
+					future("  " + usage);
 				});
 			}
 		});
@@ -3728,6 +3788,18 @@ function createAPIXML(symbols, filename, options) {
 		}
 	}
 
+	function isEnum(name) {
+		var symbol = getAPIJSON(name);
+		return !!symbol && symbol.kind === "enum";
+	}
+
+	function toRaw(value, type) {
+		if ( typeof value === "string" && !isEnum(type) ) {
+			value = "\"" + value.replace(/"/g, "\\\"") + "\"";
+		}
+		return value;
+	}
+
 	function getAsString() {
 		return output.join("");
 	}
@@ -3772,7 +3844,7 @@ function createAPIXML(symbols, filename, options) {
 				attrib("name", prop.name);
 				attrib("type", prop.type, 'string');
 				if ( prop.defaultValue !== null ) {
-					attrib("defaultValue", prop.defaultValue, null);
+					attrib("defaultValue", toRaw(prop.defaultValue, prop.type));
 				}
 				attrib("visibility", prop.visibility, 'public');
 				if ( prop.since ) {
@@ -3943,7 +4015,7 @@ function createAPIXML(symbols, filename, options) {
 				attrib("type", prop.type);
 				attrib("group", prop.group, 'Misc');
 				if ( prop.defaultValue !== null ) {
-					attrib("defaultValue", typeof prop.defaultValue === 'string' ? "\"" + prop.defaultValue + "\"" : prop.defaultValue);
+					attrib("defaultValue", toRaw(prop.defaultValue, prop.type));
 				}
 				attrib("optional");
 				if ( inherited ) {


### PR DESCRIPTION
Includes the following changes

- [INTERNAL] Update copyright year to 2021
  SAP/openui5@bc6825e48

- [FIX] Corrected regular expression (SAPHosted)
  SAP/openui5@319798593

- [FEATURE] Improve documentation for restricted APIs
  SAP/openui5@cb855596b

  - generated "auto-doc" honors visibility of target class. If target
    class is restricted, generated documentation also has visibility
    restricted
  - for restricted APIs, export the list of allowed consumers to
    api.json (property name 'allowedFor')
  - fix split of allowed consumers in tag handler for '@ui5-restricted'
    (comma is the only valid separator)

- [FEATURE] Added FAQ section in ApiRef
  SAP/openui5@8d2d85e69

  An extra FAQ section will be displayed in ApiRef whenever
  FAQ content is specified.

- [INTERNAL] Change to inclusive term "excluded"/"included"
  SAP/openui5@7b2ac1edb

- [INTERNAL] Add missing props to event metadata
  SAP/openui5@ab7ab07ea

  The properties 'allowPreventDefault' and 'enableEventBubbling' had
  been missing in the API summary (api.json) for events.

- [INTERNAL] Make interface validation more robust
  SAP/openui5@32f59b31c

  The validation of an implementation against an implemented interface
  should not crash when the implementation has no methods at all.

- [INTERNAL] Minor improvements of template
  SAP/openui5@e766eeee5

- [INTERNAL] Handling of defaultValues, error logging
  SAP/openui5@3bd509b1f

  A default value of "" (empty string) was not handled properly when
  generating auto-doc comments and a default value of "undefined" was
  not represented in the final api.json.

  To avoid confusion in the log, errors that do not break the build are
  no longer reported as errors, but as 'future errors'.

  APIs that can only be addressed via their global name, not via an AMD
  dependency, can now be marked with @ui5-global-only. They are no
  longer reported as errors during the build (as they can't be fixed).

- [INTERNAL] Export only valid 'since' values
  SAP/openui5@a58310b2d

- [INTERNAL] Normalize notation for generic types
  SAP/openui5@6e4e0ea87

  For generic types, JSDoc allows two different notations, one with a
  dot between the type's name and the type parameters (e.g.
  Array.<string>) and one without the dot. The documentation for the
  Google Closure Compiler (to which JSDoc refers) already rates the
  notation with the dot as 'deprecated' (see
https://github.com/google/closure-compiler/wiki/Types-in-the-Closure-Type-System
  , Type Application), JSDoc doesn't.

  However, as the notation without the dot is also common to TypeScript
  developers, all types in the api.json will now be normalized to that
  notation.

- [INTERNAL] Add default value to JSDoc
  SAP/openui5@bb6001950

  Adding default values of function parameters to JSDoc conform notation

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [ ] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
