### PR TITLE
[FIX] JSDoc: adapt sdkTransformer to change in transformApiJson.js

### DIFF
--- a/lib/processors/jsdoc/sdkTransformer.js
+++ b/lib/processors/jsdoc/sdkTransformer.js
@@ -26,7 +26,7 @@ const sdkTransformer = async function({
 		throw new Error("[sdkTransformer]: One or more mandatory parameters not provided");
 	}
 	const fakeTargetPath = "/ignore/this/path/resource/will/be/returned";
-	const apiJsonContent = await transformer(apiJsonPath, fakeTargetPath, dotLibraryPath, dependencyApiJsonPaths, {
+	const apiJsonContent = await transformer(apiJsonPath, fakeTargetPath, dotLibraryPath, dependencyApiJsonPaths, "", {
 		fs,
 		returnOutputFiles: true
 	});

--- a/test/lib/processors/jsdoc/sdkTransformer.js
+++ b/test/lib/processors/jsdoc/sdkTransformer.js
@@ -40,10 +40,12 @@ test.serial("sdkTransformer", async (t) => {
 		"/some/path/x/api.json",
 		"/some/path/y/api.json"
 	], "transform-apijson-for-sdk called with correct argument #4");
-	t.deepEqual(transformerStub.getCall(0).args[4], {
+	t.deepEqual(transformerStub.getCall(0).args[4], "",
+		"transform-apijson-for-sdk called with correct argument #5");
+	t.deepEqual(transformerStub.getCall(0).args[5], {
 		fs: "custom fs",
 		returnOutputFiles: true
-	}, "transform-apijson-for-sdk called with correct argument #5");
+	}, "transform-apijson-for-sdk called with correct argument #6");
 
 	t.deepEqual(createResourceStub.callCount, 1, "createResource called once");
 	t.deepEqual(createResourceStub.getCall(0).args[0], {


### PR DESCRIPTION
This is just a quick fix, compensating for the new positional parameter
introduced with 0cb02acee2b070889146ef9f725cc139691f0ab2.

A more comprehensive fix should migrate the transformApiJson's API to
named parameters and add tests that ensure a working JSDoc build
including the transformation.

Additionally, a later change should also implement proper handling of
the FAQ markup feature, which has been left out for now.

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [ ] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
