### PR TITLE
[FIX] versionInfoGenerator: manifest without embeds #486

### DIFF
--- a/lib/processors/versionInfoGenerator.js
+++ b/lib/processors/versionInfoGenerator.js
@@ -299,7 +299,7 @@ const processLibraryInfo = async (libraryInfo) => {
 	const bundledComponents = new Set();
 	libraryArtifactInfo.bundledComponents = bundledComponents;
 
-	const embeds = manifestInfo.embeds; // e.g. ["sub"]
+	const embeds = manifestInfo.embeds||[]; // e.g. ["sub"]
 	// filter only embedded manifests
 	const embeddedPaths = embeds.map((embed) => {
 		return getManifestPath(libraryInfo.libraryManifest.getPath(), embed);

--- a/test/lib/processors/versionInfoGenerator.js
+++ b/test/lib/processors/versionInfoGenerator.js
@@ -293,6 +293,88 @@ test.serial("versionInfoGenerator library infos with embeds", async (t) => {
 	t.is(t.context.warnLogStub.callCount, 0);
 });
 
+test.serial("versionInfoGenerator library infos with no embeds", async (t) => {
+	const libAManifest = {
+		getPath: () => {
+			return "/resources/lib/a/manifest.json";
+		},
+		getString: async () => {
+			return JSON.stringify({
+				"sap.app": {
+					"id": "lib.a"
+				},
+				"sap.ui5": {
+					"dependencies": {
+						"minUI5Version": "1.84",
+						"libs": {
+							"my.dep": {
+								"minVersion": "1.84.0",
+								"lazy": false
+							}
+						}
+					}
+				}
+			});
+		}
+	};
+	const libA = {name: "lib.a", version: "1.2.3", libraryManifest: libAManifest};
+	const myDepManifest = {
+		getPath: () => {
+			return "/resources/my/dep/manifest.json";
+		},
+		getString: async () => {
+			return JSON.stringify({
+				"sap.app": {
+					"id": "my.dep"
+				},
+				"sap.ui5": {
+					"dependencies": {
+						"minUI5Version": "1.84",
+						"libs": {}
+					}
+				}
+			});
+		}
+	};
+	const myDep = {name: "my.dep", version: "1.2.3", libraryManifest: myDepManifest};
+	const options = {
+		rootProjectName: "myname", rootProjectVersion: "1.33.7", libraryInfos: [
+			libA, myDep
+		]};
+	const versionInfos = await versionInfoGenerator({options});
+
+	const resource = versionInfos[0];
+	const result = await resource.getString();
+
+	const oExpected = {
+		"name": "myname",
+		"version": "1.33.7",
+		"scmRevision": "",
+		"libraries": [
+			{
+				"name": "lib.a",
+				"version": "1.2.3",
+				"scmRevision": "",
+				"manifestHints": {
+					"dependencies": {
+						"libs": {
+							"my.dep": {}
+						}
+					}
+				}
+			},
+			{
+				"name": "my.dep",
+				"version": "1.2.3",
+				"scmRevision": ""
+			}
+		]
+	};
+	assertVersionInfoContent(t, oExpected, result);
+	t.is(t.context.infoLogStub.callCount, 0);
+	t.is(t.context.warnLogStub.callCount, 0);
+});
+
 test.serial("versionInfoGenerator library infos with embeds and embeddedBy (hasOwnPreload)", async (t) => {
 	const libAManifest = {
 		getPath: () => {


### PR DESCRIPTION
manifestInfo.embeds can be initial and calling map on initial value will not work, thus default to empty array when initial

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [ ] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
