### PR TITLE
[FIX] moduleBundler: Apply defaultFileTypes

### DIFF
--- a/lib/lbt/bundle/AutoSplitter.js
+++ b/lib/lbt/bundle/AutoSplitter.js
@@ -47,7 +47,7 @@ class AutoSplitter {
 		this.optimize = !!options.optimize;
 
 		// ---- resolve module definition
-		const resolvedModule = await this.resolver.resolve(moduleDef, options);
+		const resolvedModule = await this.resolver.resolve(moduleDef);
 		// ---- calculate overall size of merged module
 
 		if ( moduleDef.configuration ) {

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -133,7 +133,7 @@ class BundleBuilder {
 	}
 
 	async _createBundle(module, options) {
-		const resolvedModule = await this.resolver.resolve(module, options);
+		const resolvedModule = await this.resolver.resolve(module);
 		if ( options.skipIfEmpty && isEmptyBundle(resolvedModule) ) {
 			log.verbose("  skipping empty bundle " + module.name);
 			return undefined;

--- a/lib/lbt/bundle/Resolver.js
+++ b/lib/lbt/bundle/Resolver.js
@@ -13,6 +13,17 @@ const log = require("@ui5/logger").getLogger("lbt:bundle:Resolver");
 
 let dependencyTracker;
 
+const DEFAULT_FILE_TYPES = [
+	".js",
+	".control.xml", // XMLComposite
+	".fragment.html",
+	".fragment.json",
+	".fragment.xml",
+	".view.html",
+	".view.json",
+	".view.xml"
+];
+
 /**
  * Resolve a bundle definition.
  *
@@ -32,13 +43,11 @@ class BundleResolver {
 
 	/**
 	 * @param {ModuleDefinition} bundle Bundle definition to resolve
-	 * @param {object} [options] Options
-	 * @param {string[]} [options.defaultFileTypes]
 	 			List of default file types to which a prefix pattern shall be expanded.
 	 * @returns {Promise<ResolvedBundleDefinition>}
 	 */
-	resolve(bundle, options) {
-		const fileTypes = (options && options.defaultFileTypes) || undefined;
+	resolve(bundle) {
+		const fileTypes = bundle.defaultFileTypes || DEFAULT_FILE_TYPES;
 		let visitedResources = Object.create(null);
 		let selectedResources = Object.create(null);
 		let selectedResourcesSequence = [];

--- a/lib/processors/bundlers/moduleBundler.js
+++ b/lib/processors/bundlers/moduleBundler.js
@@ -64,16 +64,18 @@ const log = require("@ui5/logger").getLogger("builder:processors:bundlers:module
  * @property {boolean} [sort=true] Whether the modules should be sorted by their dependencies
  */
 
+/* eslint-disable max-len */
 /**
  * Module bundle definition
  *
  * @public
  * @typedef {object} ModuleBundleDefinition
  * @property {string} name The module bundle name
- * @property {string[]} [defaultFileTypes=[".js", ".fragment.xml", ".view.xml", ".properties", ".json"]]
+ * @property {string[]} [defaultFileTypes=[".js", ".control.xml", ".fragment.html", ".fragment.json", ".fragment.xml", ".view.html", ".view.json", ".view.xml"]]
  *   List of default file types to be included in the bundle
  * @property {ModuleBundleDefinitionSection[]} sections List of module bundle definition sections.
  */
+/* eslint-enable max-len */
 
 /**
  * Module bundle options

--- a/lib/tasks/bundlers/generateComponentPreload.js
+++ b/lib/tasks/bundlers/generateComponentPreload.js
@@ -68,6 +68,8 @@ module.exports = function({
 				const filters = [
 					`${namespace}/`,
 					`${namespace}/**/manifest.json`,
+					`${namespace}/changes/changes-bundle.json`,
+					`${namespace}/changes/flexibility-bundle.json`,
 					`!${namespace}/test/`
 				];
 

--- a/lib/tasks/bundlers/generateComponentPreload.js
+++ b/lib/tasks/bundlers/generateComponentPreload.js
@@ -67,8 +67,8 @@ module.exports = function({
 			const bundleDefinitions = allNamespaces.map((namespace) => {
 				const filters = [
 					`${namespace}/`,
-					`!${namespace}/test/`,
-					`!${namespace}/*.html`
+					`${namespace}/**/manifest.json`,
+					`!${namespace}/test/`
 				];
 
 				// Add configured excludes for namespace
@@ -90,7 +90,17 @@ module.exports = function({
 
 				return {
 					name: `${namespace}/Component-preload.js`,
-					defaultFileTypes: [".js", ".fragment.xml", ".view.xml", ".properties", ".json"],
+					defaultFileTypes: [
+						".js",
+						".control.xml",
+						".fragment.html",
+						".fragment.json",
+						".fragment.xml",
+						".view.html",
+						".view.json",
+						".view.xml",
+						".properties"
+					],
 					sections: [
 						{
 							mode: "preload",

--- a/lib/tasks/bundlers/generateComponentPreload.js
+++ b/lib/tasks/bundlers/generateComponentPreload.js
@@ -85,6 +85,9 @@ module.exports = function({
 				allNamespaces.forEach((ns) => {
 					if (ns !== namespace && ns.startsWith(`${namespace}/`)) {
 						filters.push(`!${ns}/`);
+						// Explicitly exclude manifest.json files of subcomponents since the general exclude above this
+						// comment only applies to the configured default file types, which do not include ".json"
+						filters.push(`!${ns}/**/manifest.json`);
 					}
 				});
 

--- a/lib/tasks/bundlers/generateLibraryPreload.js
+++ b/lib/tasks/bundlers/generateLibraryPreload.js
@@ -3,29 +3,14 @@ const moduleBundler = require("../../processors/bundlers/moduleBundler");
 const ReaderCollectionPrioritized = require("@ui5/fs").ReaderCollectionPrioritized;
 const {negateFilters} = require("../../lbt/resources/ResourceFilterList");
 
-const DEFAULT_FILE_TYPES = [
-	".js",
-	".control.xml", // XMLComposite
-	".fragment.html",
-	".fragment.json",
-	".fragment.xml",
-	".view.html",
-	".view.json",
-	".view.xml",
-	".properties",
-	".json"
-];
-
 function getDefaultLibraryPreloadFilters(namespace, excludes) {
 	const filters = [
 		`${namespace}/`,
-		`!${namespace}/.library`,
+		`${namespace}/**/manifest.json`,
 		`!${namespace}/*-preload.js`, // exclude all bundles
 		`!${namespace}/designtime/`,
 		`!${namespace}/**/*.designtime.js`,
-		`!${namespace}/**/*.support.js`,
-		`!${namespace}/themes/`,
-		`!${namespace}/messagebundle*`
+		`!${namespace}/**/*.support.js`
 	];
 
 	if (Array.isArray(excludes)) {
@@ -50,7 +35,6 @@ function getBundleDefinition(namespace, excludes) {
 	if (namespace === "sap/ui/core") {
 		return {
 			name: `${namespace}/library-preload.js`,
-			defaultFileTypes: DEFAULT_FILE_TYPES,
 			sections: [
 				{
 					// exclude the content of sap-ui-core by declaring it as 'provided'
@@ -106,7 +90,6 @@ function getBundleDefinition(namespace, excludes) {
 	}
 	return {
 		name: `${namespace}/library-preload.js`,
-		defaultFileTypes: DEFAULT_FILE_TYPES,
 		sections: [
 			{
 				mode: "preload",
@@ -122,7 +105,6 @@ function getBundleDefinition(namespace, excludes) {
 function getDesigntimeBundleDefinition(namespace) {
 	return {
 		name: `${namespace}/designtime/library-preload.designtime.js`,
-		defaultFileTypes: DEFAULT_FILE_TYPES,
 		sections: [
 			{
 				mode: "preload",
@@ -145,7 +127,6 @@ function getDesigntimeBundleDefinition(namespace) {
 function getSupportFilesBundleDefinition(namespace) {
 	return {
 		name: `${namespace}/library-preload.support.js`,
-		defaultFileTypes: DEFAULT_FILE_TYPES,
 		sections: [
 			{
 				mode: "preload",

--- a/lib/tasks/bundlers/generateStandaloneAppBundle.js
+++ b/lib/tasks/bundlers/generateStandaloneAppBundle.js
@@ -35,6 +35,8 @@ function getBundleDefinition(config) {
 			filters: [
 				`${config.namespace || ""}/`,
 				`${config.namespace || ""}/**/manifest.json`,
+				`${config.namespace || ""}/changes/changes-bundle.json`,
+				`${config.namespace || ""}/changes/flexibility-bundle.json`,
 				`!${config.namespace || ""}/test/`,
 				"sap/ui/core/Core.js"
 			],

--- a/lib/tasks/bundlers/generateStandaloneAppBundle.js
+++ b/lib/tasks/bundlers/generateStandaloneAppBundle.js
@@ -4,7 +4,17 @@ const moduleBundler = require("../../processors/bundlers/moduleBundler");
 function getBundleDefinition(config) {
 	const bundleDefinition = {
 		name: config.name,
-		defaultFileTypes: [".js", ".fragment.xml", ".view.xml", ".properties", ".json"],
+		defaultFileTypes: [
+			".js",
+			".control.xml",
+			".fragment.html",
+			".fragment.json",
+			".fragment.xml",
+			".view.html",
+			".view.json",
+			".view.xml",
+			".properties"
+		],
 		sections: []
 	};
 
@@ -23,9 +33,9 @@ function getBundleDefinition(config) {
 		bundleDefinition.sections.push({
 			mode: "preload",
 			filters: [
-				`${config.namespace|| ""}/`,
+				`${config.namespace || ""}/`,
+				`${config.namespace || ""}/**/manifest.json`,
 				`!${config.namespace || ""}/test/`,
-				`!${config.namespace || ""}/*.html`,
 				"sap/ui/core/Core.js"
 			],
 			resolve: true,

--- a/test/lib/tasks/bundlers/generateComponentPreload.js
+++ b/test/lib/tasks/bundlers/generateComponentPreload.js
@@ -63,18 +63,22 @@ test.serial("generateComponentPreload - one namespace", async (t) => {
 			bundleDefinition: {
 				defaultFileTypes: [
 					".js",
+					".control.xml",
+					".fragment.html",
+					".fragment.json",
 					".fragment.xml",
+					".view.html",
+					".view.json",
 					".view.xml",
-					".properties",
-					".json",
+					".properties"
 				],
 				name: "my/app/Component-preload.js",
 				sections: [
 					{
 						filters: [
 							"my/app/",
+							"my/app/**/manifest.json",
 							"!my/app/test/",
-							"!my/app/*.html"
 						],
 						mode: "preload",
 						renderer: false,
@@ -140,18 +144,22 @@ test.serial("generateComponentPreload - one namespace - excludes", async (t) => 
 			bundleDefinition: {
 				defaultFileTypes: [
 					".js",
+					".control.xml",
+					".fragment.html",
+					".fragment.json",
 					".fragment.xml",
+					".view.html",
+					".view.json",
 					".view.xml",
-					".properties",
-					".json",
+					".properties"
 				],
 				name: "my/app/Component-preload.js",
 				sections: [
 					{
 						filters: [
 							"my/app/",
+							"my/app/**/manifest.json",
 							"!my/app/test/",
-							"!my/app/*.html",
 							"!my/app/thirdparty/",
 							"+my/app/thirdparty/NotExcluded.js"
 						],
@@ -219,18 +227,22 @@ test.serial("generateComponentPreload - one namespace - excludes w/o namespace",
 			bundleDefinition: {
 				defaultFileTypes: [
 					".js",
+					".control.xml",
+					".fragment.html",
+					".fragment.json",
 					".fragment.xml",
+					".view.html",
+					".view.json",
 					".view.xml",
-					".properties",
-					".json",
+					".properties"
 				],
 				name: "my/app/Component-preload.js",
 				sections: [
 					{
 						filters: [
 							"my/app/",
+							"my/app/**/manifest.json",
 							"!my/app/test/",
-							"!my/app/*.html",
 							"!thirdparty/",
 						],
 						mode: "preload",
@@ -302,18 +314,22 @@ test.serial("generateComponentPreload - multiple namespaces - excludes", async (
 			bundleDefinition: {
 				defaultFileTypes: [
 					".js",
+					".control.xml",
+					".fragment.html",
+					".fragment.json",
 					".fragment.xml",
+					".view.html",
+					".view.json",
 					".view.xml",
-					".properties",
-					".json",
+					".properties"
 				],
 				name: "my/app1/Component-preload.js",
 				sections: [
 					{
 						filters: [
 							"my/app1/",
+							"my/app1/**/manifest.json",
 							"!my/app1/test/",
-							"!my/app1/*.html",
 							"!my/app1/thirdparty1/",
 							"+my/app1/thirdparty1/NotExcluded.js",
 							"!my/app2/thirdparty2/",
@@ -337,18 +353,22 @@ test.serial("generateComponentPreload - multiple namespaces - excludes", async (
 			bundleDefinition: {
 				defaultFileTypes: [
 					".js",
+					".control.xml",
+					".fragment.html",
+					".fragment.json",
 					".fragment.xml",
+					".view.html",
+					".view.json",
 					".view.xml",
-					".properties",
-					".json",
+					".properties"
 				],
 				name: "my/app2/Component-preload.js",
 				sections: [
 					{
 						filters: [
 							"my/app2/",
+							"my/app2/**/manifest.json",
 							"!my/app2/test/",
-							"!my/app2/*.html",
 							"!my/app1/thirdparty1/",
 							"!my/app2/thirdparty2/",
 							"+my/app2/thirdparty2/NotExcluded.js"
@@ -469,18 +489,22 @@ test.serial("generateComponentPreload - nested namespaces - excludes", async (t)
 			bundleDefinition: {
 				defaultFileTypes: [
 					".js",
+					".control.xml",
+					".fragment.html",
+					".fragment.json",
 					".fragment.xml",
+					".view.html",
+					".view.json",
 					".view.xml",
-					".properties",
-					".json",
+					".properties"
 				],
 				name: "my/project/component1/Component-preload.js",
 				sections: [
 					{
 						filters: [
 							"my/project/component1/",
+							"my/project/component1/**/manifest.json",
 							"!my/project/component1/test/",
-							"!my/project/component1/*.html",
 
 							// via excludes config
 							"!my/project/component1/foo/"
@@ -504,18 +528,22 @@ test.serial("generateComponentPreload - nested namespaces - excludes", async (t)
 			bundleDefinition: {
 				defaultFileTypes: [
 					".js",
+					".control.xml",
+					".fragment.html",
+					".fragment.json",
 					".fragment.xml",
+					".view.html",
+					".view.json",
 					".view.xml",
-					".properties",
-					".json",
+					".properties"
 				],
 				name: "my/project/Component-preload.js",
 				sections: [
 					{
 						filters: [
 							"my/project/",
+							"my/project/**/manifest.json",
 							"!my/project/test/",
-							"!my/project/*.html",
 
 							// via excludes config
 							"!my/project/component1/foo/",
@@ -545,18 +573,22 @@ test.serial("generateComponentPreload - nested namespaces - excludes", async (t)
 			bundleDefinition: {
 				defaultFileTypes: [
 					".js",
+					".control.xml",
+					".fragment.html",
+					".fragment.json",
 					".fragment.xml",
+					".view.html",
+					".view.json",
 					".view.xml",
-					".properties",
-					".json",
+					".properties"
 				],
 				name: "my/project/component2/Component-preload.js",
 				sections: [
 					{
 						filters: [
 							"my/project/component2/",
+							"my/project/component2/**/manifest.json",
 							"!my/project/component2/test/",
-							"!my/project/component2/*.html",
 
 							// via excludes config
 							"!my/project/component1/foo/",

--- a/test/lib/tasks/bundlers/generateComponentPreload.js
+++ b/test/lib/tasks/bundlers/generateComponentPreload.js
@@ -78,6 +78,8 @@ test.serial("generateComponentPreload - one namespace", async (t) => {
 						filters: [
 							"my/app/",
 							"my/app/**/manifest.json",
+							"my/app/changes/changes-bundle.json",
+							"my/app/changes/flexibility-bundle.json",
 							"!my/app/test/",
 						],
 						mode: "preload",
@@ -159,6 +161,8 @@ test.serial("generateComponentPreload - one namespace - excludes", async (t) => 
 						filters: [
 							"my/app/",
 							"my/app/**/manifest.json",
+							"my/app/changes/changes-bundle.json",
+							"my/app/changes/flexibility-bundle.json",
 							"!my/app/test/",
 							"!my/app/thirdparty/",
 							"+my/app/thirdparty/NotExcluded.js"
@@ -242,6 +246,8 @@ test.serial("generateComponentPreload - one namespace - excludes w/o namespace",
 						filters: [
 							"my/app/",
 							"my/app/**/manifest.json",
+							"my/app/changes/changes-bundle.json",
+							"my/app/changes/flexibility-bundle.json",
 							"!my/app/test/",
 							"!thirdparty/",
 						],
@@ -329,6 +335,8 @@ test.serial("generateComponentPreload - multiple namespaces - excludes", async (
 						filters: [
 							"my/app1/",
 							"my/app1/**/manifest.json",
+							"my/app1/changes/changes-bundle.json",
+							"my/app1/changes/flexibility-bundle.json",
 							"!my/app1/test/",
 							"!my/app1/thirdparty1/",
 							"+my/app1/thirdparty1/NotExcluded.js",
@@ -368,6 +376,8 @@ test.serial("generateComponentPreload - multiple namespaces - excludes", async (
 						filters: [
 							"my/app2/",
 							"my/app2/**/manifest.json",
+							"my/app2/changes/changes-bundle.json",
+							"my/app2/changes/flexibility-bundle.json",
 							"!my/app2/test/",
 							"!my/app1/thirdparty1/",
 							"!my/app2/thirdparty2/",
@@ -504,6 +514,8 @@ test.serial("generateComponentPreload - nested namespaces - excludes", async (t)
 						filters: [
 							"my/project/component1/",
 							"my/project/component1/**/manifest.json",
+							"my/project/component1/changes/changes-bundle.json",
+							"my/project/component1/changes/flexibility-bundle.json",
 							"!my/project/component1/test/",
 
 							// via excludes config
@@ -543,6 +555,8 @@ test.serial("generateComponentPreload - nested namespaces - excludes", async (t)
 						filters: [
 							"my/project/",
 							"my/project/**/manifest.json",
+							"my/project/changes/changes-bundle.json",
+							"my/project/changes/flexibility-bundle.json",
 							"!my/project/test/",
 
 							// via excludes config
@@ -552,7 +566,9 @@ test.serial("generateComponentPreload - nested namespaces - excludes", async (t)
 
 							// sub-namespaces are excluded
 							"!my/project/component1/",
+							"!my/project/component1/**/manifest.json",
 							"!my/project/component2/",
+							"!my/project/component2/**/manifest.json",
 						],
 						mode: "preload",
 						renderer: false,
@@ -588,6 +604,8 @@ test.serial("generateComponentPreload - nested namespaces - excludes", async (t)
 						filters: [
 							"my/project/component2/",
 							"my/project/component2/**/manifest.json",
+							"my/project/component2/changes/changes-bundle.json",
+							"my/project/component2/changes/flexibility-bundle.json",
 							"!my/project/component2/test/",
 
 							// via excludes config

--- a/test/lib/tasks/bundlers/generateLibraryPreload.js
+++ b/test/lib/tasks/bundlers/generateLibraryPreload.js
@@ -64,30 +64,16 @@ test.serial("generateLibraryPreload", async (t) => {
 	t.deepEqual(moduleBundlerStub.getCall(0).args, [{
 		options: {
 			bundleDefinition: {
-				defaultFileTypes: [
-					".js",
-					".control.xml",
-					".fragment.html",
-					".fragment.json",
-					".fragment.xml",
-					".view.html",
-					".view.json",
-					".view.xml",
-					".properties",
-					".json"
-				],
 				name: "my/lib/library-preload.js",
 				sections: [
 					{
 						filters: [
 							"my/lib/",
-							"!my/lib/.library",
+							"my/lib/**/manifest.json",
 							"!my/lib/*-preload.js",
 							"!my/lib/designtime/",
 							"!my/lib/**/*.designtime.js",
 							"!my/lib/**/*.support.js",
-							"!my/lib/themes/",
-							"!my/lib/messagebundle*",
 						],
 						mode: "preload",
 						renderer: true,
@@ -107,18 +93,6 @@ test.serial("generateLibraryPreload", async (t) => {
 	t.deepEqual(moduleBundlerStub.getCall(1).args, [{
 		options: {
 			bundleDefinition: {
-				defaultFileTypes: [
-					".js",
-					".control.xml",
-					".fragment.html",
-					".fragment.json",
-					".fragment.xml",
-					".view.html",
-					".view.json",
-					".view.xml",
-					".properties",
-					".json"
-				],
 				name: "my/lib/designtime/library-preload.designtime.js",
 				sections: [
 					{
@@ -149,18 +123,6 @@ test.serial("generateLibraryPreload", async (t) => {
 	t.deepEqual(moduleBundlerStub.getCall(2).args, [{
 		options: {
 			bundleDefinition: {
-				defaultFileTypes: [
-					".js",
-					".control.xml",
-					".fragment.html",
-					".fragment.json",
-					".fragment.xml",
-					".view.html",
-					".view.json",
-					".view.xml",
-					".properties",
-					".json"
-				],
 				name: "my/lib/library-preload.support.js",
 				sections: [
 					{
@@ -387,18 +349,6 @@ test.serial("generateLibraryPreload for sap.ui.core (w/o ui5loader.js)", async (
 	t.deepEqual(moduleBundlerStub.getCall(4).args, [{
 		options: {
 			bundleDefinition: {
-				defaultFileTypes: [
-					".js",
-					".control.xml",
-					".fragment.html",
-					".fragment.json",
-					".fragment.xml",
-					".view.html",
-					".view.json",
-					".view.xml",
-					".properties",
-					".json"
-				],
 				name: "sap/ui/core/library-preload.js",
 				sections: [
 					{
@@ -412,13 +362,11 @@ test.serial("generateLibraryPreload for sap.ui.core (w/o ui5loader.js)", async (
 					{
 						filters: [
 							"sap/ui/core/",
-							"!sap/ui/core/.library",
+							"sap/ui/core/**/manifest.json",
 							"!sap/ui/core/*-preload.js",
 							"!sap/ui/core/designtime/",
 							"!sap/ui/core/**/*.designtime.js",
 							"!sap/ui/core/**/*.support.js",
-							"!sap/ui/core/themes/",
-							"!sap/ui/core/messagebundle*",
 
 							"!sap/ui/core/cldr/",
 							"*.js",
@@ -662,18 +610,6 @@ test.serial("generateLibraryPreload for sap.ui.core (/w ui5loader.js)", async (t
 	t.deepEqual(moduleBundlerStub.getCall(4).args, [{
 		options: {
 			bundleDefinition: {
-				defaultFileTypes: [
-					".js",
-					".control.xml",
-					".fragment.html",
-					".fragment.json",
-					".fragment.xml",
-					".view.html",
-					".view.json",
-					".view.xml",
-					".properties",
-					".json"
-				],
 				name: "sap/ui/core/library-preload.js",
 				sections: [
 					{
@@ -687,13 +623,11 @@ test.serial("generateLibraryPreload for sap.ui.core (/w ui5loader.js)", async (t
 					{
 						filters: [
 							"sap/ui/core/",
-							"!sap/ui/core/.library",
+							"sap/ui/core/**/manifest.json",
 							"!sap/ui/core/*-preload.js",
 							"!sap/ui/core/designtime/",
 							"!sap/ui/core/**/*.designtime.js",
 							"!sap/ui/core/**/*.support.js",
-							"!sap/ui/core/themes/",
-							"!sap/ui/core/messagebundle*",
 
 							"!sap/ui/core/cldr/",
 							"*.js",
@@ -735,18 +669,6 @@ test.serial("generateLibraryPreload for sap.ui.core (/w ui5loader.js)", async (t
 	t.deepEqual(moduleBundlerStub.getCall(5).args, [{
 		options: {
 			bundleDefinition: {
-				defaultFileTypes: [
-					".js",
-					".control.xml",
-					".fragment.html",
-					".fragment.json",
-					".fragment.xml",
-					".view.html",
-					".view.json",
-					".view.xml",
-					".properties",
-					".json"
-				],
 				name: "sap/ui/core/designtime/library-preload.designtime.js",
 				sections: [
 					{
@@ -777,18 +699,6 @@ test.serial("generateLibraryPreload for sap.ui.core (/w ui5loader.js)", async (t
 	t.deepEqual(moduleBundlerStub.getCall(6).args, [{
 		options: {
 			bundleDefinition: {
-				defaultFileTypes: [
-					".js",
-					".control.xml",
-					".fragment.html",
-					".fragment.json",
-					".fragment.xml",
-					".view.html",
-					".view.json",
-					".view.xml",
-					".properties",
-					".json"
-				],
 				name: "sap/ui/core/library-preload.support.js",
 				sections: [
 					{
@@ -855,30 +765,16 @@ test.serial("generateLibraryPreload with excludes", async (t) => {
 	t.deepEqual(moduleBundlerStub.getCall(0).args, [{
 		options: {
 			bundleDefinition: {
-				defaultFileTypes: [
-					".js",
-					".control.xml",
-					".fragment.html",
-					".fragment.json",
-					".fragment.xml",
-					".view.html",
-					".view.json",
-					".view.xml",
-					".properties",
-					".json"
-				],
 				name: "my/lib/library-preload.js",
 				sections: [
 					{
 						filters: [
 							"my/lib/",
-							"!my/lib/.library",
+							"my/lib/**/manifest.json",
 							"!my/lib/*-preload.js",
 							"!my/lib/designtime/",
 							"!my/lib/**/*.designtime.js",
 							"!my/lib/**/*.support.js",
-							"!my/lib/themes/",
-							"!my/lib/messagebundle*",
 
 							// via excludes option
 							"!my/lib/thirdparty/",
@@ -943,30 +839,16 @@ test.serial("generateLibraryPreload with invalid excludes", async (t) => {
 	t.deepEqual(moduleBundlerStub.getCall(0).args, [{
 		options: {
 			bundleDefinition: {
-				defaultFileTypes: [
-					".js",
-					".control.xml",
-					".fragment.html",
-					".fragment.json",
-					".fragment.xml",
-					".view.html",
-					".view.json",
-					".view.xml",
-					".properties",
-					".json"
-				],
 				name: "my/lib/library-preload.js",
 				sections: [
 					{
 						filters: [
 							"my/lib/",
-							"!my/lib/.library",
+							"my/lib/**/manifest.json",
 							"!my/lib/*-preload.js",
 							"!my/lib/designtime/",
 							"!my/lib/**/*.designtime.js",
-							"!my/lib/**/*.support.js",
-							"!my/lib/themes/",
-							"!my/lib/messagebundle*"
+							"!my/lib/**/*.support.js"
 						],
 						mode: "preload",
 						renderer: true,

--- a/test/lib/tasks/bundlers/generateStandaloneAppBundle.js
+++ b/test/lib/tasks/bundlers/generateStandaloneAppBundle.js
@@ -53,10 +53,21 @@ test.serial("execute module bundler and write results", async (t) => {
 	], "Correct filter in first bundle definition section");
 	t.deepEqual(options.bundleDefinition.sections[1].filters, [
 		"some/project/namespace/",
+		"some/project/namespace/**/manifest.json",
 		"!some/project/namespace/test/",
-		"!some/project/namespace/*.html",
 		"sap/ui/core/Core.js"
 	], "Correct filter in second bundle definition section");
+	t.deepEqual(options.bundleDefinition.defaultFileTypes, [
+		".js",
+		".control.xml",
+		".fragment.html",
+		".fragment.json",
+		".fragment.xml",
+		".view.html",
+		".view.json",
+		".view.xml",
+		".properties"
+	], "Correct default file types in bundle definition");
 });
 
 test.serial("execute module bundler and write results without namespace", async (t) => {
@@ -90,8 +101,8 @@ test.serial("execute module bundler and write results without namespace", async 
 	], "Correct filter in first bundle definition section");
 	t.deepEqual(options.bundleDefinition.sections[1].filters, [
 		"/",
+		"/**/manifest.json",
 		"!/test/",
-		"!/*.html",
 		"sap/ui/core/Core.js"
 	], "Correct filter in second bundle definition section");
 });
@@ -129,8 +140,8 @@ test.serial("execute module bundler and write results in evo mode", async (t) =>
 	], "Evo mode active - Correct filter in first bundle definition section");
 	t.deepEqual(options.bundleDefinition.sections[1].filters, [
 		"some/project/namespace/",
+		"some/project/namespace/**/manifest.json",
 		"!some/project/namespace/test/",
-		"!some/project/namespace/*.html",
 		"sap/ui/core/Core.js"
 	], "Correct filter in second bundle definition section");
 });

--- a/test/lib/tasks/bundlers/generateStandaloneAppBundle.js
+++ b/test/lib/tasks/bundlers/generateStandaloneAppBundle.js
@@ -54,6 +54,8 @@ test.serial("execute module bundler and write results", async (t) => {
 	t.deepEqual(options.bundleDefinition.sections[1].filters, [
 		"some/project/namespace/",
 		"some/project/namespace/**/manifest.json",
+		"some/project/namespace/changes/changes-bundle.json",
+		"some/project/namespace/changes/flexibility-bundle.json",
 		"!some/project/namespace/test/",
 		"sap/ui/core/Core.js"
 	], "Correct filter in second bundle definition section");
@@ -102,6 +104,8 @@ test.serial("execute module bundler and write results without namespace", async 
 	t.deepEqual(options.bundleDefinition.sections[1].filters, [
 		"/",
 		"/**/manifest.json",
+		"/changes/changes-bundle.json",
+		"/changes/flexibility-bundle.json",
 		"!/test/",
 		"sap/ui/core/Core.js"
 	], "Correct filter in second bundle definition section");
@@ -141,6 +145,8 @@ test.serial("execute module bundler and write results in evo mode", async (t) =>
 	t.deepEqual(options.bundleDefinition.sections[1].filters, [
 		"some/project/namespace/",
 		"some/project/namespace/**/manifest.json",
+		"some/project/namespace/changes/changes-bundle.json",
+		"some/project/namespace/changes/flexibility-bundle.json",
 		"!some/project/namespace/test/",
 		"sap/ui/core/Core.js"
 	], "Correct filter in second bundle definition section");


### PR DESCRIPTION
Use default if not provided in bundle definition.

In the past neither a default, nor the bundle definition configuration
was used, since the parameter was mistakenly expected on the bundle
options.

Also align the defaults for library- and component-bundles with Maven.

New moduleBundler defaults:  
* `.js`
* `.control.xml`
* `.fragment.html`
* `.fragment.json`
* `.fragment.xml`
* `.view.html`
* `.view.json`
* `.view.xm`

Component-bundles (Component-preload.js and sap-ui-custom.js) additionally include:
* `.properties`
* and via filters:
    * `${namespace}/**/manifest.json`
    * `${namespace}/changes/flexibility-bundle.json`
    * `${namespace}/changes/changes-bundle.json`