### PR TITLE
[INTERNAL] TaskUtil: Support specVersion 2.3

### DIFF
--- a/lib/tasks/TaskUtil.js
+++ b/lib/tasks/TaskUtil.js
@@ -144,6 +144,7 @@ class TaskUtil {
 		};
 		switch (specVersion) {
 		case "2.2":
+		case "2.3":
 			return baseInterface;
 		default:
 			throw new Error(`TaskUtil: Unknown or unsupported Specification Version ${specVersion}`);

--- a/test/lib/tasks/TaskUtil.js
+++ b/test/lib/tasks/TaskUtil.js
@@ -146,6 +146,32 @@ test("getInterface: specVersion 2.2", async (t) => {
 	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
 });
 
+test("getInterface: specVersion 2.3", async (t) => {
+	const taskUtil = new TaskUtil({
+		projectBuildContext: {
+			STANDARD_TAGS: ["some tag"]
+		}
+	});
+
+	const interfacedTaskUtil = taskUtil.getInterface("2.3");
+
+	t.deepEqual(Object.keys(interfacedTaskUtil), [
+		"STANDARD_TAGS",
+		"setTag",
+		"clearTag",
+		"getTag",
+		"isRootProject",
+		"registerCleanupTask"
+	], "Correct methods are provided");
+
+	t.deepEqual(interfacedTaskUtil.STANDARD_TAGS, ["some tag"], "attribute STANDARD_TAGS is provided");
+	t.is(typeof interfacedTaskUtil.setTag, "function", "function setTag is provided");
+	t.is(typeof interfacedTaskUtil.clearTag, "function", "function clearTag is provided");
+	t.is(typeof interfacedTaskUtil.getTag, "function", "function getTag is provided");
+	t.is(typeof interfacedTaskUtil.isRootProject, "function", "function isRootProject is provided");
+	t.is(typeof interfacedTaskUtil.registerCleanupTask, "function", "function registerCleanupTask is provided");
+});
+
 test("getInterface: specVersion undefined", async (t) => {
 	const taskUtil = new TaskUtil({
 		projectBuildContext: {


### PR DESCRIPTION
New specVersion does not affect TaskUtil but still needs to be
supported and handled.
