### PR TITLE
[INTERNAL] manifestCreator: If manifest.json already exists, log message as verbose instead of info

### DIFF
--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -712,7 +712,7 @@ module.exports = function({libraryResource, resources, options}) {
 	// check whether a manifest exists already
 	const manifestResource = libBundle.findResource("manifest.json");
 	if ( manifestResource != null ) {
-		log.info("Library manifest already exists at '%s', skipping generation", manifestResource.getPath());
+		log.verbose("Library manifest already exists at '%s', skipping generation", manifestResource.getPath());
 		return Promise.resolve(null); // a fulfillment of null indicates that no manifest has been created
 	}
 


### PR DESCRIPTION
In the future, we expect libraries to always have a manifest.json and not to rely on this task.

An eventual "manifest enhancement" task could update any dynamic information in an already existing manifest.json, thus making benefits from using the manifestCreator obsolete.