### PR TITLE
[FIX] versionInfoGenerator: fix hasOwnPreload flag

### DIFF
--- a/lib/processors/versionInfoGenerator.js
+++ b/lib/processors/versionInfoGenerator.js
@@ -423,18 +423,19 @@ module.exports = async function({options}) {
 	let components;
 	artifactInfos.forEach((artifactInfo) => {
 		artifactInfo.embeds.forEach((embeddedArtifactInfo) => {
-			const componentObject = {
-				library: artifactInfo.componentName
-			};
+			const componentObject = {};
+			const bundledComponents = artifactInfo.bundledComponents;
 			const componentName = embeddedArtifactInfo.componentName;
+			if (!bundledComponents.has(componentName)) {
+				componentObject.hasOwnPreload = true;
+			}
+			componentObject.library = artifactInfo.componentName;
+
 			const manifestHints = getManifestHints(embeddedArtifactInfo.dependencyInfo, dependencyInfoMap);
 			if (manifestHints) {
 				componentObject.manifestHints = manifestHints;
 			}
-			const bundledComponents = artifactInfo.bundledComponents;
-			if (!bundledComponents.has(componentName)) {
-				componentObject.hasOwnPreload = true;
-			}
+
 			components = components || {};
 			components[componentName] = componentObject;
 		});

--- a/lib/processors/versionInfoGenerator.js
+++ b/lib/processors/versionInfoGenerator.js
@@ -432,7 +432,7 @@ module.exports = async function({options}) {
 				componentObject.manifestHints = manifestHints;
 			}
 			const bundledComponents = artifactInfo.bundledComponents;
-			if (bundledComponents.has(componentName)) {
+			if (!bundledComponents.has(componentName)) {
 				componentObject.hasOwnPreload = true;
 			}
 			components = components || {};

--- a/lib/processors/versionInfoGenerator.js
+++ b/lib/processors/versionInfoGenerator.js
@@ -254,11 +254,11 @@ const getManifestHints = (dependencyInfo, dependencyInfoMap) => {
 
 /**
  * Common type for Library and Component
- * embeds and bundled components makes only sense for library
+ * embeds and bundled components make only sense for library
  *
  * @typedef {object} ArtifactInfo
  * @property {string} componentName The library name, e.g. "lib.x"
- * @property {Set<string>} bundledComponents The embedded components which have a embeddedBy reference to the library
+ * @property {Set<string>} bundledComponents The embedded components which have an embeddedBy reference to the library
  * @property {DependencyInfo} dependencyInfo The dependency info object
  * @property {ArtifactInfo[]} embeds The embedded artifact infos
  */

--- a/test/lib/processors/versionInfoGenerator.js
+++ b/test/lib/processors/versionInfoGenerator.js
@@ -284,6 +284,7 @@ test.serial("versionInfoGenerator library infos with embeds", async (t) => {
 		],
 		"components": {
 			"lib.a.sub": {
+				"hasOwnPreload": true,
 				"library": "lib.a"
 			}
 		}
@@ -439,7 +440,6 @@ test.serial("versionInfoGenerator library infos with embeds and embeddedBy (hasO
 		],
 		"components": {
 			"lib.a.sub": {
-				"hasOwnPreload": true,
 				"library": "lib.a"
 			}
 		}

--- a/test/lib/tasks/generateVersionInfo.js
+++ b/test/lib/tasks/generateVersionInfo.js
@@ -726,6 +726,7 @@ test.serial("integration: Library with dependencies and subcomponent complex sce
 		}],
 		"components": {
 			"lib.a.sub.fold": {
+				"hasOwnPreload": true,
 				"library": "lib.a",
 				"manifestHints": {
 					"dependencies": {
@@ -863,6 +864,7 @@ test.serial("integration: Library with dependencies and subcomponent bigger scen
 		}],
 		"components": {
 			"lib.a.sub.fold": {
+				"hasOwnPreload": true,
 				"library": "lib.a",
 				"manifestHints": {
 					"dependencies": {
@@ -917,7 +919,6 @@ test.serial("integration: Library without dependencies and embeds and embeddedBy
 		}],
 		"components": {
 			"lib.a.sub.fold": {
-				"hasOwnPreload": true,
 				"library": "lib.a"
 			}
 		},
@@ -964,6 +965,7 @@ test.serial("integration: Library without dependencies and embeddedBy undefined"
 		}],
 		"components": {
 			"lib.a.sub.fold": {
+				"hasOwnPreload": true,
 				"library": "lib.a"
 			}
 		},
@@ -1014,6 +1016,7 @@ test.serial("integration: Library without dependencies and embeddedBy not a stri
 		}],
 		"components": {
 			"lib.a.sub.fold": {
+				"hasOwnPreload": true,
 				"library": "lib.a"
 			}
 		},
@@ -1065,6 +1068,7 @@ test.serial("integration: Library without dependencies and embeddedBy empty stri
 		}],
 		"components": {
 			"lib.a.sub.fold": {
+				"hasOwnPreload": true,
 				"library": "lib.a"
 			}
 		},
@@ -1116,6 +1120,7 @@ test.serial("integration: Library without dependencies and embeddedBy path not c
 		}],
 		"components": {
 			"lib.a.sub.fold": {
+				"hasOwnPreload": true,
 				"library": "lib.a"
 			}
 		},


### PR DESCRIPTION
`hasOwnPreload` is only `true` if the library has `embeds` field set in manifest
and embedded manifest does not have a backlink (`embeddedBy`) to the library.