### PR TITLE
[FIX] LibraryFormatter: Do not throw for missing .library in legacy OpenUI5 theme libraries

### DIFF
--- a/lib/types/application/ApplicationFormatter.js
+++ b/lib/types/application/ApplicationFormatter.js
@@ -110,7 +110,7 @@ class ApplicationFormatter extends AbstractUi5Formatter {
 		}
 		const namespace = appId.replace(/\./g, "/");
 		log.verbose(
-			`Namespace of project ${this._project.metadata.name} is ${namespace} (from manifest.appdescr_variant)`);
+			`Namespace of project ${this._project.metadata.name} is ${namespace} (from manifest.json)`);
 		return namespace;
 	}
 

--- a/lib/types/library/LibraryFormatter.js
+++ b/lib/types/library/LibraryFormatter.js
@@ -58,7 +58,7 @@ class LibraryFormatter extends AbstractUi5Formatter {
 			log.verbose(err.message);
 		}
 
-		if (isFrameworkProject(project)) {
+		if (isFrameworkProject(project) && !SAP_THEMES_NS_EXEMPTIONS.includes(this._project.metadata.name)) {
 			if (project.builder && project.builder.libraryPreload && project.builder.libraryPreload.excludes) {
 				log.verbose(
 					`Using preload excludes for framework library ${project.metadata.name} from project configuration`);

--- a/test/lib/types/library/LibraryFormatter.js
+++ b/test/lib/types/library/LibraryFormatter.js
@@ -36,6 +36,31 @@ const libraryETree = {
 	}
 };
 
+const legacyThemeLibPath = path.join(__dirname, "..", "..", "..", "fixtures", "theme.library.e");
+const legacyThemeLibTree = {
+	id: "@openui5/themelib_sap_bluecrystal",
+	version: "1.0.0",
+	path: legacyThemeLibPath,
+	dependencies: [],
+	_level: 0,
+	_isRoot: true,
+	specVersion: "2.0",
+	type: "library",
+	metadata: {
+		name: "themelib_sap_bluecrystal",
+		copyright: "UI development toolkit for HTML5 (OpenUI5)\n * (c) Copyright 2009-xxx SAP SE or an SAP affiliate " +
+			"company.\n * Licensed under the Apache License, Version 2.0 - see LICENSE.txt."
+	},
+	resources: {
+		configuration: {
+			paths: {
+				src: "src",
+				test: "test"
+			}
+		}
+	}
+};
+
 function clone(o) {
 	return JSON.parse(JSON.stringify(o));
 }
@@ -394,6 +419,15 @@ test.serial("format: namespace resolution fails", async (t) => {
 
 	mock.stop("globby");
 	mock.stop("@ui5/logger");
+});
+
+test("format: legacy OpenUI5 theme library", async (t) => {
+	const myProject = clone(legacyThemeLibTree);
+	const libraryFormatter = new LibraryFormatter({project: myProject});
+	sinon.stub(libraryFormatter, "validate").resolves();
+
+	await t.notThrowsAsync(libraryFormatter.format(), "Does not throw for missing .library");
+	t.deepEqual(myProject.metadata.copyright, legacyThemeLibTree.metadata.copyright, "Copyright was not altered");
 });
 
 test("format: configuration test path", async (t) => {


### PR DESCRIPTION
Exception handling was already in place for legacy OpenUI5 theme
libraries that still use type 'library' instead of 'theme-library':
https://github.com/SAP/ui5-builder/pull/437

This allowed them to still be formatted even though they are missing a
.library file.

However, the newly added preload exclude configuration fallback for
framework libraries also requires a .library file and did not make the
mentioned exception for legacy OpenUI5 theme libraries:
https://github.com/SAP/ui5-builder/pull/573

This fix adds that exception and the tests that were missing from
https://github.com/SAP/ui5-builder/pull/437