### PR TITLE
[FIX] lbt/Builder: Preserve comments in bundles

### DIFF
--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -5,7 +5,6 @@
 const terser = require("terser");
 const {pd} = require("pretty-data");
 const esprima = require("esprima");
-const escodegen = require("escodegen");
 const {Syntax} = esprima;
 // const MOZ_SourceMap = require("source-map");
 
@@ -347,13 +346,12 @@ class BundleBuilder {
 				if ( /\.js$/.test(module) ) {
 					// console.log("Processing " + module);
 					const resource = await this.pool.findResourceWithInfo(module);
-					const code = await resource.buffer();
-					const ast = rewriteDefine(this.targetBundleFormat, code, module);
-					if ( ast ) {
+					let code = await resource.buffer();
+					code = rewriteDefine(this.targetBundleFormat, code, module);
+					if ( code ) {
 						outW.startSegment(module);
 						outW.ensureNewLine();
-						const astAsCode = escodegen.generate(ast);
-						const fileContent = await this.compressJS(astAsCode, resource);
+						const fileContent = await this.compressJS(code, resource);
 						outW.write( fileContent );
 						outW.ensureNewLine();
 						const compressedSize = outW.endSegment();
@@ -466,46 +464,82 @@ class BundleBuilder {
 const CALL_SAP_UI_DEFINE = ["sap", "ui", "define"];
 
 function rewriteDefine(targetBundleFormat, code, moduleName) {
-	function _injectModuleNameIfNeeded(defineCall) {
-		if ( defineCall.arguments.length == 0 ||
-				defineCall.arguments[0].type !== Syntax.Literal ) {
-			defineCall.arguments.unshift({
-				type: Syntax.Literal,
-				value: ModuleName.toRequireJSName(moduleName)
-			});
-		}
-	}
 	let ast;
+	const codeStr = code.toString();
 	try {
-		ast = esprima.parseScript(code.toString(), {loc: true});
+		ast = esprima.parseScript(codeStr, {range: true});
 	} catch (e) {
 		log.error("error while parsing %s: %s", moduleName, e.message);
 		return;
 	}
 
 	if ( ast.type === Syntax.Program &&
-			ast.body.length === 1 &&
-			ast.body[0].type === Syntax.ExpressionStatement ) {
-		// rewrite define to require.predefine
-		if ( isMethodCall(ast.body[0].expression, CALL_SAP_UI_DEFINE) ) {
-			const defineCall = ast.body[0].expression;
+			ast.body.length === 1 && ast.body[0].type === Syntax.ExpressionStatement &&
+			isMethodCall(ast.body[0].expression, CALL_SAP_UI_DEFINE) ) {
+		const changes = [];
+		const defineCall = ast.body[0].expression;
 
-			// rewrite sap.ui.define to sap.ui.predefine
-			if ( defineCall.callee.type === Syntax.MemberExpression &&
-					defineCall.callee.property.type === Syntax.Identifier &&
-					defineCall.callee.property.name === "define" ) {
-				defineCall.callee.property.name = "predefine";
+
+		// Inject module name if missing
+		if ( defineCall.arguments.length == 0 ||
+			defineCall.arguments[0].type !== Syntax.Literal ) {
+			let value = `"${ModuleName.toRequireJSName(moduleName)}"`;
+			let index;
+
+			if (defineCall.arguments.length == 0) {
+				index = defineCall.range[1] - 1;
+			} else {
+				index = defineCall.arguments[0].range[0];
+				value += ", ";
 			}
 
-			_injectModuleNameIfNeeded(defineCall, moduleName);
-
-			// console.log("rewriting %s", module, defineCall);
-
-			return ast;
+			changes.push({
+				index,
+				count: 0,
+				value
+			});
 		}
+
+		// rewrite sap.ui.define to sap.ui.predefine
+		if ( defineCall.callee.type === Syntax.MemberExpression &&
+				defineCall.callee.property.type === Syntax.Identifier &&
+				defineCall.callee.property.name === "define" ) {
+			changes.push({
+				index: defineCall.callee.property.range[0],
+				count: 0,
+				value: "pre"
+			});
+		}
+
+		return applyChanges(codeStr, changes);
 	}
 
 	return false;
+}
+
+function applyChanges(string, changes) {
+	changes.sort((a, b) => {
+		// Sort descending by index
+		// This means replacements are done from bottom to top to not affect length/index of upcoming replacements
+
+		if (a.index < b.index) {
+			return 1;
+		}
+		if (a.index > b.index) {
+			return -1;
+		}
+		return 0;
+	});
+
+	const array = Array.from(string);
+	changes.forEach((change) => {
+		array.splice(
+			change.index,
+			change.count,
+			change.value
+		);
+	});
+	return array.join("");
 }
 
 module.exports = BundleBuilder;

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -487,8 +487,10 @@ function rewriteDefine(targetBundleFormat, code, moduleName) {
 			let index;
 
 			if (defineCall.arguments.length == 0) {
+				// asterisk marks the index: sap.ui.define(*)
 				index = defineCall.range[1] - 1;
 			} else {
+				// asterisk marks the index: sap.ui.define(*argument1)
 				index = defineCall.arguments[0].range[0];
 				value += ", ";
 			}
@@ -505,6 +507,7 @@ function rewriteDefine(targetBundleFormat, code, moduleName) {
 				defineCall.callee.property.type === Syntax.Identifier &&
 				defineCall.callee.property.name === "define" ) {
 			changes.push({
+				// asterisk marks the index: sap.ui.*define()
 				index: defineCall.callee.property.range[0],
 				count: 0,
 				value: "pre"
@@ -518,18 +521,7 @@ function rewriteDefine(targetBundleFormat, code, moduleName) {
 }
 
 function applyChanges(string, changes) {
-	changes.sort((a, b) => {
-		// Sort descending by index
-		// This means replacements are done from bottom to top to not affect length/index of upcoming replacements
-
-		if (a.index < b.index) {
-			return 1;
-		}
-		if (a.index > b.index) {
-			return -1;
-		}
-		return 0;
-	});
+	// No sorting needed as changes are added in correct order
 
 	const array = Array.from(string);
 	changes.forEach((change) => {

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -61,10 +61,6 @@ const UI5BundleFormat = {
 
 	shouldDecorate(resolvedModule) {
 		return resolvedModule.executes(UI5ClientConstants.MODULE__JQUERY_SAP_GLOBAL);
-	},
-
-	supportsNativeDefine() {
-		return false;
 	}
 };
 
@@ -90,11 +86,6 @@ const EVOBundleFormat = {
 			resolvedModule.executes(UI5ClientConstants.MODULE__UI5LOADER_AUTOCONFIG) ||
 			resolvedModule.executes(UI5ClientConstants.MODULE__JQUERY_SAP_GLOBAL) ||
 			resolvedModule.executes(UI5ClientConstants.MODULE__SAP_UI_CORE_CORE);
-	},
-
-	supportsNativeDefine() {
-		// disabled in 1.54 as the standard global names define/require are not written by the ui5loader
-		return false;
 	}
 };
 

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -272,7 +272,6 @@ class BundleBuilder {
 
 	async writePreloadFunction(section) {
 		const outW = this.outW;
-		const avoidLazyParsing = section.sectionDefinition.avoidLazyParsing;
 
 		outW.ensureNewLine();
 
@@ -280,7 +279,7 @@ class BundleBuilder {
 
 		this.beforeWriteFunctionPreloadSection(sequence);
 
-		await this.rewriteAMDModules(sequence, avoidLazyParsing);
+		await this.rewriteAMDModules(sequence);
 		if ( sequence.length > 0 ) {
 			this.targetBundleFormat.beforePreloads(outW, section);
 			let i = 0;
@@ -293,7 +292,7 @@ class BundleBuilder {
 					this.beforeWritePreloadModule(module, resource.info, resource);
 					outW.write(`\t"${module.toString()}":`);
 					outW.startSegment(module);
-					await this.writePreloadModule(module, resource.info, resource, avoidLazyParsing);
+					await this.writePreloadModule(module, resource.info, resource);
 					const compressedSize = outW.endSegment();
 					log.verbose("    %s (%d,%d)", module,
 						resource.info != null ? resource.info.size : -1, compressedSize);
@@ -339,7 +338,7 @@ class BundleBuilder {
 		sequence.sort();
 	}
 
-	async rewriteAMDModules(sequence, avoidLazyParsing) {
+	async rewriteAMDModules(sequence) {
 		if ( this.options.usePredefineCalls ) {
 			const outW = this.outW;
 
@@ -349,7 +348,7 @@ class BundleBuilder {
 					// console.log("Processing " + module);
 					const resource = await this.pool.findResourceWithInfo(module);
 					const code = await resource.buffer();
-					const ast = rewriteDefine(this.targetBundleFormat, code, module, avoidLazyParsing);
+					const ast = rewriteDefine(this.targetBundleFormat, code, module);
 					if ( ast ) {
 						outW.startSegment(module);
 						outW.ensureNewLine();
@@ -385,25 +384,18 @@ class BundleBuilder {
 	 * @param {string} module module name
 	 * @param {ModuleInfo} info
 	 * @param {module:@ui5/fs.Resource} resource
-	 * @param {boolean} avoidLazyParsing
 	 * @returns {Promise<boolean>}
 	 */
-	async writePreloadModule(module, info, resource, avoidLazyParsing) {
+	async writePreloadModule(module, info, resource) {
 		const outW = this.outW;
 
 		if ( /\.js$/.test(module) && (info == null || !info.requiresTopLevelScope) ) {
 			const compressedContent = await this.compressJS( await resource.buffer(), resource );
-			if ( avoidLazyParsing ) {
-				outW.write(`(`);
-			}
 			outW.write(`function(){`);
 			outW.write( compressedContent );
 			this.exportGlobalNames(info);
 			outW.ensureNewLine();
 			outW.write(`}`);
-			if ( avoidLazyParsing ) {
-				outW.write(`)`);
-			}
 		} else if ( /\.js$/.test(module) /* implicitly: && info != null && info.requiresTopLevelScope */ ) {
 			log.warn("**** warning: module %s requires top level scope" +
 					" and can only be embedded as a string (requires 'eval')", module);
@@ -471,10 +463,9 @@ class BundleBuilder {
 	}
 }
 
-const CALL_DEFINE = ["define"];
 const CALL_SAP_UI_DEFINE = ["sap", "ui", "define"];
 
-function rewriteDefine(targetBundleFormat, code, moduleName, avoidLazyParsing) {
+function rewriteDefine(targetBundleFormat, code, moduleName) {
 	function _injectModuleNameIfNeeded(defineCall) {
 		if ( defineCall.arguments.length == 0 ||
 				defineCall.arguments[0].type !== Syntax.Literal ) {
@@ -484,32 +475,6 @@ function rewriteDefine(targetBundleFormat, code, moduleName, avoidLazyParsing) {
 			});
 		}
 	}
-
-	function enforceEagerParsing(defineCall) {
-		const args = defineCall.arguments;
-		// wrap factory function to avoid lazy parsing (V8 and Chakra)
-		let iFactory = 0;
-		// skip any hard coded module name
-		if ( iFactory < args.length && args[iFactory].type === Syntax.Literal ) {
-			iFactory++;
-		}
-		// skip array of dependencies
-		if ( iFactory < args.length && args[iFactory].type === Syntax.ArrayExpression ) {
-			iFactory++;
-		}
-		// wrap factory
-		if ( iFactory < args.length && args[iFactory].type === Syntax.FunctionExpression ) {
-			/* NODE-TODO
-			Token firstToken = doc.getToken(args.getChild(iFactory).getTokenStartIndex());
-			Token lastToken = doc.getToken(args.getChild(iFactory).getTokenStopIndex());
-			if ( "function".equals(firstToken.getText())
-					 && "}".equals(lastToken.getText()) ) {
-				firstToken.setText("(" + firstToken.getText());
-				lastToken.setText(lastToken.getText() + ")");
-			} */
-		}
-	}
-
 	let ast;
 	try {
 		ast = esprima.parseScript(code.toString(), {loc: true});
@@ -522,49 +487,6 @@ function rewriteDefine(targetBundleFormat, code, moduleName, avoidLazyParsing) {
 			ast.body.length === 1 &&
 			ast.body[0].type === Syntax.ExpressionStatement ) {
 		// rewrite define to require.predefine
-		if ( targetBundleFormat.supportsNativeDefine() && isMethodCall(ast.body[0].expression, CALL_DEFINE) ) {
-			const defineCall = ast.body[0].expression;
-
-			if ( defineCall.callee.type === Syntax.Identifier &&
-					defineCall.callee.name === "define" ) {
-				defineCall.callee.name = "predefine"; // rename method to predefine
-				// add a member expression 'sap.ui.require.'
-				defineCall.callee = {
-					type: Syntax.MemberExpression,
-					object: {
-						type: Syntax.MemberExpression,
-						object: {
-							type: Syntax.MemberExpression,
-							object: {
-								type: Syntax.Identifier,
-								name: "sap"
-							},
-							property: {
-								type: Syntax.Identifier,
-								name: "ui"
-							}
-						},
-						property: {
-							type: Syntax.Identifier,
-							name: "require"
-						}
-					},
-					property: defineCall.callee
-				};
-			}
-
-			_injectModuleNameIfNeeded(defineCall, moduleName);
-
-			if ( avoidLazyParsing ) {
-				enforceEagerParsing(defineCall);
-			}
-
-			// console.log("rewriting %s", module, defineCall);
-
-			return ast;
-		}
-
-
 		if ( isMethodCall(ast.body[0].expression, CALL_SAP_UI_DEFINE) ) {
 			const defineCall = ast.body[0].expression;
 
@@ -576,10 +498,6 @@ function rewriteDefine(targetBundleFormat, code, moduleName, avoidLazyParsing) {
 			}
 
 			_injectModuleNameIfNeeded(defineCall, moduleName);
-
-			if ( avoidLazyParsing ) {
-				enforceEagerParsing(defineCall);
-			}
 
 			// console.log("rewriting %s", module, defineCall);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1936,7 +1936,8 @@
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"default-require-extensions": {
 			"version": "3.0.0",
@@ -2297,25 +2298,6 @@
 			"resolved": "https://registry.npmjs.org/escape-unicode/-/escape-unicode-0.2.0.tgz",
 			"integrity": "sha512-7jMQuKb8nm0h/9HYLfu4NCLFwoUsd5XO6OZ1z86PbKcMf8zDK1m7nFR0iA2CCShq4TSValaLIveE8T1UBxgALQ=="
 		},
-		"escodegen": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-			"integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-			"requires": {
-				"esprima": "^4.0.1",
-				"estraverse": "^5.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
-				}
-			}
-		},
 		"escope": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
@@ -2595,7 +2577,8 @@
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true
 		},
 		"event-emitter": {
 			"version": "0.3.5",
@@ -2694,7 +2677,8 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fastq": {
 			"version": "1.11.0",
@@ -3618,15 +3602,6 @@
 				"mime": "^1.6.0"
 			}
 		},
-		"levn": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
-			}
-		},
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -4411,19 +4386,6 @@
 				"temp-write": "^4.0.0"
 			}
 		},
-		"optionator": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.6",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"word-wrap": "~1.2.3"
-			}
-		},
 		"ora": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.0.tgz",
@@ -4808,11 +4770,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
 			"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
 			"dev": true
-		},
-		"prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"prepend-http": {
 			"version": "2.0.0",
@@ -5887,14 +5844,6 @@
 			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
 			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
 		},
-		"type-check": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"requires": {
-				"prelude-ls": "~1.1.2"
-			}
-		},
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -6092,7 +6041,8 @@
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"dev": true
 		},
 		"wrap-ansi": {
 			"version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
 		"@ui5/logger": "^2.0.1",
 		"cheerio": "^0.22.0",
 		"escape-unicode": "^0.2.0",
-		"escodegen": "^2.0.0",
 		"escope": "^3.6.0",
 		"esprima": "^4.0.1",
 		"estraverse": "5.1.0",

--- a/test/lib/lbt/bundle/Builder.js
+++ b/test/lib/lbt/bundle/Builder.js
@@ -179,6 +179,17 @@ test("integration: createBundle EVOBundleFormat, using predefine calls", async (
 		buffer: async () => "sap.ui.define([], function(){return {};});"
 	});
 	pool.addResource({
+		name: "jquery.sap.pony1.js",
+		buffer: async () => "sap.ui.define(); // hello"
+	});
+	pool.addResource({
+		name: "jquery.sap.pony2.js",
+		buffer: async () => `sap.
+		ui.define
+		/*hello*/
+				();`
+	});
+	pool.addResource({
 		name: "myRawModule.js",
 		buffer: async () => "(function(){window.mine = {};}());"
 	});
@@ -193,7 +204,12 @@ test("integration: createBundle EVOBundleFormat, using predefine calls", async (
 		sections: [{
 			mode: "preload",
 			name: "preload-section",
-			filters: ["jquery.sap.global.js", "myModuleUsingGlobalScope.js"]
+			filters: [
+				"jquery.sap.global.js",
+				"myModuleUsingGlobalScope.js",
+				"jquery.sap.pony1.js",
+				"jquery.sap.pony2.js"
+			]
 		}, {
 			declareRawModules: undefined,
 			mode: "raw",
@@ -216,6 +232,8 @@ test("integration: createBundle EVOBundleFormat, using predefine calls", async (
 	const expectedContent = `//@ui5-bundle Component-preload.js
 window["sap-ui-optimized"] = true;
 sap.ui.predefine("jquery.sap.global",[],function(){return{}});
+sap.ui.predefine("jquery.sap.pony1");
+sap.ui.predefine("jquery.sap.pony2");
 sap.ui.require.preload({
 	"myModuleUsingGlobalScope.js":'var magic={};'
 },"preload-section");
@@ -231,8 +249,110 @@ sap.ui.requireSync("ui5loader");
 	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules,
-		["jquery.sap.global.js", "myModuleUsingGlobalScope.js", "myRawModule.js"],
-		"bundle info subModules are correct");
+		[
+			"jquery.sap.global.js",
+			"jquery.sap.pony1.js",
+			"jquery.sap.pony2.js",
+			"myModuleUsingGlobalScope.js",
+			"myRawModule.js"
+		], "bundle info subModules are correct");
+});
+
+test("integration: createBundle EVOBundleFormat, using predefine calls, no optimize", async (t) => {
+	const pool = new ResourcePool();
+	pool.addResource({
+		name: "ui5loader.js",
+		buffer: async () => "(function(__global) {sap.ui.require = function(){};}(window));"
+	});
+	pool.addResource({ // the pool must contain this to activate optimization markers
+		name: "jquery.sap.global-dbg.js",
+		buffer: async () => "sap.ui.define([], function(){return {};});"
+	});
+	pool.addResource({
+		name: "jquery.sap.global.js",
+		buffer: async () => "sap.ui.define([], function(){return {};});"
+	});
+	pool.addResource({
+		name: "jquery.sap.pony1.js",
+		buffer: async () => "sap.ui.define(); // hello"
+	});
+	pool.addResource({
+		name: "jquery.sap.pony2.js",
+		buffer: async () => `sap.
+		ui.define
+		/*hello*/
+				();`
+	});
+	pool.addResource({
+		name: "myRawModule.js",
+		buffer: async () => "(function(){window.mine = {};}());"
+	});
+	pool.addResource({
+		name: "myModuleUsingGlobalScope.js",
+		buffer: async () => "var magic = {};"
+	});
+
+	const bundleDefinition = {
+		name: `Component-preload.js`,
+		defaultFileTypes: [".js"],
+		sections: [{
+			mode: "preload",
+			name: "preload-section",
+			filters: [
+				"jquery.sap.global.js",
+				"myModuleUsingGlobalScope.js",
+				"jquery.sap.pony1.js",
+				"jquery.sap.pony2.js"
+			]
+		}, {
+			declareRawModules: undefined,
+			mode: "raw",
+			filters: ["myRawModule.js"],
+			sort: undefined
+		}, {
+			mode: "require",
+			filters: ["ui5loader.js"]
+		}]
+	};
+
+	const builder = new Builder(pool);
+	const oResult = await builder.createBundle(bundleDefinition, {
+		usePredefineCalls: true,
+		numberOfParts: 1,
+		decorateBootstrapModule: true,
+		optimize: false
+	});
+	t.deepEqual(oResult.name, "Component-preload.js");
+	const expectedContent = `//@ui5-bundle Component-preload.js
+window["sap-ui-optimized"] = true;
+sap.ui.predefine("jquery.sap.global", [], function(){return {};});
+sap.ui.predefine("jquery.sap.pony1"); // hello
+sap.
+		ui.predefine
+		/*hello*/
+				("jquery.sap.pony2");
+sap.ui.require.preload({
+	"myModuleUsingGlobalScope.js":'var magic = {};'
+},"preload-section");
+//@ui5-bundle-raw-include myRawModule.js
+(function(){window.mine = {};}());
+sap.ui.requireSync("ui5loader");
+`;
+	t.deepEqual(oResult.content, expectedContent, "EVOBundleFormat should start with optomization and " +
+		"should contain:" +
+		" preload part from jquery.sap.global-dbg.js" +
+		" raw part from myModule.js" +
+		" require part from ui5loader.js");
+	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
+	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
+	t.deepEqual(oResult.bundleInfo.subModules,
+		[
+			"jquery.sap.global.js",
+			"jquery.sap.pony1.js",
+			"jquery.sap.pony2.js",
+			"myModuleUsingGlobalScope.js",
+			"myRawModule.js"
+		], "bundle info subModules are correct");
 });
 
 test("integration: createBundle (bootstrap bundle)", async (t) => {
@@ -305,7 +425,7 @@ test("integration: createBundle UI5BundleFormat (non ui5loader.js)", async (t) =
 	});
 	pool.addResource({
 		name: "jquery.sap.global-dbg.js",
-		buffer: async () => "sap.ui.define([], function(){return {};});"
+		buffer: async () => "sap.ui.define([], function(){/* comment */ return {};});"
 	});
 	pool.addResource({
 		name: "myModule.js",
@@ -338,7 +458,7 @@ jQuery.sap.registerPreloadedModules({
 "name":"preload-section",
 "version":"2.0",
 "modules":{
-	"jquery.sap.global-dbg.js":function(){sap.ui.define([], function(){return {};});
+	"jquery.sap.global-dbg.js":function(){sap.ui.define([], function(){/* comment */ return {};});
 }
 }});
 //@ui5-bundle-raw-include myModule.js


### PR DESCRIPTION
Replace AST-to-code procedure based on escodegen, which apparently removes comments from the bundled source, with some basic string manipulation.

JIRA: CPOUI5FOUNDATION-260