### PR TITLE
[FIX] JSDoc: add project name to JSDoc configuration and api.json

### DIFF
--- a/lib/processors/jsdoc/jsdocGenerator.js
+++ b/lib/processors/jsdoc/jsdocGenerator.js
@@ -106,6 +106,7 @@ async function generateJsdocConfig({targetPath, tmpPath, namespace, projectName,
 			"ui5": {
 				"variants": ${JSON.stringify(variants)},
 				"version": "${version}",
+				"uilib": "${projectName}",
 				"jsapiFile": "${jsapiFilePath}",
 				"apiJsonFolder": "${apiJsonFolderPath}",
 				"apiJsonFile": "${apiJsonFilePath}"

--- a/test/expected/build/library.j/dest/test-resources/library/j/designtime/api.json
+++ b/test/expected/build/library.j/dest/test-resources/library/j/designtime/api.json
@@ -1,1 +1,1 @@
-{"$schema-ref":"http://schemas.sap.com/sapui5/designtime/api.json/1.0","version":"1.0.0","symbols":[{"kind":"namespace","name":"library.j","basename":"j","resource":"library/j/some.js","module":"library/j/some","static":true,"visibility":"public"}]}
+{"$schema-ref":"http://schemas.sap.com/sapui5/designtime/api.json/1.0","version":"1.0.0","library":"library.j","symbols":[{"kind":"namespace","name":"library.j","basename":"j","resource":"library/j/some.js","module":"library/j/some","static":true,"visibility":"public"}]}

--- a/test/lib/processors/jsdoc/jsdocGenerator.js
+++ b/test/lib/processors/jsdoc/jsdocGenerator.js
@@ -50,6 +50,7 @@ test("generateJsdocConfig", async (t) => {
 			"ui5": {
 				"variants": ["apijson"],
 				"version": "1.0.0",
+				"uilib": "some.namespace",
 				"jsapiFile": "${jsapiFilePath}",
 				"apiJsonFolder": "${apiJsonFolderPath}",
 				"apiJsonFile": "${apiJsonFilePath}"


### PR DESCRIPTION
The JSDoc processor did not propagate the library name (project name) to the JSDoc configuration. As a consequence, the UI5 template (publish.js) could not properly validate the metadata property 'library' for control and element classes. It reported many false positives ("ERROR: specified library 'foo.bar' for class 'foo.bar.Control' doesn't match containing library 'undefined'").
