### PR TITLE
[FIX] lib/processors/debugFileCreator: Add -dbg suffix only to files

### DIFF
--- a/lib/processors/debugFileCreator.js
+++ b/lib/processors/debugFileCreator.js
@@ -14,7 +14,7 @@ const util = require("util");
  */
 module.exports = function({resources, fs}) {
 	const options = {
-		pattern: /((\.view|\.fragment|\.controller|\.designtime|\.support)?\.js)$/,
+		pattern: /((?:\.view|\.fragment|\.controller|\.designtime|\.support)?\.js)$/,
 		replacement: "-dbg$1"
 	};
 

--- a/lib/processors/debugFileCreator.js
+++ b/lib/processors/debugFileCreator.js
@@ -14,7 +14,7 @@ const util = require("util");
  */
 module.exports = function({resources, fs}) {
 	const options = {
-		pattern: /((\.view|\.fragment|\.controller|\.designtime|\.support)?\.js)/,
+		pattern: /((\.view|\.fragment|\.controller|\.designtime|\.support)?\.js)$/,
 		replacement: "-dbg$1"
 	};
 


### PR DESCRIPTION
The debugFileCreator added the '-dbg' suffix to the first occurrence
in the path string which could also be a folder name. This change
ensures that the '.js' file extension is at the end of the string.
