### PR TITLE
[FIX] JSDoc: Use namespace to derive uilib name for jsdoc generator

### DIFF
--- a/lib/processors/jsdoc/jsdocGenerator.js
+++ b/lib/processors/jsdoc/jsdocGenerator.js
@@ -91,6 +91,13 @@ async function generateJsdocConfig({targetPath, tmpPath, namespace, projectName,
 		path.join(targetPath, "test-resources", path.normalize(namespace), "designtime", "api.json")
 			.replace(backslashRegex, "\\\\");
 
+	// Note: While the projectName could also be used here, it is not ensured that it fits to
+	// the library namespace.
+	// As the "uilib" information is used to check for certain constraints it must be aligned with
+	// the technical namespace that is used in the folder-structure, library.js and for the
+	// sap.ui.base.Object based classes.
+	const uilib = namespace.replace(/\//g, ".");
+
 	const config = `{
 		"plugins": ["${pluginPath}"],
 		"opts": {
@@ -106,7 +113,7 @@ async function generateJsdocConfig({targetPath, tmpPath, namespace, projectName,
 			"ui5": {
 				"variants": ${JSON.stringify(variants)},
 				"version": "${version}",
-				"uilib": "${projectName}",
+				"uilib": "${uilib}",
 				"jsapiFile": "${jsapiFilePath}",
 				"apiJsonFolder": "${apiJsonFolderPath}",
 				"apiJsonFile": "${apiJsonFilePath}"

--- a/test/lib/processors/jsdoc/jsdocGenerator.js
+++ b/test/lib/processors/jsdoc/jsdocGenerator.js
@@ -10,7 +10,7 @@ test("generateJsdocConfig", async (t) => {
 		targetPath: "/some/target/path",
 		tmpPath: "/some/tm\\p/path",
 		namespace: "some/namespace",
-		projectName: "some.namespace",
+		projectName: "some.projectName",
 		version: "1.0.0",
 		variants: ["apijson"]
 	});
@@ -26,7 +26,7 @@ test("generateJsdocConfig", async (t) => {
 		.replace(backslashRegex, "\\\\");
 	const destinationPath = path.join("/", "some", "tm\\p", "path")
 		.replace(backslashRegex, "\\\\");
-	const jsapiFilePath = path.join("/", "some", "target", "path", "libraries", "some.namespace.js")
+	const jsapiFilePath = path.join("/", "some", "target", "path", "libraries", "some.projectName.js")
 		.replace(backslashRegex, "\\\\");
 	const apiJsonFolderPath = path.join("/", "some", "tm\\p", "path", "dependency-apis")
 		.replace(backslashRegex, "\\\\");


### PR DESCRIPTION
Tests have been adopted to check whether the right information is used.

Follow-up of https://github.com/SAP/ui5-builder/pull/609
