### PR TITLE
[FIX] lbt/resources/ResourceCollector: Ensure proper matching of indicator files

### DIFF
--- a/lib/lbt/resources/ResourceCollector.js
+++ b/lib/lbt/resources/ResourceCollector.js
@@ -93,7 +93,7 @@ class ResourceCollector {
 			const p = name.lastIndexOf("/");
 			const prefix = name.substring(0, p + 1);
 			const basename = name.substring(p + 1);
-			if ( basename.match("[^/]*\\.library|Component\\.js|manifest\\.json") && !this._components.has(prefix) ) {
+			if ( basename.match("^([^/]*\\.library|Component\\.js|manifest\\.json)$") && !this._components.has(prefix) ) {
 				this._components.set(prefix, new ResourceInfoList(prefix));
 			}
 			// a .theme file within a theme folder indicates a library/theme package

--- a/lib/lbt/resources/ResourceCollector.js
+++ b/lib/lbt/resources/ResourceCollector.js
@@ -93,7 +93,8 @@ class ResourceCollector {
 			const p = name.lastIndexOf("/");
 			const prefix = name.substring(0, p + 1);
 			const basename = name.substring(p + 1);
-			if ( basename.match("^([^/]*\\.library|Component\\.js|manifest\\.json)$") && !this._components.has(prefix) ) {
+			if ( basename.match("^([^/]*\\.library|Component\\.js|manifest\\.json)$") &&
+					!this._components.has(prefix)) {
 				this._components.set(prefix, new ResourceInfoList(prefix));
 			}
 			// a .theme file within a theme folder indicates a library/theme package

--- a/test/lib/lbt/resources/ResourceCollector.js
+++ b/test/lib/lbt/resources/ResourceCollector.js
@@ -73,6 +73,28 @@ test.serial("visitResource: library.source.less", async (t) => {
 	t.is(resourceCollector.themePackages.size, 1, "theme package was added");
 });
 
+test.serial("visitResource: ensure proper matching of indicator files", async (t) => {
+	const resourceCollector = new ResourceCollector();
+	t.is(resourceCollector.components.size, 0, "initially there are no prefixes");
+	await resourceCollector.visitResource({
+		getPath: () => "/resources/projectA/NotComponent.js",
+		getSize: async () => 13
+	});
+	await resourceCollector.visitResource({
+		getPath: () => "/resources/projectB/notmanifest.json",
+		getSize: async () => 13
+	});
+	await resourceCollector.visitResource({
+		getPath: () => "/resources/projectC/not.library.yaml",
+		getSize: async () => 13
+	});
+	await resourceCollector.visitResource({
+		getPath: () => "/resources/projectD/Component.json",
+		getSize: async () => 13
+	});
+	t.is(resourceCollector.components.size, 0, "No prefixes should be added");
+});
+
 test.serial("groupResourcesByComponents: debugBundles", async (t) => {
 	const resourceCollector = new ResourceCollector();
 	resourceCollector.setExternalResources({


### PR DESCRIPTION
Indicator files like "Component.js", "manifest.json" or ".library" should only be matched
if the full basename is matched.

Before this fix, files like "MyComponent.js" were matched which resulted in the unexpected
creation of a resources.json file. The file should only be created for components, libraries
and themes.