### PR TITLE
[INTERNAL] JSDoc: Add check for copyright notice

### DIFF
--- a/lib/processors/jsdoc/lib/ui5/plugin.js
+++ b/lib/processors/jsdoc/lib/ui5/plugin.js
@@ -2652,6 +2652,27 @@ exports.astNodeVisitor = {
 				processPotentialEnum(node.expression.right, comment);
 			}
 
+		} else if ( node.type === Syntax.File ) {
+			// Check for copyright notice
+
+			let programBodyStart;
+			if ( node.program.body.length >= 1 ) {
+				programBodyStart = node.program.body[0].start
+			} else {
+				// File has no code at all
+				programBodyStart = Infinity;
+			}
+
+			const hasCopyrightComment = ( node.comments || [] ).some(function(commentBlock) {
+				return (
+					// Copyright comments must be at the top of the file, not between some code or at the end
+					commentBlock.end <= programBodyStart &&
+					/copyright|\(c\)|released under|license|\u00a9/.test(commentBlock.value)
+				);
+			});
+			if ( !hasCopyrightComment ) {
+				error(`document doesn't contain a copyright notice: ${currentSourceName}`);
+			}
 		}
 	}
 


### PR DESCRIPTION
Checks for a copyright notice at the beginning of each file.
The comment doesn't need to be the first comment but it must be placed
before any code starts.

This implements the same check as the internal validation rule
DOCUMENTATION__COPYRIGHT_NOTICE_MISSING.

Adds a jsdoc exclude configuration for sap.ui.model.odata.datajs which
is a legacy redirect file that only exists in the internal core overlay.
It is configured to be excluded from the internal validation, so it also
needs to be excluded from the jsdoc build so that no error is caused.

JIRA: CPOUI5FOUNDATION-329

Cherry picked from https://github.com/SAP/openui5/commit/bcb511074319aca894a026379bd2979627fb69c7
