### PR TITLE
[INTERNAL] JSDoc: Log resource name instead of full file path

### DIFF
--- a/lib/processors/jsdoc/lib/ui5/plugin.js
+++ b/lib/processors/jsdoc/lib/ui5/plugin.js
@@ -2671,7 +2671,7 @@ exports.astNodeVisitor = {
 				);
 			});
 			if ( !hasCopyrightComment ) {
-				error(`document doesn't contain a copyright notice: ${currentSourceName}`);
+				error(`document doesn't contain a copyright notice: ${getResourceName(currentSourceName)}`);
 			}
 		}
 	}


### PR DESCRIPTION
Follow-up of https://github.com/SAP/ui5-builder/pull/617

Cherry picked from https://github.com/SAP/openui5/commit/f79290bfcf8655a7c71b9d0ea51859405226873b
