### PR TITLE
[INTERNAL] Switch visitor-keys usage from estraverse to espree

### DIFF
--- a/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const {Syntax} = require("../utils/parseUtils");
+const {Syntax, VisitorKeys} = require("../utils/parseUtils");
 const escope = require("escope");
 const ModuleName = require("../utils/ModuleName");
 const {Format: ModuleFormat} = require("../resources/ModuleInfo");
@@ -11,8 +11,6 @@ const log = require("@ui5/logger").getLogger("lbt:analyzer:JSModuleAnalyzer");
 // ------------------------------------------------------------------------------------------------------------------
 
 const EnrichedVisitorKeys = (function() {
-	const VisitorKeys = require("estraverse").VisitorKeys;
-
 	function toBeDone() {
 		return null;
 	}
@@ -69,12 +67,11 @@ const EnrichedVisitorKeys = (function() {
 		ClassBody: [],
 		ClassDeclaration: [],
 		ClassExpression: [],
-		ComprehensionBlock: toBeDone(["left", "right"]),	// CAUTION: It's deferred to ES7.
-		ComprehensionExpression: toBeDone(),	// CAUTION: It's deferred to ES7.
+		// ComprehensionBlock: toBeDone(["left", "right"]),	// CAUTION: It's deferred to ES7.
+		// ComprehensionExpression: toBeDone(),	// CAUTION: It's deferred to ES7.
 		ConditionalExpression: ["consequent", "alternate"],
 		ContinueStatement: [],
 		DebuggerStatement: [],
-		DirectiveStatement: [],
 		/*
 		 * 'condition' is executed on the same conditions as the surrounding block, potentially repeated,
 		 * 'block' is always entered and might be repeated
@@ -91,7 +88,7 @@ const EnrichedVisitorKeys = (function() {
 		ForOfStatement: ["body"],
 		FunctionDeclaration: ["body"], // a nested function is potentially 'conditional'
 		FunctionExpression: ["body"], // a nested function is potentially 'conditional'
-		GeneratorExpression: toBeDone(["blocks", "filter", "body"]),	// CAUTION: It's deferred to ES7.
+		// GeneratorExpression: toBeDone(["blocks", "filter", "body"]),	// CAUTION: It's deferred to ES7.
 		Identifier: [],
 		IfStatement: ["consequent", "alternate"],
 		/*
@@ -120,7 +117,6 @@ const EnrichedVisitorKeys = (function() {
 		MemberExpression: [],
 		MetaProperty: toBeDone(["meta", "property"]),
 		MethodDefinition: [],
-		ModuleSpecifier: [],
 		NewExpression: [],
 		ObjectExpression: [],
 		/*
@@ -175,6 +171,16 @@ const EnrichedVisitorKeys = (function() {
 
 	// merge with 'official' visitor keys
 	Object.keys(VisitorKeys).forEach( (type) => {
+		// Check if the visitor-key exists in the available Syntax because
+		// the list of visitor-keys does not match the available Syntax.
+		if (!Syntax[type]) {
+			return;
+		}
+		// Ignore JSX visitor-keys because they aren't used.
+		if (type.startsWith("JSX")) {
+			return;
+		}
+
 		const visitorKeys = VisitorKeys[type];
 		const condKeys = TempKeys[type];
 		if ( condKeys === undefined ) {

--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -1,7 +1,6 @@
 "use strict";
-const {parseJS, Syntax} = require("../utils/parseUtils");
+const {parseJS, Syntax, VisitorKeys} = require("../utils/parseUtils");
 const {getPropertyKey, isMethodCall, isIdentifier, getStringArray} = require("../utils/ASTUtils");
-const VisitorKeys = require("estraverse").VisitorKeys;
 
 const CALL__SAP_UI_GETCORE = ["sap", "ui", "getCore"];
 

--- a/lib/lbt/utils/parseUtils.js
+++ b/lib/lbt/utils/parseUtils.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const espree = require("espree");
-const {Syntax} = espree;
+const {Syntax, VisitorKeys} = espree;
 
 const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
 
@@ -27,5 +27,6 @@ function parseJS(code, userOptions = {}) {
 
 module.exports = {
 	parseJS,
-	Syntax
+	Syntax,
+	VisitorKeys
 };

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
 		"escape-unicode": "^0.2.0",
 		"escope": "^3.6.0",
 		"espree": "^6.2.1",
-		"estraverse": "5.1.0",
 		"globby": "^11.0.4",
 		"graceful-fs": "^4.2.6",
 		"jsdoc": "^3.6.7",


### PR DESCRIPTION
Use espree.VisitorKeys instead of those provided by estraverse
since the ui5-builder is already using espree.
The visitor-keys list from estraverse and espree are different
and some unnecessary keys got removed from our list.
Espree is using the "eslint-visitor-keys" library which may contain
unexpected keys due to the used version range. Therefore the
visitor-keys are checked against the available syntax.
The visitor-keys were moved to the parseUtils module.
