### PR TITLE
[FIX] XMLTemplateAnalyzer: Include document name for XML parsing errors

### DIFF
--- a/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -146,7 +146,7 @@ class XMLTemplateAnalyzer {
 	_analyze(xml, info, isFragment) {
 		if ( this.busy ) {
 			// TODO delegate to fresh instances instead
-			throw new Error("analyzer is busy");
+			throw new Error("XMLTemplateAnalyzer is unexpectedly busy");
 		}
 
 		this.info = info;
@@ -160,7 +160,7 @@ class XMLTemplateAnalyzer {
 				// parse error
 				if ( err ) {
 					this.busy = false;
-					reject(err);
+					reject(new Error(`Error while parsing XML document ${info.name}: ${err.message}`));
 					return;
 				}
 

--- a/lib/lbt/resources/ResourcePool.js
+++ b/lib/lbt/resources/ResourcePool.js
@@ -109,15 +109,15 @@ async function determineDependencyInfo(resource, rawInfo, pool) {
 	} else if ( /\.view.xml$/.test(resource.name) ) {
 		const xmlView = await resource.buffer();
 		info.size = xmlView.length;
-		new XMLTemplateAnalyzer(pool).analyzeView(xmlView, info);
+		await new XMLTemplateAnalyzer(pool).analyzeView(xmlView, info);
 	} else if ( /\.control.xml$/.test(resource.name) ) {
 		const xmlView = await resource.buffer();
 		info.size = xmlView.length;
-		new XMLTemplateAnalyzer(pool).analyzeFragment(xmlView, info);
+		await new XMLTemplateAnalyzer(pool).analyzeFragment(xmlView, info);
 	} else if ( /\.fragment.xml$/.test(resource.name) ) {
 		const xmlView = await resource.buffer();
 		info.size = xmlView.length;
-		new XMLTemplateAnalyzer(pool).analyzeFragment(xmlView, info);
+		await new XMLTemplateAnalyzer(pool).analyzeFragment(xmlView, info);
 	}
 
 	return info;

--- a/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -370,8 +370,11 @@ test("_analyze: parseString error", async (t) => {
 	const analyzer = new XMLTemplateAnalyzer();
 	sinon.stub(analyzer._parser, "parseString").callsArgWith(1, new Error("my-error"), "result");
 
-	const error = await t.throwsAsync(analyzer._analyze());
-	t.deepEqual(error.message, "my-error");
+	const moduleInfo = {
+		name: "my.fragment.xml"
+	};
+	const error = await t.throwsAsync(analyzer._analyze(null, moduleInfo));
+	t.deepEqual(error.message, "Error while parsing XML document my.fragment.xml: my-error");
 	t.false(analyzer.busy, "busy state is restored");
 });
 
@@ -391,7 +394,7 @@ test("_analyze: call twice to simulate busy", async (t) => {
 	const error = t.throws(()=> {
 		analyzer._analyze(null, moduleInfo, true);
 	});
-	t.deepEqual(error.message, "analyzer is busy");
+	t.deepEqual(error.message, "XMLTemplateAnalyzer is unexpectedly busy");
 
 	await resultPromise;
 	t.false(analyzer.busy, "busy state is reset after promise resolves");


### PR DESCRIPTION
Also properly wait for the asynchronous analyze function to prevent
unhandled promise rejections and possible race conditions.

Change wording of an unrelated error message.

Resolves https://github.com/SAP/ui5-tooling/issues/539