### PR TITLE
[INTERNAL] JSDoc generation: improve basename determination

### DIFF
--- a/lib/processors/jsdoc/lib/ui5/template/publish.js
+++ b/lib/processors/jsdoc/lib/ui5/template/publish.js
@@ -2277,6 +2277,10 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 	// In some cases, JSDoc does not provide a basename in property symbol.name, but a partially qualified name
 	// this function reduces this to the base name
 	function basename(name) {
+		if (name.startsWith("module:")) {
+			const p = name.lastIndexOf("/");
+			name = name.slice(p + 1);
+		}
 		const p = name.lastIndexOf(".");
 		return p < 0 ? name : name.slice(p + 1);
 	}
@@ -4832,4 +4836,3 @@ function makeExample(example) {
 /* ---- exports ---- */
 
 exports.publish = publish;
-


### PR DESCRIPTION
Improve the determination of 'basename' to also support
the "module:Namespace/Entity" notation.
Trim "module:Namespace/Entity" to "Entity"

JIRA: CPOUI5FOUNDATION-386
