### PR TITLE
[INTERNAL] generateResourcesJson: Remove unused configuration

### DIFF
--- a/lib/tasks/generateResourcesJson.js
+++ b/lib/tasks/generateResourcesJson.js
@@ -24,19 +24,7 @@ function getCreatorOptions(projectName) {
 					"sap/base/",
 					"sap/ui/"
 				]
-			},
-			mergedResourcesFilters: [
-				"jquery-sap*.js",
-				"sap-ui-core*.js",
-				"**/Component-preload.js",
-				"**/library-preload.js",
-				"**/library-preload-dbg.js",
-				"**/library-preload.json",
-				"**/library-all.js",
-				"**/library-all-dbg.js",
-				"**/designtime/library-preload.designtime.js",
-				"**/library-preload.support.js"
-			]
+			}
 		});
 	} else if ( projectName === "sap.ui.integration" ) {
 		Object.assign(creatorOptions, {

--- a/test/lib/tasks/generateResourcesJson.js
+++ b/test/lib/tasks/generateResourcesJson.js
@@ -58,19 +58,7 @@ test.serial("empty resources (sap.ui.core)", async (t) => {
 				"sap/base/",
 				"sap/ui/"
 			]
-		},
-		mergedResourcesFilters: [
-			"jquery-sap*.js",
-			"sap-ui-core*.js",
-			"**/Component-preload.js",
-			"**/library-preload.js",
-			"**/library-preload-dbg.js",
-			"**/library-preload.json",
-			"**/library-all.js",
-			"**/library-all-dbg.js",
-			"**/designtime/library-preload.designtime.js",
-			"**/library-preload.support.js"
-		]
+		}
 	};
 	t.deepEqual(resourceListCreatorStub.getCall(0).args[0].options, expectedOptions, "options match");
 });


### PR DESCRIPTION
The option is actually called 'mergedResources', so it was never taken
into account.

The configuration should anyways become part of the individual project
configurations (ui5.yaml), as already stated in the TODO comment.

JIRA: CPOUI5FOUNDATION-271
