### PR TITLE
[FIX] manifestCreator: Trim whitespace/new-lines for sap.app/title

### DIFF
--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -237,7 +237,7 @@ async function createManifest(libraryResource, libBundle, descriptorVersion, _in
 			if ( library.getDocumentation() ) {
 				let desc = library.getDocumentation();
 				// remove all tags
-				desc = desc.replace(/\\s+/g, " ").replace(/<\/?[a-zA-Z][a-zA-Z0-9_$.]*(\s[^>]*)>/g, "");
+				desc = desc.replace(/\s+/g, " ").replace(/<\/?[a-zA-Z][a-zA-Z0-9_$.]*(\s[^>]*)>/g, "");
 				// extract summary (first sentence)
 				const m = /^([\w\W]+?[.;!?])[^a-zA-Z0-9_$]/.exec(desc);
 				return m ? m[1] : desc;

--- a/test/lib/processors/manifestCreator.js
+++ b/test/lib/processors/manifestCreator.js
@@ -137,6 +137,70 @@ test.serial("default manifest creation", async (t) => {
 	t.is(await result.getString(), expectedManifestContent, "Correct result returned");
 });
 
+test.serial("default manifest creation (multi-line documentation)", async (t) => {
+	const {manifestCreator, errorLogStub} = t.context;
+	const prefix = "/resources/sap/ui/mine/";
+	const libraryResource = {
+		getPath: () => {
+			return prefix + ".library";
+		},
+		getString: async () => {
+			return `<?xml version="1.0" encoding="UTF-8" ?>
+			<library xmlns="http://www.sap.com/sap.ui.library.xsd" >
+				<name>library.e</name>
+				<vendor>SAP SE</vendor>
+				<copyright>my copyright</copyright>
+				<version>1.0.0</version>
+				<documentation>Library E
+    uses a multi-line documentation text.</documentation>
+
+				<dependencies>
+					<dependency>
+					  <libraryName>sap.ui.core</libraryName>
+					</dependency>
+				</dependencies>
+
+				<appData>
+					<manifest xmlns="http://www.sap.com/ui5/buildext/manifest">
+						<i18n>i18n/i18n.properties</i18n>
+					</manifest>
+				</appData>
+
+			</library>`;
+		},
+		_project: {
+			dependencies: [{
+				metadata: {
+					name: "sap.ui.core"
+				}
+			}]
+		}
+	};
+	const resources = ["", "_en", "_de"].map((lang) => {
+		return {
+			getPath: () => {
+				return `${prefix}i18n/i18n${lang}.properties`;
+			}
+		};
+	});
+
+	const expectedManifestContentObjectMultilineDocumentation = expectedManifestContentObject();
+	expectedManifestContentObjectMultilineDocumentation["sap.app"].title =
+		`Library E uses a multi-line documentation text.`;
+	expectedManifestContentObjectMultilineDocumentation["sap.app"].description =
+		`Library E
+    uses a multi-line documentation text.`;
+
+	const expectedManifestContentMultilineDocumentation =
+		JSON.stringify(expectedManifestContentObjectMultilineDocumentation, null, 2);
+
+	t.is(errorLogStub.callCount, 0);
+
+	const result = await manifestCreator({libraryResource, resources, options: {}});
+	t.is(await result.getString(), expectedManifestContentMultilineDocumentation, "Correct result returned");
+});
+
+
 test.serial("default manifest creation i18n empty string", async (t) => {
 	const {manifestCreator, errorLogStub} = t.context;
 	const prefix = "/resources/sap/ui/mine/";


### PR DESCRIPTION
The regular expression to trim additional whitespace / line-endings
wasn't working correctly. This is probably caused by the migration from
Java where double backslashes are required.

JIRA: CPOUI5FOUNDATION-422
