### PR TITLE
[INTERNAL] TaskUtil: Document standard tag 'IsBundle'

### DIFF
--- a/lib/builder/ProjectBuildContext.js
+++ b/lib/builder/ProjectBuildContext.js
@@ -1,5 +1,7 @@
 const ResourceTagCollection = require("@ui5/fs").ResourceTagCollection;
 
+// Note: When adding standard tags, always update the public documentation in TaskUtil
+// (Type "module:@ui5/builder.tasks.TaskUtil~StandardBuildTags")
 const STANDARD_TAGS = Object.freeze({
 	OmitFromBuildResult: "ui5:OmitFromBuildResult",
 	IsBundle: "ui5:IsBundle"

--- a/lib/tasks/TaskUtil.js
+++ b/lib/tasks/TaskUtil.js
@@ -20,6 +20,8 @@ class TaskUtil {
 	 * @typedef {object} module:@ui5/builder.tasks.TaskUtil~StandardBuildTags
 	 * @property {string} OmitFromBuildResult
 	 * 		Setting this tag to true for a resource will prevent it from being written to the build target
+	 * @property {string} IsBundle
+	 * 		This tag identifies resources that contain (i.e. bundle) multiple other resources
 	 */
 
 	/**


### PR DESCRIPTION
Seems like an oversight in https://github.com/SAP/ui5-builder/pull/535.
The tag can already be used and should be documented in the API reference