### PR TITLE
[FIX] Bundler: Sort raw modules by default

### DIFF
--- a/lib/lbt/bundle/Resolver.js
+++ b/lib/lbt/bundle/Resolver.js
@@ -289,7 +289,7 @@ class BundleResolver {
 
 				return collectModulesForSection(section).
 					then( (modules) => {
-						if ( section.mode == SectionType.Raw && section.sort ) {
+						if ( section.mode == SectionType.Raw && section.sort !== false ) {
 							// sort the modules in topological order
 							return topologicalSort(pool, modules).then( (modules) => {
 								log.verbose("      resolved modules (sorted): %s", modules);

--- a/test/lib/lbt/graph/topologicalSort.js
+++ b/test/lib/lbt/graph/topologicalSort.js
@@ -30,10 +30,17 @@ test("topologicalSort", async (t) => {
 	t.deepEqual(topologicalSortResult, ["mydep", "myroot"]);
 });
 
-
 test("cyclic dependencies", async (t) => {
 	const pool = createMockPool({"third": "mydep", "mydep": "third"});
 	const roots = ["myroot", "mydep", "third"];
 	const error = await t.throwsAsync(topologicalSort(pool, roots));
 	t.deepEqual(error.message, "failed to resolve cyclic dependencies: mydep,third");
+});
+
+test("no dependencies", async (t) => {
+	const pool = createMockPool({});
+	const roots = ["module4", "module2", "module3", "module1"];
+	const topologicalSortResult = await topologicalSort(pool, roots);
+	// Modules should not be sorted by any means as no dependencies are defined
+	t.deepEqual(topologicalSortResult, ["module4", "module2", "module3", "module1"]);
 });


### PR DESCRIPTION
Unlike the documentation states, topological sorting of modules within
'raw' sections was not enabled by default.

Sorting is based on dependencies only, so enabling it by default should
only solve issues in case dependencies are declared but sort was not
enabled.
If no dependencies are defined, the order will not change.

This could only break use cases where dependencies have been wrongly
declared and a user relies on the current unsorted order.