### PR TITLE
[FIX] Enable buildThemes for libraries without .library

### DIFF
--- a/lib/tasks/buildThemes.js
+++ b/lib/tasks/buildThemes.js
@@ -54,8 +54,12 @@ module.exports = async function({
 		*/
 	let availableLibraries;
 	if (pAvailableLibraries) {
-		availableLibraries = (await pAvailableLibraries).map((resource) => {
-			return resource.getPath().replace(/[^/]*\.library/i, "");
+		availableLibraries = [];
+		(await pAvailableLibraries).forEach((resource) => {
+			const library = path.dirname(resource.getPath());
+			if (!availableLibraries.includes(library)) {
+				availableLibraries.push(library);
+			}
 		});
 	}
 	let availableThemes;

--- a/lib/types/library/LibraryBuilder.js
+++ b/lib/types/library/LibraryBuilder.js
@@ -176,7 +176,7 @@ class LibraryBuilder extends AbstractBuilder {
 				dependencies: resourceCollections.dependencies,
 				options: {
 					projectName: project.metadata.name,
-					librariesPattern: !taskUtil.isRootProject() ? "/resources/**/*.library" : undefined,
+					librariesPattern: !taskUtil.isRootProject() ? "/resources/**/(*.library|library.js)" : undefined,
 					themesPattern: !taskUtil.isRootProject() ? "/resources/sap/ui/core/themes/*" : undefined,
 					inputPattern
 				}

--- a/lib/types/themeLibrary/ThemeLibraryBuilder.js
+++ b/lib/types/themeLibrary/ThemeLibraryBuilder.js
@@ -29,7 +29,7 @@ class ThemeLibraryBuilder extends AbstractBuilder {
 				dependencies: resourceCollections.dependencies,
 				options: {
 					projectName: project.metadata.name,
-					librariesPattern: !taskUtil.isRootProject() ? "/resources/**/*.library" : undefined,
+					librariesPattern: !taskUtil.isRootProject() ? "/resources/**/(*.library|library.js)" : undefined,
 					themesPattern: !taskUtil.isRootProject() ? "/resources/sap/ui/core/themes/*" : undefined,
 					inputPattern: "/resources/**/themes/*/library.source.less"
 				}

--- a/test/lib/tasks/buildThemes.js
+++ b/test/lib/tasks/buildThemes.js
@@ -233,8 +233,11 @@ test.serial("buildThemes (filtering libraries)", async (t) => {
 		"sap/ui/lib1/.library": {
 			getPath: sinon.stub().returns("/resources/sap/ui/lib1/.library")
 		},
-		"sap/ui/lib3/.library": {
-			getPath: sinon.stub().returns("/resources/sap/ui/lib3/.library")
+		"sap/ui/lib1/library.js": {
+			getPath: sinon.stub().returns("/resources/sap/ui/lib1/library.js")
+		},
+		"sap/ui/lib3/library.js": {
+			getPath: sinon.stub().returns("/resources/sap/ui/lib3/library.js")
 		}
 	};
 
@@ -252,9 +255,10 @@ test.serial("buildThemes (filtering libraries)", async (t) => {
 		]);
 
 	t.context.comboByGlob
-		.withArgs("/resources/**/*.library").resolves([
+		.withArgs("/resources/**/(*.library|library.js)").resolves([
 			dotLibraryResources["sap/ui/lib1/.library"],
-			dotLibraryResources["sap/ui/lib3/.library"]
+			dotLibraryResources["sap/ui/lib1/library.js"],
+			dotLibraryResources["sap/ui/lib3/library.js"]
 		]);
 
 	t.context.themeBuilderStub.returns([{}]);
@@ -264,7 +268,7 @@ test.serial("buildThemes (filtering libraries)", async (t) => {
 		options: {
 			projectName: "sap.ui.test.lib1",
 			inputPattern: "/resources/**/themes/*/library.source.less",
-			librariesPattern: "/resources/**/*.library"
+			librariesPattern: "/resources/**/(*.library|library.js)"
 		}
 	});
 
@@ -403,8 +407,11 @@ test.serial("buildThemes (filtering libraries + themes)", async (t) => {
 		"sap/ui/lib1/.library": {
 			getPath: sinon.stub().returns("/resources/sap/ui/lib1/.library")
 		},
-		"sap/ui/lib3/.library": {
-			getPath: sinon.stub().returns("/resources/sap/ui/lib3/.library")
+		"sap/ui/lib1/library.js": {
+			getPath: sinon.stub().returns("/resources/sap/ui/lib1/library.js")
+		},
+		"sap/ui/lib3/library.js": {
+			getPath: sinon.stub().returns("/resources/sap/ui/lib3/library.js")
 		}
 	};
 
@@ -443,9 +450,10 @@ test.serial("buildThemes (filtering libraries + themes)", async (t) => {
 		]);
 
 	t.context.comboByGlob
-		.withArgs("/resources/**/*.library").resolves([
+		.withArgs("/resources/**/(*.library|library.js)").resolves([
 			dotLibraryResources["sap/ui/lib1/.library"],
-			dotLibraryResources["sap/ui/lib3/.library"]
+			dotLibraryResources["sap/ui/lib1/library.js"],
+			dotLibraryResources["sap/ui/lib3/library.js"]
 		])
 		.withArgs("/resources/sap/ui/core/themes/*", {nodir: false}).resolves([
 			baseThemes["sap/ui/core/themes/theme1/"],
@@ -459,7 +467,7 @@ test.serial("buildThemes (filtering libraries + themes)", async (t) => {
 		options: {
 			projectName: "sap.ui.test.lib1",
 			inputPattern: "/resources/**/themes/*/library.source.less",
-			librariesPattern: "/resources/**/*.library",
+			librariesPattern: "/resources/**/(*.library|library.js)",
 			themesPattern: "/resources/sap/ui/core/themes/*"
 		}
 	});


### PR DESCRIPTION
Fixes that libraries using a "library.js" file but no ".library"
file can also build theming files.

Fixes: https://github.com/SAP/ui5-tooling/issues/582
