### PR TITLE
[INTERNAL] Enhance replaceVersion task to handle ${project.version} pattern

### DIFF
--- a/lib/tasks/replaceVersion.js
+++ b/lib/tasks/replaceVersion.js
@@ -18,7 +18,7 @@ module.exports = function({workspace, options: {pattern, version}}) {
 			return stringReplacer({
 				resources: allResources,
 				options: {
-					pattern: "${version}",
+					pattern: /\$\{(?:project\.)?version\}/g,
 					replacement: version
 				}
 			});

--- a/test/lib/tasks/replaceVersion.js
+++ b/test/lib/tasks/replaceVersion.js
@@ -13,8 +13,8 @@ test("integration: replace version", (t) => {
 		virBasePath: "/"
 	});
 
-	const content = "console.log('${version}');";
-	const expected = "console.log('1.337.0');";
+	const content = "console.log('${version} equals ${project.version}');";
+	const expected = "console.log('1.337.0 equals 1.337.0');";
 
 	const resource = resourceFactory.createResource({
 		path: "/test.js",


### PR DESCRIPTION
Ensures that the build task "replaceVersion" replaces
the pattern ${project.version} equally to ${version}.

JIRA: CPOUI5FOUNDATION-423