### PR TITLE
[INTERNAL] npm release: Add missing CHANGELOG file

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 	},
 	"files": [
 		"index.js",
+		"CHANGELOG.md",
 		"CONTRIBUTING.md",
 		"jsdoc.json",
 		"lib/**",


### PR DESCRIPTION
The CLI needs the changelog files of all modules to create a
consolidated changelog.

Since npm v7 the CHANGELOG file is not always published anymore.
See: https://github.com/npm/npm-packlist/pull/61
