### PR TITLE
[FIX] XMLTemplateAnalyzer: Analyze core:require of FragmentDefinition

### DIFF
--- a/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -231,9 +231,10 @@ class XMLTemplateAnalyzer {
 			// looks like a UI5 library or package name
 			const moduleName = ModuleName.fromUI5LegacyName( (namespace ? namespace + "." : "") + localName );
 
+			this._analyzeCoreRequire(node);
+
 			// ignore FragmentDefinition (also skipped by runtime XMLTemplateProcessor)
 			if ( FRAGMENTDEFINITION_MODULE !== moduleName ) {
-				this._analyzeCoreRequire(node);
 				this.promises.push(this._analyzeModuleDependency(node, moduleName, this.conditional));
 			}
 		}

--- a/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -326,6 +326,26 @@ test("integration: Analysis of an xml fragment", async (t) => {
 		"Implicit dependency should be added since a fragment is analyzed");
 });
 
+test("integration: Analysis of an xml fragment with core:require", async (t) => {
+	const xml = `
+	<core:FragmentDefinition
+		xmlns:core="sap.ui.core"
+		core:require="{Toast:'sap/m/MessageToast'}">
+	</core:FragmentDefinition>`;
+
+	const moduleInfo = new ModuleInfo();
+
+	const analyzer = new XMLTemplateAnalyzer(fakeMockPool);
+	await analyzer.analyzeFragment(xml, moduleInfo);
+	t.deepEqual(moduleInfo.dependencies,
+		[
+			"sap/ui/core/Fragment.js",
+			"sap/m/MessageToast.js"
+		], "Dependencies should come from the XML template");
+	t.true(moduleInfo.isImplicitDependency("sap/ui/core/Fragment.js"),
+		"Implicit dependency should be added since an XML Fragment is analyzed");
+});
+
 test("integration: Analysis of an empty xml view", async (t) => {
 	const xml = "";
 


### PR DESCRIPTION
The FragmentDefinition node should be skipped, but it may still contain
a core:require definition.
This is in line with the current runtime which also reads the require
and loads the module.
