### PR TITLE
[INTERNAL] generateLibraryManifest: Ignore dependency resources

### DIFF
--- a/lib/tasks/generateLibraryManifest.js
+++ b/lib/tasks/generateLibraryManifest.js
@@ -2,7 +2,6 @@
 
 const log = require("@ui5/logger").getLogger("builder:tasks:generateLibraryManifest");
 const manifestCreator = require("../processors/manifestCreator");
-const ReaderCollectionPrioritized = require("@ui5/fs").ReaderCollectionPrioritized;
 
 
 /**
@@ -12,23 +11,18 @@ const ReaderCollectionPrioritized = require("@ui5/fs").ReaderCollectionPrioritiz
  * @alias module:@ui5/builder.tasks.generateLibraryManifest
  * @param {object} parameters Parameters
  * @param {module:@ui5/fs.DuplexCollection} parameters.workspace DuplexCollection to read and write files
- * @param {module:@ui5/fs.AbstractReader} parameters.dependencies Reader or Collection to read dependency files
  * @param {object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written
  */
-module.exports = function({workspace, dependencies, options: {projectName}}) {
-	const combo = new ReaderCollectionPrioritized({
-		name: `libraryManifestGenerator - prioritize workspace over dependencies: ${projectName}`,
-		readers: [workspace, dependencies]
-	});
+module.exports = function({workspace, options: {projectName}}) {
 	// Note:
 	// *.library files are needed to identify libraries
 	// *.json files are needed to avoid overwriting them
 	// *.js files are needed to identify nested components
 	// *.less, *.css, *.theming and *.theme files are needed to identify supported themes
 	// *.properties to identify existence of i18n bundles (e.g. messagebundle.properties)
-	return combo.byGlob("/**/*.{js,json,library,less,css,theming,theme,properties}").then((resources) => {
+	return workspace.byGlob("/resources/**/*.{js,json,library,less,css,theming,theme,properties}").then((resources) => {
 		// Find all libraries and create a manifest.json file
 		return workspace.byGlob("/resources/**/.library").then((libraryIndicatorResources) => {
 			if (libraryIndicatorResources.length < 1) {

--- a/lib/types/library/LibraryBuilder.js
+++ b/lib/types/library/LibraryBuilder.js
@@ -112,7 +112,6 @@ class LibraryBuilder extends AbstractBuilder {
 		this.addTask("generateLibraryManifest", async () => {
 			return getTask("generateLibraryManifest").task({
 				workspace: resourceCollections.workspace,
-				dependencies: resourceCollections.dependencies,
 				taskUtil,
 				options: {
 					projectName: project.metadata.name

--- a/test/lib/tasks/generateLibraryManifest.js
+++ b/test/lib/tasks/generateLibraryManifest.js
@@ -1,7 +1,6 @@
 const test = require("ava");
 
 const generateLibraryManifest = require("../../../lib/tasks/generateLibraryManifest");
-const path = require("path");
 const ui5Fs = require("@ui5/fs");
 const resourceFactory = ui5Fs.resourceFactory;
 
@@ -25,21 +24,13 @@ function createWorkspace() {
 	});
 }
 
-function createDependencies() {
-	return resourceFactory.createAdapter({
-		fsBasePath: path.join(__dirname, "..", "..", "fixtures", "sap.ui.core-evo", "main", "src"),
-		virBasePath: "/resources"
-	});
-}
-
 async function assertCreatedManifest(t, oExpectedManifest) {
-	const {workspace, dependencies, resources} = t.context;
+	const {workspace, resources} = t.context;
 
 	await Promise.all(resources.map((resource) => workspace.write(resource)));
 
 	await generateLibraryManifest({
 		workspace,
-		dependencies,
 		options: {
 			projectName: "Test Lib"
 		}
@@ -57,8 +48,6 @@ async function assertCreatedManifest(t, oExpectedManifest) {
 
 test("integration: Library without i18n bundle file", async (t) => {
 	t.context.workspace = createWorkspace();
-	t.context.dependencies = createDependencies();
-
 	t.context.resources = [];
 	t.context.resources.push(resourceFactory.createResource({
 		path: "/resources/test/lib/.library",
@@ -110,7 +99,6 @@ test("integration: Library without i18n bundle file", async (t) => {
 
 test("integration: Library with i18n bundle file (messagebundle.properties)", async (t) => {
 	t.context.workspace = createWorkspace();
-	t.context.dependencies = createDependencies();
 
 	t.context.resources = [];
 	t.context.resources.push(resourceFactory.createResource({
@@ -171,7 +159,6 @@ test("integration: Library with i18n bundle file (messagebundle.properties)", as
 
 test("integration: Library with i18n=true declared in .library", async (t) => {
 	t.context.workspace = createWorkspace();
-	t.context.dependencies = createDependencies();
 
 	t.context.resources = [];
 	t.context.resources.push(resourceFactory.createResource({
@@ -241,7 +228,6 @@ test("integration: Library with i18n=true declared in .library", async (t) => {
 
 test("integration: Library with i18n=false declared in .library", async (t) => {
 	t.context.workspace = createWorkspace();
-	t.context.dependencies = createDependencies();
 
 	t.context.resources = [];
 	t.context.resources.push(resourceFactory.createResource({
@@ -304,7 +290,6 @@ test("integration: Library with i18n=false declared in .library", async (t) => {
 
 test("integration: Library with i18n=foo.properties declared in .library", async (t) => {
 	t.context.workspace = createWorkspace();
-	t.context.dependencies = createDependencies();
 
 	t.context.resources = [];
 	t.context.resources.push(resourceFactory.createResource({
@@ -374,7 +359,6 @@ test("integration: Library with i18n=foo.properties declared in .library", async
 
 test("integration: Library with css=true declared in .library", async (t) => {
 	t.context.workspace = createWorkspace();
-	t.context.dependencies = createDependencies();
 
 	t.context.resources = [];
 	t.context.resources.push(resourceFactory.createResource({
@@ -437,7 +421,6 @@ test("integration: Library with css=true declared in .library", async (t) => {
 
 test("integration: Library with css=false declared in .library", async (t) => {
 	t.context.workspace = createWorkspace();
-	t.context.dependencies = createDependencies();
 
 	t.context.resources = [];
 	t.context.resources.push(resourceFactory.createResource({


### PR DESCRIPTION
They should not be required to generate a manifest.json for a library
project.