### PR TITLE
[INTERNAL] JSDoc generation: enable links with prefix 'demo:'

### DIFF
--- a/lib/processors/jsdoc/lib/transformApiJson.js
+++ b/lib/processors/jsdoc/lib/transformApiJson.js
@@ -1386,13 +1386,16 @@ function transformer(sInputFile, sOutputFile, sLibraryFile, vDependencyAPIFiles,
 
 		},
 
+		formatUrlToLink: function(sTarget, sText, bSAPHosted){
+			return `<a target="_blank" rel="noopener noreferrer" href="${sTarget}">${sText}</a>
+			<img src="./resources/sap/ui/documentation/sdk/images/${bSAPHosted ? 'link-sap' : 'link-external'}.png"
+			title="Information published on ${bSAPHosted ? '' : 'non '}SAP site" class="sapUISDKExternalLink"/>`;
+		},
+
 		handleExternalUrl: function (sTarget, sText) {
 			// Check if the external domain is SAP hosted
 			let bSAPHosted = /^https?:\/\/([\w.]*\.)?(?:sap|hana\.ondemand|sapfioritrial)\.com/.test(sTarget);
-
-			return `<a target="_blank" rel="noopener noreferrer" href="${sTarget}">${sText}</a>
-<img src="./resources/sap/ui/documentation/sdk/images/${bSAPHosted ? 'link-sap' : 'link-external'}.png"
-title="Information published on ${bSAPHosted ? '' : 'non '}SAP site" class="sapUISDKExternalLink"/>`;
+			return this.formatUrlToLink(sTarget, sText, bSAPHosted);
 		},
 
 		/**
@@ -1597,6 +1600,12 @@ title="Information published on ${bSAPHosted ? '' : 'non '}SAP site" class="sapU
 						aMatch = sTarget.match(/^topic:(\w{32})$/);
 						if (aMatch) {
 							return '<a target="_self" href="topic/' + aMatch[1] + '">' + sText + '</a>';
+						}
+
+						// demo:xxx Demo, open the demonstration page in a new window
+						aMatch = sTarget.match(/^demo:([a-zA-Z0-9\/.]*)$/);
+						if (aMatch) {
+							return this.formatUrlToLink("test-resources/" + aMatch[1], sText, true);
 						}
 
 						// sap.x.Xxx.prototype.xxx - In case of prototype we have a link to method


### PR DESCRIPTION
Allows using the following JSDoc syntax {@link demo:my/module/page/demo.html My Demo}

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [x] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
