### PR TITLE
[INTERNAL] Fix tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"rimraf": "^3.0.2",
 				"semver": "^7.3.5",
 				"sourcemap-codec": "^1.4.8",
-				"terser": "^5.10.0",
+				"terser": "^5.14.1",
 				"xml2js": "^0.4.23",
 				"yazl": "^2.5.1"
 			},

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 		"rimraf": "^3.0.2",
 		"semver": "^7.3.5",
 		"sourcemap-codec": "^1.4.8",
-		"terser": "^5.10.0",
+		"terser": "^5.14.1",
 		"xml2js": "^0.4.23",
 		"yazl": "^2.5.1"
 	},

--- a/test/lib/builder/builder.js
+++ b/test/lib/builder/builder.js
@@ -8,7 +8,6 @@ const readFile = promisify(fs.readFile);
 const assert = chai.assert;
 const sinon = require("sinon");
 const mock = require("mock-require");
-const resourceFactory = require("@ui5/fs").resourceFactory;
 
 const {generateProjectGraph} = require("@ui5/project");
 const builder = require("@ui5/project").builder;
@@ -513,27 +512,11 @@ test.serial("Build application.j with resources.json and version info", async (t
 	const destPath = "./test/tmp/build/application.j/dest-resources-json";
 	const expectedPath = path.join("test", "expected", "build", "application.j", "dest-resources-json");
 
-
-	const dummyVersionInfoGenerator = () => {
-		const versionJson = {
-			"name": "application.j",
-			"version": "1.0.0",
-			"buildTimestamp": "202008120917",
-			"scmRevision": "",
-			"libraries": []
-		};
-
-		return [resourceFactory.createResource({
-			path: "/resources/sap-ui-version.json",
-			string: JSON.stringify(versionJson, null, "\t")
-		})];
-	};
-
-	mock("../../../lib/processors/versionInfoGenerator", dummyVersionInfoGenerator);
-	mock.reRequire("../../../lib/tasks/generateVersionInfo");
-
-	// TODO: Is this still required? If so, the @ui5/project build needs to be re-required
-	// const builder = mock.reRequire("../../../lib/builder/builder");
+	sinon.stub(Date.prototype, "getFullYear").returns(2020);
+	sinon.stub(Date.prototype, "getMonth").returns(7);
+	sinon.stub(Date.prototype, "getDate").returns(12);
+	sinon.stub(Date.prototype, "getHours").returns(9);
+	sinon.stub(Date.prototype, "getMinutes").returns(17);
 
 	const graph = await generateProjectGraph.usingObject({
 		dependencyTree: applicationJTree


### PR DESCRIPTION
- Ensure latest terser version
  (Related to 4789c2079a460447171dbbf4627ae6d0b56f9e6c)
- Mock Date methods to get a stable timestamp result
  Note: mocking a processor isn't easily possible as the @ui5/project
  builder is using its own @ui5/builder dependency.
