### PR TITLE
[INTERNAL] Move some verbose logging to silly level

### DIFF
--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -539,7 +539,7 @@ class BundleBuilder {
 		const sourceMapUrlMatch = moduleContent.match(sourceMappingUrlPattern);
 		if (sourceMapUrlMatch) {
 			const sourceMapUrl = sourceMapUrlMatch[1];
-			log.verbose(`Found source map reference in content of module ${moduleName}: ${sourceMapUrl}`);
+			log.silly(`Found source map reference in content of module ${moduleName}: ${sourceMapUrl}`);
 
 			// Strip sourceMappingURL from module code to be bundled
 			// It has no effect and might be cause for confusion

--- a/lib/lbt/bundle/Resolver.js
+++ b/lib/lbt/bundle/Resolver.js
@@ -292,12 +292,12 @@ class BundleResolver {
 						if ( section.mode == SectionType.Raw && section.sort !== false ) {
 							// sort the modules in topological order
 							return topologicalSort(pool, modules).then( (modules) => {
-								log.verbose("      resolved modules (sorted): %s", modules);
+								log.silly("      resolved modules (sorted): %s", modules);
 								return modules;
 							});
 						}
 
-						log.verbose("      resolved modules: %s", modules);
+						log.silly("      resolved modules: %s", modules);
 						return modules;
 					}).then( function(modules) {
 						resolvedSection.modules = modules;

--- a/lib/tasks/buildThemes.js
+++ b/lib/tasks/buildThemes.js
@@ -97,7 +97,7 @@ module.exports = async function({
 
 		if (log.isLevelEnabled("verbose")) {
 			if (!libraryAvailable) {
-				log.verbose(`Skipping ${resourcePath}: Library is not available`);
+				log.silly(`Skipping ${resourcePath}: Library is not available`);
 			}
 			if (!themeAvailable) {
 				log.verbose(`Skipping ${resourcePath}: sap.ui.core theme '${themeName}' is not available. ` +


### PR DESCRIPTION
This should help analysing issues.

* bundle/Resolver: The list of resolved modules typically gets truncated
  by the console.log anyways: "... xx more items". So we should think of
  a better way to output something usefull there if needed (maybe the
  count of modules?).
* bundle/Builder: We typically find lots of source maps.
* buildThemes: Not sure about this one, but I think it is typically OK
  to not find theme libraries, since they might just not be requested.