### PR TITLE
[INTERNAL] use eslint-plugin-ava and cleanup test-suite

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,7 +65,10 @@ module.exports = {
 		"jsdoc/require-returns": 0,
 		"jsdoc/require-returns-description": 0,
 		"jsdoc/require-returns-type": 2,
-		"jsdoc/valid-types": 0
+		"jsdoc/valid-types": 0,
+		// ava/assertion-arguments reports concatenated strings in a assertion message as an issue
+		// See: https://github.com/avajs/eslint-plugin-ava/issues/332
+		"ava/assertion-arguments": 0
 	},
 	"settings": {
 		"jsdoc": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,9 +3,10 @@ module.exports = {
 		"node": true,
 		"es2021": true
 	},
-	"extends": ["eslint:recommended", "google"],
+	"extends": ["eslint:recommended", "plugin:ava/recommended", "google"],
 	"plugins": [
-		"jsdoc"
+		"jsdoc",
+		"ava"
 	],
 	"rules": {
 		"indent": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
 				"docdash": "^1.2.0",
 				"eslint": "^8.7.0",
 				"eslint-config-google": "^0.14.0",
+				"eslint-plugin-ava": "^13.2.0",
 				"eslint-plugin-jsdoc": "^37.6.3",
 				"extract-zip": "^2.0.1",
 				"mock-require": "^3.0.3",
@@ -3005,6 +3006,18 @@
 				"once": "^1.4.0"
 			}
 		},
+		"node_modules/enhance-visitors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
+			"integrity": "sha512-+29eJLiUixTEDRaZ35Vu8jP3gPLNcQQkQkOQjLp2X+6cZGGPDD/uasbFzvLsJKnGZnvmyZ0srxudwOtskHeIDA==",
+			"dev": true,
+			"dependencies": {
+				"lodash": "^4.13.1"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/entities": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -3251,6 +3264,119 @@
 				"eslint": ">=5.16.0"
 			}
 		},
+		"node_modules/eslint-plugin-ava": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-13.2.0.tgz",
+			"integrity": "sha512-i5B5izsEdERKQLruk1nIWzTTE7C26/ju8qQf7JeyRv32XT2lRMW0zMFZNhIrEf5/5VvpSz2rqrV7UcjClGbKsw==",
+			"dev": true,
+			"dependencies": {
+				"enhance-visitors": "^1.0.0",
+				"eslint-utils": "^3.0.0",
+				"espree": "^9.0.0",
+				"espurify": "^2.1.1",
+				"import-modules": "^2.1.0",
+				"micro-spelling-correcter": "^1.1.1",
+				"pkg-dir": "^5.0.0",
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.22 <13 || >=14.17 <15 || >=16.4"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.22.0"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/pkg-dir": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/eslint-plugin-jsdoc": {
 			"version": "37.9.7",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.7.tgz",
@@ -3394,6 +3520,12 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/espurify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-2.1.1.tgz",
+			"integrity": "sha512-zttWvnkhcDyGOhSH4vO2qCBILpdCMv/MX8lp4cqgRkQoDRGK2oZxi2GfWhlP2dIXmk7BaKeOTuzbHhyC68o8XQ==",
+			"dev": true
 		},
 		"node_modules/esquery": {
 			"version": "1.4.0",
@@ -4380,6 +4512,18 @@
 			"bin": {
 				"import-local-fixture": "fixtures/cli.js"
 			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/import-modules": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
+			"integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -5446,6 +5590,12 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/micro-spelling-correcter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz",
+			"integrity": "sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==",
+			"dev": true
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.5",
@@ -9092,6 +9242,18 @@
 			"dependencies": {
 				"buffer-crc32": "~0.2.3"
 			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		}
 	},
 	"dependencies": {
@@ -11433,6 +11595,15 @@
 				"once": "^1.4.0"
 			}
 		},
+		"enhance-visitors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
+			"integrity": "sha512-+29eJLiUixTEDRaZ35Vu8jP3gPLNcQQkQkOQjLp2X+6cZGGPDD/uasbFzvLsJKnGZnvmyZ0srxudwOtskHeIDA==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.13.1"
+			}
+		},
 		"entities": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -11665,6 +11836,82 @@
 			"dev": true,
 			"requires": {}
 		},
+		"eslint-plugin-ava": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-13.2.0.tgz",
+			"integrity": "sha512-i5B5izsEdERKQLruk1nIWzTTE7C26/ju8qQf7JeyRv32XT2lRMW0zMFZNhIrEf5/5VvpSz2rqrV7UcjClGbKsw==",
+			"dev": true,
+			"requires": {
+				"enhance-visitors": "^1.0.0",
+				"eslint-utils": "^3.0.0",
+				"espree": "^9.0.0",
+				"espurify": "^2.1.1",
+				"import-modules": "^2.1.0",
+				"micro-spelling-correcter": "^1.1.1",
+				"pkg-dir": "^5.0.0",
+				"resolve-from": "^5.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+					"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^5.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				}
+			}
+		},
 		"eslint-plugin-jsdoc": {
 			"version": "37.9.7",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.7.tgz",
@@ -11735,6 +11982,12 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"espurify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-2.1.1.tgz",
+			"integrity": "sha512-zttWvnkhcDyGOhSH4vO2qCBILpdCMv/MX8lp4cqgRkQoDRGK2oZxi2GfWhlP2dIXmk7BaKeOTuzbHhyC68o8XQ==",
 			"dev": true
 		},
 		"esquery": {
@@ -12531,6 +12784,12 @@
 				"pkg-dir": "^4.2.0",
 				"resolve-cwd": "^3.0.0"
 			}
+		},
+		"import-modules": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
+			"integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
@@ -13348,6 +13607,12 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+		},
+		"micro-spelling-correcter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz",
+			"integrity": "sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "4.0.5",
@@ -16224,6 +16489,12 @@
 			"requires": {
 				"buffer-crc32": "~0.2.3"
 			}
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
 		"eslint": "^8.7.0",
 		"eslint-config-google": "^0.14.0",
 		"eslint-plugin-jsdoc": "^37.6.3",
+		"eslint-plugin-ava": "^13.2.0",
 		"extract-zip": "^2.0.1",
 		"mock-require": "^3.0.3",
 		"nyc": "^15.1.0",

--- a/test/lib/builder/builder.js
+++ b/test/lib/builder/builder.js
@@ -648,13 +648,13 @@ test.serial("Build library.e with build manifest", async (t) => {
 		}
 	}, "Build manifest contains expected tags");
 
-	t.deepEqual(manifest.buildManifest.namespace, "library/e",
+	t.is(manifest.buildManifest.namespace, "library/e",
 		"Build manifest contains expected namespace");
 
-	t.deepEqual(manifest.buildManifest.timestamp, "2022-07-27T09:00:00.000Z",
+	t.is(manifest.buildManifest.timestamp, "2022-07-27T09:00:00.000Z",
 		"Build manifest contains expected timestamp");
 
-	t.deepEqual(manifest.buildManifest.version, "1.0.0",
+	t.is(manifest.buildManifest.version, "1.0.0",
 		"Build manifest contains expected version");
 });
 
@@ -843,13 +843,13 @@ test.serial("Build library.h w/ custom bundles, component-preloads, resources.js
 		}
 	}, "Build manifest contains expected tags");
 
-	t.deepEqual(manifest.buildManifest.namespace, "library/h",
+	t.is(manifest.buildManifest.namespace, "library/h",
 		"Build manifest contains expected namespace");
 
-	t.deepEqual(manifest.buildManifest.timestamp, "2022-07-27T09:00:00.000Z",
+	t.is(manifest.buildManifest.timestamp, "2022-07-27T09:00:00.000Z",
 		"Build manifest contains expected timestamp");
 
-	t.deepEqual(manifest.buildManifest.version, "1.0.0",
+	t.is(manifest.buildManifest.version, "1.0.0",
 		"Build manifest contains expected version");
 });
 
@@ -994,13 +994,13 @@ test.serial("Build library.i, bundling library.h with build manifest", async (t)
 		}
 	}, "Build manifest contains expected tags");
 
-	t.deepEqual(manifest.buildManifest.namespace, "library/i",
+	t.is(manifest.buildManifest.namespace, "library/i",
 		"Build manifest contains expected namespace");
 
-	t.deepEqual(manifest.buildManifest.timestamp, "2022-07-27T09:00:00.000Z",
+	t.is(manifest.buildManifest.timestamp, "2022-07-27T09:00:00.000Z",
 		"Build manifest contains expected timestamp");
 
-	t.deepEqual(manifest.buildManifest.version, "1.0.0",
+	t.is(manifest.buildManifest.version, "1.0.0",
 		"Build manifest contains expected version");
 });
 
@@ -1118,13 +1118,13 @@ test.serial("Build theme.j with build manifest", async (t) => {
 
 	t.deepEqual(manifest.buildManifest.tags, {}, "Build manifest contains expected tags");
 
-	t.deepEqual(manifest.buildManifest.namespace, null,
+	t.is(manifest.buildManifest.namespace, null,
 		"Build manifest contains expected namespace");
 
-	t.deepEqual(manifest.buildManifest.timestamp, "2022-07-27T09:00:00.000Z",
+	t.is(manifest.buildManifest.timestamp, "2022-07-27T09:00:00.000Z",
 		"Build manifest contains expected timestamp");
 
-	t.deepEqual(manifest.buildManifest.version, "1.0.0",
+	t.is(manifest.buildManifest.version, "1.0.0",
 		"Build manifest contains expected version");
 });
 

--- a/test/lib/lbt/analyzer/ComponentAnalyzer.js
+++ b/test/lib/lbt/analyzer/ComponentAnalyzer.js
@@ -300,11 +300,9 @@ test("rootView with object", async (t) => {
 	};
 
 	const subject = new ComponentAnalyzer(mockPool);
-	return await subject.analyze({name: path.join("test", "Component.js")}, mockInfo).then( () => {
-		t.deepEqual(mockInfo.deps, [
-			"test/view/App.view.js",
-		], "dependencies should be correct");
-	});
+
+	await subject.analyze({name: path.join("test", "Component.js")}, mockInfo);
+	t.deepEqual(mockInfo.deps, ["test/view/App.view.js"], "dependencies should be correct");
 });
 
 test("rootView with string", async (t) => {
@@ -324,11 +322,8 @@ test("rootView with string", async (t) => {
 	};
 
 	const subject = new ComponentAnalyzer(mockPool);
-	return await subject.analyze({name: path.join("test", "Component.js")}, mockInfo).then( () => {
-		t.deepEqual(mockInfo.deps, [
-			"test/view/App.view.xml",
-		], "dependencies should be correct");
-	});
+	await subject.analyze({name: path.join("test", "Component.js")}, mockInfo);
+	t.deepEqual(mockInfo.deps, ["test/view/App.view.xml"], "dependencies should be correct");
 });
 
 

--- a/test/lib/lbt/analyzer/ComponentAnalyzer.js
+++ b/test/lib/lbt/analyzer/ComponentAnalyzer.js
@@ -279,7 +279,7 @@ test("routing with targets with local config", async (t) => {
 	], "dependencies should be correct");
 });
 
-test("rootView with object", (t) => {
+test("rootView with object", async (t) => {
 	const mockManifest = {
 		"sap.ui5": {
 			rootView: {
@@ -300,14 +300,14 @@ test("rootView with object", (t) => {
 	};
 
 	const subject = new ComponentAnalyzer(mockPool);
-	return subject.analyze({name: path.join("test", "Component.js")}, mockInfo).then( () => {
+	return await subject.analyze({name: path.join("test", "Component.js")}, mockInfo).then( () => {
 		t.deepEqual(mockInfo.deps, [
 			"test/view/App.view.js",
 		], "dependencies should be correct");
 	});
 });
 
-test("rootView with string", (t) => {
+test("rootView with string", async (t) => {
 	const mockManifest = {
 		"sap.ui5": {
 			rootView: "test.view.App"
@@ -324,7 +324,7 @@ test("rootView with string", (t) => {
 	};
 
 	const subject = new ComponentAnalyzer(mockPool);
-	return subject.analyze({name: path.join("test", "Component.js")}, mockInfo).then( () => {
+	return await subject.analyze({name: path.join("test", "Component.js")}, mockInfo).then( () => {
 		t.deepEqual(mockInfo.deps, [
 			"test/view/App.view.xml",
 		], "dependencies should be correct");
@@ -437,10 +437,10 @@ test("_analyzeManifest: Manifest with routing and routes array", async (t) => {
 
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
-	t.deepEqual(stubAddDependency.callCount, 2, "addDependency was called twice");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/core/routing/Router.js",
+	t.is(stubAddDependency.callCount, 2, "addDependency was called twice");
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/core/routing/Router.js",
 		"addDependency should be called with the router dependency name");
-	t.deepEqual(stubAddDependency.getCall(1).args[0], "test/view/App.view.xml",
+	t.is(stubAddDependency.getCall(1).args[0], "test/view/App.view.xml",
 		"addDependency should be called with the app dependency name");
 });
 
@@ -473,10 +473,10 @@ test("_analyzeManifest: Manifest with routing and routes object", async (t) => {
 
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
-	t.deepEqual(stubAddDependency.callCount, 2, "addDependency was called twice");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/core/routing/Router.js",
+	t.is(stubAddDependency.callCount, 2, "addDependency was called twice");
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/core/routing/Router.js",
 		"addDependency should be called with the router dependency name");
-	t.deepEqual(stubAddDependency.getCall(1).args[0], "test/view/App.view.xml",
+	t.is(stubAddDependency.getCall(1).args[0], "test/view/App.view.xml",
 		"addDependency should be called with the app dependency name");
 });
 
@@ -511,7 +511,7 @@ test("_analyzeManifest: Manifest with legacy routes object", async (t) => {
 
 	// Note: Dependencies to views within legacy routes are not collected
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/core/routing/Router.js",
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/core/routing/Router.js",
 		"addDependency should be called with the router dependency name");
 });
 
@@ -538,7 +538,7 @@ test("_analyzeManifest: Manifest with empty routes array", async (t) => {
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/core/routing/Router.js",
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/core/routing/Router.js",
 		"addDependency should be called with the router dependency name");
 });
 
@@ -563,7 +563,7 @@ test("_analyzeManifest: Manifest with rootview object", async (t) => {
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "test/view/App.view.js",
+	t.is(stubAddDependency.getCall(0).args[0], "test/view/App.view.js",
 		"addDependency should be called with the dependency name");
 });
 
@@ -583,7 +583,7 @@ test("_analyzeManifest: Manifest with rootview string", async (t) => {
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "test/view/App.view.xml",
+	t.is(stubAddDependency.getCall(0).args[0], "test/view/App.view.xml",
 		"addDependency should be called with the dependency name");
 });
 
@@ -607,7 +607,7 @@ test("_analyzeManifest: Manifest with dependency libs", async (t) => {
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/core/library.js",
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/core/library.js",
 		"addDependency should be called with the dependency name");
 });
 
@@ -631,7 +631,7 @@ test("_analyzeManifest: Manifest with dependency components", async (t) => {
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/test/manifestload/Component.js",
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/test/manifestload/Component.js",
 		"addDependency should be called with the dependency name");
 });
 
@@ -655,7 +655,7 @@ test("_analyzeManifest: Manifest with models", async (t) => {
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/model/resource/ResourceModel.js",
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/model/resource/ResourceModel.js",
 		"addDependency should be called with the dependency name");
 });
 
@@ -690,7 +690,7 @@ test("_analyzeManifest: Manifest with V2 OData model via dataSources", async (t)
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/model/odata/v2/ODataModel.js",
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/model/odata/v2/ODataModel.js",
 		"addDependency should be called with the dependency name");
 });
 
@@ -721,7 +721,7 @@ test("_analyzeManifest: Manifest with V2 OData model via dataSources (default ty
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/model/odata/v2/ODataModel.js",
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/model/odata/v2/ODataModel.js",
 		"addDependency should be called with the dependency name");
 });
 
@@ -753,7 +753,7 @@ test("_analyzeManifest: Manifest with V2 OData model via dataSources with settin
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/model/odata/v2/ODataModel.js",
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/model/odata/v2/ODataModel.js",
 		"addDependency should be called with the dependency name");
 });
 
@@ -788,7 +788,7 @@ test("_analyzeManifest: Manifest with V4 OData model via dataSources", async (t)
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/model/odata/v4/ODataModel.js",
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/model/odata/v4/ODataModel.js",
 		"addDependency should be called with the dependency name");
 });
 
@@ -854,7 +854,7 @@ test("_analyzeManifest: Manifest with JSON model via dataSources", async (t) => 
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/model/json/JSONModel.js",
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/model/json/JSONModel.js",
 		"addDependency should be called with the dependency name");
 });
 
@@ -886,7 +886,7 @@ test("_analyzeManifest: Manifest with XML model via dataSources", async (t) => {
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/ui/model/xml/XMLModel.js",
+	t.is(stubAddDependency.getCall(0).args[0], "sap/ui/model/xml/XMLModel.js",
 		"addDependency should be called with the dependency name");
 });
 

--- a/test/lib/lbt/analyzer/FioriElementsAnalyzer.js
+++ b/test/lib/lbt/analyzer/FioriElementsAnalyzer.js
@@ -95,7 +95,7 @@ test("_analyzeManifest: Manifest with TemplateAssembler code", async (t) => {
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.true(stubAnalyzeTemplateComponent.calledOnce, "_analyzeManifest was called once");
-	t.deepEqual(stubAnalyzeTemplateComponent.getCall(0).args[0], "sap/fe/templates/MyTmpl/Component.js",
+	t.is(stubAnalyzeTemplateComponent.getCall(0).args[0], "sap/fe/templates/MyTmpl/Component.js",
 		"_analyzeManifest should be called with the module name");
 
 	t.deepEqual(stubAnalyzeTemplateComponent.getCall(0).args[1], {
@@ -106,7 +106,7 @@ test("_analyzeManifest: Manifest with TemplateAssembler code", async (t) => {
 		"_analyzeManifest should be called with moduleInfo");
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "sap/fe/templates/MyTmpl/Component.js",
+	t.is(stubAddDependency.getCall(0).args[0], "sap/fe/templates/MyTmpl/Component.js",
 		"addDependency should be called with the dependency name");
 });
 
@@ -149,12 +149,12 @@ test.serial("_analyzeTemplateComponent: Manifest with TemplateAssembler code", a
 		{}, moduleInfo);
 
 	t.true(stubAnalyzeAST.calledOnce, "_analyzeManifest was called once");
-	t.deepEqual(stubAnalyzeAST.getCall(0).args[0], "pony",
+	t.is(stubAnalyzeAST.getCall(0).args[0], "pony",
 		"_analyzeManifest should be called with the module name");
 
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "mytpl.view.xml",
+	t.is(stubAddDependency.getCall(0).args[0], "mytpl.view.xml",
 		"addDependency should be called with the dependency name");
 	stubAnalyzeAST.restore();
 	stubParse.restore();
@@ -219,7 +219,7 @@ test.serial("_analyzeTemplateComponent: with template name from pageConfig", asy
 	t.true(stubAnalyzeAST.calledOnce, "_analyzeManifest was called once");
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "donkey.view.xml",
+	t.is(stubAddDependency.getCall(0).args[0], "donkey.view.xml",
 		"addDependency should be called with the dependency name");
 	stubAnalyzeAST.restore();
 	stubParse.restore();
@@ -252,7 +252,7 @@ test("_analyzeAST: get template name from ast", async (t) => {
 	t.true(stubAnalyzeTemplateClassDefinition.calledOnce, "_analyzeTemplateClassDefinition was called once");
 
 	stubAnalyzeTemplateClassDefinition.restore();
-	t.deepEqual(result, "donkey");
+	t.is(result, "donkey");
 });
 
 test("_analyzeAST: no template name from ast", async (t) => {
@@ -282,7 +282,7 @@ test("_analyzeAST: no template name from ast", async (t) => {
 	t.true(stubAnalyzeTemplateClassDefinition.calledOnce, "_analyzeTemplateClassDefinition was called once");
 
 	stubAnalyzeTemplateClassDefinition.restore();
-	t.deepEqual(result, "");
+	t.is(result, "");
 });
 
 test("_analyzeTemplateClassDefinition: get template name from metadata", async (t) => {
@@ -304,7 +304,7 @@ test("_analyzeTemplateClassDefinition: get template name from metadata", async (
 
 	const result = await analyzer._analyzeTemplateClassDefinition(expression);
 
-	t.deepEqual(result, "sap.fe.templates.Page.view.Page", "defaultValue is retrieved");
+	t.is(result, "sap.fe.templates.Page.view.Page", "defaultValue is retrieved");
 });
 
 test("_analyzeTemplateClassDefinition: no string template name from metadata", async (t) => {

--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -199,15 +199,15 @@ test.cb("AMDMultipleNamedModulesOneMatchingFileName", (t) => {
 	);
 });
 
-test("AMDMultipleUnnamedModules", (t) =>
-	analyze("modules/amd_multiple_unnamed_modules.js")
-		.then(() => {
-			t.fail("parsing a file with multiple unnamed modules shouldn't succeed");
-		}, (err) => {
-			t.true(/only one of them/.test(err.message),
-				"Exception message should contain a hint on multiple unnamed modules");
-		})
-);
+test("AMDMultipleUnnamedModules", async (t) => {
+	try {
+		await analyze("modules/amd_multiple_unnamed_modules.js");
+		t.fail("parsing a file with multiple unnamed modules shouldn't succeed");
+	} catch (error) {
+		t.regex(error.message, /only one of them/,
+			"Exception message should contain a hint on multiple unnamed modules");
+	}
+});
 
 test.cb("AMDSingleNamedModule", (t) => {
 	analyzeModule(t,
@@ -230,35 +230,35 @@ test.cb("AMDSingleUnnamedModule", (t) => {
 });
 
 
-test("AMDMultipleModulesWithConflictBetweenNamedAndUnnamed", (t) =>
-	analyze("modules/amd_multiple_modules_with_conflict_between_named_and_unnamed.js")
-		.then(() => {
-			t.fail("parsing a file with conflicting modules shouldn't succeed");
-		}, (err) => {
-			t.is(err.message, "conflicting main modules found (unnamed + named)",
-				"Exception message should contain a hint on conflicting modules");
-		})
-);
+test("AMDMultipleModulesWithConflictBetweenNamedAndUnnamed", async (t) => {
+	try {
+		await analyze("modules/amd_multiple_modules_with_conflict_between_named_and_unnamed.js");
+		t.fail("parsing a file with conflicting modules shouldn't succeed");
+	} catch (error) {
+		t.is(error.message, "conflicting main modules found (unnamed + named)",
+			"Exception message should contain a hint on conflicting modules");
+	}
+});
 
-test("AMDMultipleModulesWithConflictBetweenUnnamedAndNamed", (t) =>
-	analyze("modules/amd_multiple_modules_with_conflict_between_unnamed_and_named.js")
-		.then(() => {
-			t.fail("parsing a file with conflicting modules shouldn't succeed");
-		}, (err) => {
-			t.is(err.message, "conflicting main modules found (unnamed + named)",
-				"Exception message should contain a hint on conflicting modules");
-		})
-);
+test("AMDMultipleModulesWithConflictBetweenUnnamedAndNamed", async (t) => {
+	try {
+		await analyze("modules/amd_multiple_modules_with_conflict_between_unnamed_and_named.js");
+		t.fail("parsing a file with conflicting modules shouldn't succeed");
+	} catch (error) {
+		t.is(error.message, "conflicting main modules found (unnamed + named)",
+			"Exception message should contain a hint on conflicting modules");
+	}
+});
 
-test("AMDMultipleModulesWithConflictBetweenTwoNamed", (t) =>
-	analyze("modules/amd_multiple_modules_with_conflict_between_two_named.js")
-		.then(() => {
-			t.fail("parsing a file with conflicting modules shouldn't succeed");
-		}, (err) => {
-			t.is(err.message, "conflicting main modules found (unnamed + named)",
-				"Exception message should contain a hint on conflicting modules");
-		})
-);
+test("AMDMultipleModulesWithConflictBetweenTwoNamed", async (t) => {
+	try {
+		await analyze("modules/amd_multiple_modules_with_conflict_between_two_named.js");
+		t.fail("parsing a file with conflicting modules shouldn't succeed");
+	} catch (error) {
+		t.is(error.message, "conflicting main modules found (unnamed + named)",
+			"Exception message should contain a hint on conflicting modules");
+	}
+});
 
 test.cb("OldStyleBundle", (t) => {
 	analyzeModule(t,
@@ -467,82 +467,77 @@ test.cb("EvoBundle", (t) => {
 	);
 });
 
-test("Bundle", (t) => {
-	return analyze("modules/bundle.js").then( (info) => {
-		const expected = [
-			"sap/m/CheckBox.js",
-			"sap/ui/core/Core.js",
-			"todo/Component.js",
-			"todo/controller/App.controller.js",
-			"sap/m/messagebundle.properties",
-			"todo/manifest.json",
-			"todo/model/todoitems.json",
-			"todo/view/App.view.xml"
-		];
-		t.deepEqual(info.subModules, expected, "module dependencies should match");
-		t.truthy(info.dependencies.every((dep) => !info.isConditionalDependency(dep)),
-			"none of the dependencies must be 'conditional'");
+test("Bundle", async (t) => {
+	const info = await analyze("modules/bundle.js");
+	const expected = [
+		"sap/m/CheckBox.js",
+		"sap/ui/core/Core.js",
+		"todo/Component.js",
+		"todo/controller/App.controller.js",
+		"sap/m/messagebundle.properties",
+		"todo/manifest.json",
+		"todo/model/todoitems.json",
+		"todo/view/App.view.xml"
+	];
+	t.deepEqual(info.subModules, expected, "module dependencies should match");
+	t.truthy(info.dependencies.every((dep) => !info.isConditionalDependency(dep)),
+		"none of the dependencies must be 'conditional'");
+	t.false(info.rawModule,
+		"ui5 module");
+});
+
+test("ES6 Syntax", async (t) => {
+	const info = await analyze("modules/es6-syntax.js", "modules/es6-syntax.js");
+	const expected = [
+		"conditional/module1.js",
+		"conditional/module2.js",
+		"conditional/module3.js",
+		"conditional/module4.js",
+		"static/module1.js",
+		"static/module2.js",
+		"static/module3.js",
+		"static/module4.js",
+		"static/module5.js",
+		"static/module6.js",
+		"static/module7.js",
+		"ui5loader-autoconfig.js"
+	];
+	const actual = info.dependencies.sort();
+	t.deepEqual(actual, expected, "module dependencies should match");
+	expected.forEach((dep) => {
+		t.is(info.isConditionalDependency(dep), /^conditional\//.test(dep),
+			"only dependencies to 'conditional/*' modules should be conditional");
+		t.is(info.isImplicitDependency(dep), !/^(?:conditional|static)\//.test(dep),
+			"all dependencies other than 'conditional/*' and 'static/*' should be implicit");
+		t.false(info.dynamicDependencies,
+			"no use of dynamic dependencies should have been detected");
 		t.false(info.rawModule,
 			"ui5 module");
 	});
 });
 
-test("ES6 Syntax", (t) => {
-	return analyze("modules/es6-syntax.js", "modules/es6-syntax.js").then( (info) => {
-		const expected = [
-			"conditional/module1.js",
-			"conditional/module2.js",
-			"conditional/module3.js",
-			"conditional/module4.js",
-			"static/module1.js",
-			"static/module2.js",
-			"static/module3.js",
-			"static/module4.js",
-			"static/module5.js",
-			"static/module6.js",
-			"static/module7.js",
-			"ui5loader-autoconfig.js"
-		];
-		const actual = info.dependencies.sort();
-		t.deepEqual(actual, expected, "module dependencies should match");
-		expected.forEach((dep) => {
-			t.is(info.isConditionalDependency(dep), /^conditional\//.test(dep),
-				"only dependencies to 'conditional/*' modules should be conditional");
-			t.is(info.isImplicitDependency(dep), !/^(?:conditional|static)\//.test(dep),
-				"all dependencies other than 'conditional/*' and 'static/*' should be implicit");
-			t.false(info.dynamicDependencies,
-				"no use of dynamic dependencies should have been detected");
-			t.false(info.rawModule,
-				"ui5 module");
-		});
-	});
+test("Dynamic import (declare/require)", async (t) => {
+	const info = await analyze("modules/declare_dynamic_require.js");
+	t.true(info.dynamicDependencies,
+		"the use of dynamic dependencies should have been detected");
+	t.false(info.rawModule,
+		"ui5 module");
 });
 
-test("Dynamic import (declare/require)", (t) => {
-	return analyze("modules/declare_dynamic_require.js").then((info) => {
-		t.true(info.dynamicDependencies,
-			"the use of dynamic dependencies should have been detected");
-		t.false(info.rawModule,
-			"ui5 module");
-	});
+test("Dynamic import (define/require)", async (t) => {
+	const info = await analyze("modules/amd_dynamic_require.js");
+	t.true(info.dynamicDependencies,
+		"the use of dynamic dependencies should have been detected");
+	t.false(info.rawModule,
+		"ui5 module");
 });
 
-test("Dynamic import (define/require)", (t) => {
-	return analyze("modules/amd_dynamic_require.js").then((info) => {
-		t.true(info.dynamicDependencies,
-			"the use of dynamic dependencies should have been detected");
-		t.false(info.rawModule,
-			"ui5 module");
-	});
-});
-
-test("Dynamic import (define/requireSync)", (t) => {
-	return analyze("modules/amd_dynamic_require_sync.js").then((info) => {
-		t.true(info.dynamicDependencies,
-			"the use of dynamic dependencies should have been detected");
-		t.false(info.rawModule,
-			"ui5 module");
-	});
+test("Dynamic import (define/requireSync)", async (t) => {
+	const info = await analyze("modules/amd_dynamic_require_sync.js");
+	t.true(info.dynamicDependencies,
+		"the use of dynamic dependencies should have been detected");
+	t.false(info.rawModule,
+		"ui5 module");
 });
 
 test("Nested require", (t) => {

--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -1,3 +1,7 @@
+/* eslint-disable ava/no-unknown-modifiers */
+/* Test modifier `cb` was deprecated with ava version
+3 and removed with ava version 4. Therefore, tests using `cb` has to be rewritten, when upgrade to ava version 4 */
+
 const test = require("ava");
 const fs = require("fs");
 const path = require("path");

--- a/test/lib/lbt/analyzer/SmartTemplateAnalyzer.js
+++ b/test/lib/lbt/analyzer/SmartTemplateAnalyzer.js
@@ -81,7 +81,7 @@ test("_analyzeManifest: with manifest with recursive pages (as array)", async (t
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.is(stubAnalyzeTemplateComponent.callCount, 2, "_analyzeTemplateComponent was called twice");
-	t.deepEqual(stubAnalyzeTemplateComponent.getCall(0).args[0], "test/mycomp/Component.js",
+	t.is(stubAnalyzeTemplateComponent.getCall(0).args[0], "test/mycomp/Component.js",
 		"_analyzeTemplateComponent should be called with the component");
 	t.deepEqual(stubAnalyzeTemplateComponent.getCall(0).args[1], {
 		"component": {
@@ -100,7 +100,7 @@ test("_analyzeManifest: with manifest with recursive pages (as array)", async (t
 		}]
 	}, "_analyzeTemplateComponent should be called with the page");
 
-	t.deepEqual(stubAnalyzeTemplateComponent.getCall(1).args[0], "test/mycomp2/Component.js",
+	t.is(stubAnalyzeTemplateComponent.getCall(1).args[0], "test/mycomp2/Component.js",
 		"_analyzeTemplateComponent should be called with the component");
 	t.deepEqual(stubAnalyzeTemplateComponent.getCall(1).args[1], {
 		"component": {
@@ -112,7 +112,7 @@ test("_analyzeManifest: with manifest with recursive pages (as array)", async (t
 	}, "_analyzeTemplateComponent should be called with the page");
 
 	t.is(stubAddDependency.callCount, 2, "addDependency was called twice");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "test/mycomp/Component.js",
+	t.is(stubAddDependency.getCall(0).args[0], "test/mycomp/Component.js",
 		"addDependency should be called with the dependency name");
 });
 
@@ -153,7 +153,7 @@ test("_analyzeManifest: with manifest with recursive pages (as object)", async (
 	await analyzer._analyzeManifest(manifest, moduleInfo);
 
 	t.is(stubAnalyzeTemplateComponent.callCount, 2, "_analyzeTemplateComponent was called twice");
-	t.deepEqual(stubAnalyzeTemplateComponent.getCall(0).args[0], "test/mycomp/Component.js",
+	t.is(stubAnalyzeTemplateComponent.getCall(0).args[0], "test/mycomp/Component.js",
 		"_analyzeTemplateComponent should be called with the component");
 	t.deepEqual(stubAnalyzeTemplateComponent.getCall(0).args[1], {
 		"component": {
@@ -174,7 +174,7 @@ test("_analyzeManifest: with manifest with recursive pages (as object)", async (
 		}
 	}, "_analyzeTemplateComponent should be called with the page");
 
-	t.deepEqual(stubAnalyzeTemplateComponent.getCall(1).args[0], "test/mycomp2/Component.js",
+	t.is(stubAnalyzeTemplateComponent.getCall(1).args[0], "test/mycomp2/Component.js",
 		"_analyzeTemplateComponent should be called with the component");
 	t.deepEqual(stubAnalyzeTemplateComponent.getCall(1).args[1], {
 		"component": {
@@ -186,7 +186,7 @@ test("_analyzeManifest: with manifest with recursive pages (as object)", async (
 	}, "_analyzeTemplateComponent should be called with the page");
 
 	t.is(stubAddDependency.callCount, 2, "addDependency was called twice");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "test/mycomp/Component.js",
+	t.is(stubAddDependency.getCall(0).args[0], "test/mycomp/Component.js",
 		"addDependency should be called with the dependency name");
 });
 
@@ -216,12 +216,12 @@ test.serial("_analyzeTemplateComponent: Manifest with TemplateAssembler code", a
 		{}, moduleInfo);
 
 	t.true(stubAnalyzeAST.calledOnce, "_analyzeManifest was called once");
-	t.deepEqual(stubAnalyzeAST.getCall(0).args[0], "pony",
+	t.is(stubAnalyzeAST.getCall(0).args[0], "pony",
 		"_analyzeManifest should be called with the module name");
 
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "mytpl.view.xml",
+	t.is(stubAddDependency.getCall(0).args[0], "mytpl.view.xml",
 		"addDependency should be called with the dependency name");
 	stubAnalyzeAST.restore();
 	stubParse.restore();
@@ -292,7 +292,7 @@ test.serial("_analyzeTemplateComponent: with template name from pageConfig", asy
 	t.true(stubAnalyzeAST.calledOnce, "_analyzeManifest was called once");
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "donkey.view.xml",
+	t.is(stubAddDependency.getCall(0).args[0], "donkey.view.xml",
 		"addDependency should be called with the dependency name");
 	stubAnalyzeAST.restore();
 	stubParse.restore();
@@ -326,7 +326,7 @@ test.serial("_analyzeTemplateComponent: dependency not found", async (t) => {
 		}
 	}, moduleInfo));
 
-	t.deepEqual(error.message, `resource not found in pool: 'pony'`);
+	t.is(error.message, `resource not found in pool: 'pony'`);
 
 	t.is(stubAnalyzeAST.callCount, 0, "_analyzeManifest was not called");
 
@@ -398,7 +398,7 @@ test("_analyzeAST: get template name from ast", async (t) => {
 	t.true(stubAnalyzeTemplateClassDefinition.calledOnce, "_analyzeTemplateClassDefinition was called once");
 
 	stubAnalyzeTemplateClassDefinition.restore();
-	t.deepEqual(result, "donkey");
+	t.is(result, "donkey");
 });
 
 test("_analyzeAST: no template name from ast", async (t) => {
@@ -429,7 +429,7 @@ test("_analyzeAST: no template name from ast", async (t) => {
 	t.true(stubAnalyzeTemplateClassDefinition.calledOnce, "_analyzeTemplateClassDefinition was called once");
 
 	stubAnalyzeTemplateClassDefinition.restore();
-	t.deepEqual(result, "");
+	t.is(result, "");
 });
 
 test("Analysis of Manifest and TemplateAssembler code", async (t) => {
@@ -496,7 +496,7 @@ test("_analyzeTemplateClassDefinition: get template name from metadata", async (
 
 	const result = await analyzer._analyzeTemplateClassDefinition(expression);
 
-	t.deepEqual(result, "sap.fe.templates.Page.view.Page", "defaultValue is retrieved");
+	t.is(result, "sap.fe.templates.Page.view.Page", "defaultValue is retrieved");
 });
 
 test("_analyzeTemplateClassDefinition: no string template name from metadata", async (t) => {

--- a/test/lib/lbt/analyzer/XMLCompositeAnalyzer.js
+++ b/test/lib/lbt/analyzer/XMLCompositeAnalyzer.js
@@ -67,12 +67,12 @@ test("analyze: XMLComposite VariableDeclaration code", async (t) => {
 	const name = "composites.ButtonList";
 	await analyzer.analyze(ast, name, moduleInfo);
 	t.true(stubCheckForXMLCClassDefinition.calledOnce, "_checkForXMLCClassDefinition was called once");
-	t.deepEqual(stubCheckForXMLCClassDefinition.getCall(0).args[0], "XMLComposite",
+	t.is(stubCheckForXMLCClassDefinition.getCall(0).args[0], "XMLComposite",
 		"_checkForXMLCClassDefinition should be called with the name");
 
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "cow.control.xml",
+	t.is(stubAddDependency.getCall(0).args[0], "cow.control.xml",
 		"addDependency should be called with the dependency name");
 });
 
@@ -97,16 +97,16 @@ test("analyze: XMLComposite Expression code", async (t) => {
 	const name = "composites.ButtonList";
 	await analyzer.analyze(ast, name, moduleInfo);
 	t.true(stubCheckForXMLCClassDefinition.calledOnce, "_checkForXMLCClassDefinition was called once");
-	t.deepEqual(stubCheckForXMLCClassDefinition.getCall(0).args[0], "XMLComposite",
+	t.is(stubCheckForXMLCClassDefinition.getCall(0).args[0], "XMLComposite",
 		"_checkForXMLCClassDefinition should be called with the name");
 
 
 	t.true(stubAddDependency.calledOnce, "addDependency was called once");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "cow.control.xml",
+	t.is(stubAddDependency.getCall(0).args[0], "cow.control.xml",
 		"addDependency should be called with the dependency name");
 });
 
-test("_checkForXMLCClassDefinition: string argument and object expression", async (t) => {
+test("_checkForXMLCClassDefinition: string argument and object expression", (t) => {
 	const code = `XMLComposite.extend("composites.ButtonList", {})`;
 
 	const ast = parseJS(code);
@@ -116,11 +116,11 @@ test("_checkForXMLCClassDefinition: string argument and object expression", asyn
 	const result = analyzer._checkForXMLCClassDefinition("XMLComposite", ast.body[0].expression);
 	t.true(stubAnalyzeXMLCClassDefinition.calledOnce, "_checkForXMLCClassDefinition was called once");
 
-	t.deepEqual(result, "cow",
+	t.is(result, "cow",
 		"addDependency should be called with the dependency name");
 });
 
-test("_analyzeXMLCClassDefinition: name retrieval", async (t) => {
+test("_analyzeXMLCClassDefinition: name retrieval", (t) => {
 	const code = `test({fragment: "cat"})`;
 
 	const ast = parseJS(code);
@@ -128,6 +128,6 @@ test("_analyzeXMLCClassDefinition: name retrieval", async (t) => {
 	const analyzer = new XMLCompositeAnalyzer();
 	const result = analyzer._analyzeXMLCClassDefinition(ast.body[0].expression.arguments[0]);
 
-	t.deepEqual(result, "cat",
+	t.is(result, "cat",
 		"addDependency should be called with the dependency name");
 });

--- a/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -382,7 +382,7 @@ test("_addDependency: add dependency", (t) => {
 	analyzer.info = moduleInfo;
 	analyzer._addDependency("new");
 	t.true(stubAddDependency.calledOnce, "addDependency was called");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "new",
+	t.is(stubAddDependency.getCall(0).args[0], "new",
 		"addDependency should be called with the dependency name");
 });
 
@@ -394,7 +394,7 @@ test("_analyze: parseString error", async (t) => {
 		name: "my.fragment.xml"
 	};
 	const error = await t.throwsAsync(analyzer._analyze(null, moduleInfo));
-	t.deepEqual(error.message, "Error while parsing XML document my.fragment.xml: my-error");
+	t.is(error.message, "Error while parsing XML document my.fragment.xml: my-error");
 	t.false(analyzer.busy, "busy state is restored");
 });
 
@@ -414,7 +414,7 @@ test("_analyze: call twice to simulate busy", async (t) => {
 	const error = t.throws(()=> {
 		analyzer._analyze(null, moduleInfo, true);
 	});
-	t.deepEqual(error.message, "XMLTemplateAnalyzer is unexpectedly busy");
+	t.is(error.message, "XMLTemplateAnalyzer is unexpectedly busy");
 
 	await resultPromise;
 	t.false(analyzer.busy, "busy state is reset after promise resolves");
@@ -433,11 +433,11 @@ test("_analyze: node", async (t) => {
 	await analyzer._analyze(null, moduleInfo, true);
 
 	t.true(stubAnalyzeNode.calledOnce, "_analyzeNode was called");
-	t.deepEqual(stubAnalyzeNode.getCall(0).args[0], "parse-result",
+	t.is(stubAnalyzeNode.getCall(0).args[0], "parse-result",
 		"_analyzeNode should be called with the result");
 
 	t.true(stubAddImplicitDependency.calledOnce, "addImplicitDependency was called once");
-	t.deepEqual(stubAddImplicitDependency.getCall(0).args[0], "sap/ui/core/Fragment.js",
+	t.is(stubAddImplicitDependency.getCall(0).args[0], "sap/ui/core/Fragment.js",
 		"addImplicitDependency should be called with the dependency name");
 });
 
@@ -450,7 +450,7 @@ test("_analyze: viewRootNode", async (t) => {
 	await analyzer._analyze(null, null, false);
 
 	t.true(stubAnalyzeViewRootNode.calledOnce, "_analyzeViewRootNode was called");
-	t.deepEqual(stubAnalyzeViewRootNode.getCall(0).args[0], "parse-result",
+	t.is(stubAnalyzeViewRootNode.getCall(0).args[0], "parse-result",
 		"_analyzeViewRootNode should be called with the result");
 });
 
@@ -483,13 +483,13 @@ test("_analyzeViewRootNode: process node", async (t) => {
 		"_analyzeChildren should be called with the result");
 
 	t.true(stubAddImplicitDependency.calledOnce, "addImplicitDependency was called");
-	t.deepEqual(stubAddImplicitDependency.getCall(0).args[0], "sap/ui/core/mvc/XMLView.js",
+	t.is(stubAddImplicitDependency.getCall(0).args[0], "sap/ui/core/mvc/XMLView.js",
 		"addImplicitDependency should be called with the dependency name");
 
-	t.deepEqual(stubAddDependency.callCount, 2, "addDependency was called twice");
-	t.deepEqual(stubAddDependency.getCall(0).args[0], "myController.controller.js",
+	t.is(stubAddDependency.callCount, 2, "addDependency was called twice");
+	t.is(stubAddDependency.getCall(0).args[0], "myController.controller.js",
 		"addDependency should be called with the dependency name");
-	t.deepEqual(stubAddDependency.getCall(1).args[0], "myResourceBundleName.properties",
+	t.is(stubAddDependency.getCall(1).args[0], "myResourceBundleName.properties",
 		"addDependency should be called with the dependency name");
 });
 

--- a/test/lib/lbt/bundle/AutoSplitter.js
+++ b/test/lib/lbt/bundle/AutoSplitter.js
@@ -151,7 +151,7 @@ test("_calcMinSize: compressedSize", async (t) => {
 		}
 	};
 	const autoSplitter = new AutoSplitter(pool);
-	t.deepEqual(await autoSplitter._calcMinSize("mymodule.js"), 123);
+	t.is(await autoSplitter._calcMinSize("mymodule.js"), 123);
 });
 
 test("_calcMinSize: js resource (optimize=false)", async (t) => {
@@ -168,7 +168,7 @@ test("_calcMinSize: js resource (optimize=false)", async (t) => {
 		}
 	};
 	const autoSplitter = new AutoSplitter(pool);
-	t.deepEqual(await autoSplitter._calcMinSize("mymodule.js"), 13);
+	t.is(await autoSplitter._calcMinSize("mymodule.js"), 13);
 });
 
 test.serial("_calcMinSize: js resource (optimize=true)", async (t) => {
@@ -190,7 +190,7 @@ test.serial("_calcMinSize: js resource (optimize=true)", async (t) => {
 	// should not get optimized by the AutoSplitter.
 	autoSplitter.optimize = true;
 
-	t.deepEqual(await autoSplitter._calcMinSize("mymodule.js"), 13);
+	t.is(await autoSplitter._calcMinSize("mymodule.js"), 13);
 });
 
 test("_calcMinSize: properties resource", async (t) => {
@@ -214,7 +214,7 @@ test("_calcMinSize: properties resource", async (t) => {
 		}
 	};
 	const autoSplitter = new AutoSplitter(pool);
-	t.deepEqual(await autoSplitter._calcMinSize("mymodule.properties"), 10, "length of 1234\\u00df");
+	t.is(await autoSplitter._calcMinSize("mymodule.properties"), 10, "length of 1234\\u00df");
 });
 
 test("_calcMinSize: xml view resource", async (t) => {
@@ -228,7 +228,7 @@ test("_calcMinSize: xml view resource", async (t) => {
 	};
 	const autoSplitter = new AutoSplitter(pool);
 	autoSplitter.optimizeXMLViews = true;
-	t.deepEqual(await autoSplitter._calcMinSize("mymodule.view.xml"), 5);
+	t.is(await autoSplitter._calcMinSize("mymodule.view.xml"), 5);
 });
 
 test("_calcMinSize: xml view resource without optimizeXMLViews", async (t) => {
@@ -241,7 +241,7 @@ test("_calcMinSize: xml view resource without optimizeXMLViews", async (t) => {
 		}
 	};
 	const autoSplitter = new AutoSplitter(pool);
-	t.deepEqual(await autoSplitter._calcMinSize("mymodule.view.xml"), 6);
+	t.is(await autoSplitter._calcMinSize("mymodule.view.xml"), 6);
 });
 
 test.serial("_calcMinSize: optimize xml view resource", async (t) => {
@@ -257,7 +257,7 @@ test.serial("_calcMinSize: optimize xml view resource", async (t) => {
 	const autoSplitter = new AutoSplitter(pool);
 	autoSplitter.optimizeXMLViews = true;
 	autoSplitter.optimize = true;
-	t.deepEqual(await autoSplitter._calcMinSize("mymodule.view.xml"), 6);
+	t.is(await autoSplitter._calcMinSize("mymodule.view.xml"), 6);
 	stubXmlmin.restore();
 });
 
@@ -275,7 +275,7 @@ test.serial("_calcMinSize: optimize xml view resource and pre tag", async (t) =>
 	autoSplitter.optimizeXMLViews = true;
 	autoSplitter.optimize = true;
 	t.false(stubXmlmin.called, "xmlmin should not be called");
-	t.deepEqual(await autoSplitter._calcMinSize("mymodule.view.xml"), 19);
+	t.is(await autoSplitter._calcMinSize("mymodule.view.xml"), 19);
 	stubXmlmin.restore();
 });
 
@@ -286,7 +286,7 @@ test("_calcMinSize: no resource", async (t) => {
 		}
 	};
 	const autoSplitter = new AutoSplitter(pool);
-	t.deepEqual(await autoSplitter._calcMinSize("mymodule.properties"), 0);
+	t.is(await autoSplitter._calcMinSize("mymodule.properties"), 0);
 });
 
 test("_calcMinSize: unknown resource with info", async (t) => {
@@ -300,5 +300,5 @@ test("_calcMinSize: unknown resource with info", async (t) => {
 		}
 	};
 	const autoSplitter = new AutoSplitter(pool);
-	t.deepEqual(await autoSplitter._calcMinSize("mymodule.mjs"), 47);
+	t.is(await autoSplitter._calcMinSize("mymodule.mjs"), 47);
 });

--- a/test/lib/lbt/bundle/Builder.js
+++ b/test/lib/lbt/bundle/Builder.js
@@ -108,7 +108,7 @@ test("integration: createBundle with exposedGlobals", async (t) => {
 
 	const builder = new Builder(pool);
 	const oResult = await builder.createBundle(bundleDefinition, {numberOfParts: 1, decorateBootstrapModule: true});
-	t.deepEqual(oResult.name, "library-preload.js");
+	t.is(oResult.name, "library-preload.js");
 	const expectedContent = `//@ui5-bundle library-preload.js
 window["sap-ui-optimized"] = true;
 sap.ui.require.preload({
@@ -124,7 +124,7 @@ ${SOURCE_MAPPING_URL}=library-preload.js.map
 		"should contain:" +
 		" preload part from a.js" +
 		" require part from ui5loader.js");
-	t.deepEqual(oResult.bundleInfo.name, "library-preload.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "library-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules, ["a.js"],
 		"bundle info subModules are correct");
@@ -177,7 +177,7 @@ test("integration: createBundle EVOBundleFormat (ui5loader.js)", async (t) => {
 
 	const builder = new Builder(pool);
 	const oResult = await builder.createBundle(bundleDefinition, {numberOfParts: 1, decorateBootstrapModule: true});
-	t.deepEqual(oResult.name, "Component-preload.js");
+	t.is(oResult.name, "Component-preload.js");
 	const expectedContent = `//@ui5-bundle Component-preload.js
 window["sap-ui-optimized"] = true;
 sap.ui.require.preload({
@@ -195,7 +195,7 @@ ${SOURCE_MAPPING_URL}=Component-preload.js.map
 		" preload part from jquery.sap.global-dbg.js" +
 		" raw part from myModule.js" +
 		" require part from ui5loader.js");
-	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules, ["jquery.sap.global-dbg.js", "myModule.js"],
 		"bundle info subModules are correct");
@@ -293,7 +293,7 @@ test("integration: createBundle EVOBundleFormat, using predefine calls", async (
 		decorateBootstrapModule: true,
 		optimize: true
 	});
-	t.deepEqual(oResult.name, "Component-preload.js");
+	t.is(oResult.name, "Component-preload.js");
 	const expectedContent = `//@ui5-bundle Component-preload.js
 window["sap-ui-optimized"] = true;
 sap.ui.predefine("jquery.sap.global", [], function(){return {};});
@@ -315,7 +315,7 @@ ${SOURCE_MAPPING_URL}=Component-preload.js.map
 		" preload part from jquery.sap.global-dbg.js" +
 		" raw part from myModule.js" +
 		" require part from ui5loader.js");
-	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules,
 		[
@@ -419,7 +419,7 @@ test("integration: createBundle EVOBundleFormat, using predefine calls, no optim
 		decorateBootstrapModule: true,
 		optimize: false
 	});
-	t.deepEqual(oResult.name, "Component-preload.js");
+	t.is(oResult.name, "Component-preload.js");
 	const expectedContent = `//@ui5-bundle Component-preload.js
 window["sap-ui-optimized"] = true;
 sap.ui.predefine("jquery.sap.global", [], function(){return {};});
@@ -441,7 +441,7 @@ ${SOURCE_MAPPING_URL}=Component-preload.js.map
 		" preload part from jquery.sap.global-dbg.js" +
 		" raw part from myModule.js" +
 		" require part from ui5loader.js");
-	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules,
 		[
@@ -498,7 +498,7 @@ test("integration: createBundle (bootstrap bundle)", async (t) => {
 		optimize: true,
 		usePredefineCalls: true
 	});
-	t.deepEqual(oResult.name, "bootstrap.js");
+	t.is(oResult.name, "bootstrap.js");
 	const expectedContent = `//@ui5-bundle bootstrap.js
 window["sap-ui-optimized"] = true;
 try {
@@ -518,7 +518,7 @@ ${SOURCE_MAPPING_URL}=bootstrap.js.map
 		" preload part from jquery.sap.global-dbg.js" +
 		" raw part from myModule.js" +
 		" require part from ui5loader.js");
-	t.deepEqual(oResult.bundleInfo.name, "bootstrap.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "bootstrap.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules, ["ui5loader.js", "sap/ui/core/Core.js"],
 		"bundle info subModules are correct");
@@ -571,7 +571,7 @@ test("integration: Legacy test: createBundle without ui5loader.js presence also 
 
 	const builder = new Builder(pool);
 	const oResult = await builder.createBundle(bundleDefinition, {numberOfParts: 1, decorateBootstrapModule: true});
-	t.deepEqual(oResult.name, "Component-preload.js");
+	t.is(oResult.name, "Component-preload.js");
 	const expectedContent = `//@ui5-bundle Component-preload.js
 sap.ui.require.preload({
 	"jquery.sap.global-dbg.js":function(){
@@ -588,7 +588,7 @@ ${SOURCE_MAPPING_URL}=Component-preload.js.map
 		" preload part from jquery.sap.global-dbg.js" +
 		" raw part from myModule.js" +
 		" require part from sap-ui-core.js");
-	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules, ["jquery.sap.global-dbg.js", "myModule.js"],
 		"bundle info subModules are correct");
@@ -647,7 +647,7 @@ test("integration: createBundle (bootstrap bundle, UI5BundleFormat)", async (t) 
 		optimize: true,
 		usePredefineCalls: true
 	});
-	t.deepEqual(oResult.name, "bootstrap.js");
+	t.is(oResult.name, "bootstrap.js");
 	const expectedContent = `//@ui5-bundle bootstrap.js
 window["sap-ui-optimized"] = true;
 try {
@@ -671,7 +671,7 @@ ${SOURCE_MAPPING_URL}=bootstrap.js.map
 		" preload part from jquery.sap.global-dbg.js" +
 		" raw part from myModule.js" +
 		" require part from ui5loader.js");
-	t.deepEqual(oResult.bundleInfo.name, "bootstrap.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "bootstrap.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules, ["jquery.sap.global.js", "myRawModule.js", "sap/ui/core/Core.js"],
 		"bundle info subModules are correct");
@@ -763,7 +763,7 @@ test.serial("integration: createBundle with bundleInfo", async (t) => {
 
 	const builder = new BuilderWithStub(pool);
 	const oResult = await builder.createBundle(bundleDefinition, {numberOfParts: 1, decorateBootstrapModule: true});
-	t.deepEqual(oResult.name, "library-preload.js");
+	t.is(oResult.name, "library-preload.js");
 	const expectedContent = `//@ui5-bundle library-preload.js
 window["sap-ui-optimized"] = true;
 sap.ui.require.preload({
@@ -783,7 +783,7 @@ ${SOURCE_MAPPING_URL}=library-preload.js.map
 		"should contain:" +
 		" preload part from a.js" +
 		" require part from ui5loader.js");
-	t.deepEqual(oResult.bundleInfo.name, "library-preload.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "library-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules, ["a.js", "b.js", "c.js"],
 		"bundle info subModules are correct");
@@ -852,13 +852,13 @@ ${SOURCE_MAPPING_URL}=jquery.sap.global.js.map`
 		usePredefineCalls: true,
 		optimize: false
 	});
-	t.deepEqual(oResult.name, "Component-preload.js");
+	t.is(oResult.name, "Component-preload.js");
 	const expectedContent = `//@ui5-bundle Component-preload.js
 sap.ui.predefine("jquery.sap.global", [],function(){console.log("Put me on a map!");return{}});
 ${SOURCE_MAPPING_URL}=Component-preload.js.map
 `;
 	t.deepEqual(oResult.content, expectedContent, "Correct bundle content");
-	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules,
 		[
@@ -953,13 +953,13 @@ ${SOURCE_MAPPING_URL}=jquery.sap.global.js.map`
 		decorateBootstrapModule: true,
 		optimize: false
 	});
-	t.deepEqual(oResult.name, "Component-preload.js");
+	t.is(oResult.name, "Component-preload.js");
 	const expectedContent = `//@ui5-bundle Component-preload.js
 sap.ui.predefine("jquery.sap.global", [],function(){console.log("Put me on a map!");return{}});
 ${SOURCE_MAPPING_URL}=Component-preload.js.map
 `;
 	t.deepEqual(oResult.content, expectedContent, "Correct bundle content");
-	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules,
 		[
@@ -1068,7 +1068,7 @@ ${SOURCE_MAPPING_URL}=jquery.sap.global.js.map`
 		decorateBootstrapModule: true,
 		optimize: false
 	});
-	t.deepEqual(oResult.name, "Component-preload.js");
+	t.is(oResult.name, "Component-preload.js");
 	const expectedContent = `//@ui5-bundle Component-preload.js
 /*!
  * OpenUI5
@@ -1079,7 +1079,7 @@ sap.ui.predefine("jquery.sap.global", ["sap/base/util/now","sap/base/util/Versio
 ${SOURCE_MAPPING_URL}=Component-preload.js.map
 `;
 	t.deepEqual(oResult.content, expectedContent, "Correct bundle content");
-	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules,
 		[
@@ -1288,7 +1288,7 @@ ${SOURCE_MAPPING_URL}=jquery.sap.dom.js.map`
 		decorateBootstrapModule: true,
 		optimize: false
 	});
-	t.deepEqual(oResult.name, "Component-preload.js");
+	t.is(oResult.name, "Component-preload.js");
 	const expectedContent = `//@ui5-bundle Component-preload.js
 /*!
  * OpenUI5
@@ -1305,7 +1305,7 @@ sap.ui.predefine("jquery.sap.global", ["sap/base/util/now","sap/base/util/Versio
 ${SOURCE_MAPPING_URL}=Component-preload.js.map
 `;
 	t.deepEqual(oResult.content, expectedContent, "Correct bundle content");
-	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules,
 		[
@@ -1468,7 +1468,7 @@ sap.ui.define(function() {
 		decorateBootstrapModule: true,
 		optimize: false
 	});
-	t.deepEqual(oResult.name, "Component-preload.js");
+	t.is(oResult.name, "Component-preload.js");
 	const expectedContent = `//@ui5-bundle Component-preload.js
 /*!
  * OpenUI5
@@ -1487,7 +1487,7 @@ sap.ui.predefine("jquery.sap.xom", function() {
 ${SOURCE_MAPPING_URL}=Component-preload.js.map
 `;
 	t.deepEqual(oResult.content, expectedContent, "Correct bundle content");
-	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules,
 		[
@@ -1591,7 +1591,7 @@ ${SOURCE_MAPPING_URL}=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjo
 		decorateBootstrapModule: true,
 		optimize: false
 	});
-	t.deepEqual(oResult.name, "Component-preload.js");
+	t.is(oResult.name, "Component-preload.js");
 	const expectedContent = `//@ui5-bundle Component-preload.js
 /*!
  * OpenUI5
@@ -1602,7 +1602,7 @@ sap.ui.predefine("jquery.sap.global", ["sap/base/util/now","sap/base/util/Versio
 ${SOURCE_MAPPING_URL}=Component-preload.js.map
 `;
 	t.deepEqual(oResult.content, expectedContent, "Correct bundle content");
-	t.deepEqual(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
+	t.is(oResult.bundleInfo.name, "Component-preload.js", "bundle info name is correct");
 	t.deepEqual(oResult.bundleInfo.size, expectedContent.length, "bundle info size is correct");
 	t.deepEqual(oResult.bundleInfo.subModules,
 		[
@@ -1962,7 +1962,7 @@ ${SOURCE_MAPPING_URL}=data:application/pony;charset=utf-8;base64,AAAA`
 	}, "Expected transitive source map has been generated");
 });
 
-test("createTransientSourceMap: includeContent=false", async (t) => {
+test("createTransientSourceMap: includeContent=false", (t) => {
 	const {createTransientSourceMap} = Builder.__localFunctions__;
 
 	const res = createTransientSourceMap({
@@ -1980,7 +1980,7 @@ Lines`,
 	}, "Expected source map has been created");
 });
 
-test("createTransientSourceMap: includeContent=true", async (t) => {
+test("createTransientSourceMap: includeContent=true", (t) => {
 	const {createTransientSourceMap} = Builder.__localFunctions__;
 
 	const moduleContent = `Some content

--- a/test/lib/lbt/graph/dominatorTree.js
+++ b/test/lib/lbt/graph/dominatorTree.js
@@ -38,7 +38,7 @@ test("basic dominator tree test", async (t) => {
 	}];
 	const graph = await dependencyGraph(pool, roots);
 	const result = dominatorTree(graph);
-	t.deepEqual(result.name, "");
+	t.is(result.name, "");
 	t.deepEqual(getNamesFromSet(result.dominators), [""], "There should be just the temp node as dominator");
 	t.deepEqual(getNamesFromSet(result.pred), [], "There should be no predecessor");
 	t.deepEqual(getNamesFromSet(result.succ), ["myroot"], "There should be the myroot node as successor");

--- a/test/lib/lbt/graph/topologicalSort.js
+++ b/test/lib/lbt/graph/topologicalSort.js
@@ -34,7 +34,7 @@ test("cyclic dependencies", async (t) => {
 	const pool = createMockPool({"third": "mydep", "mydep": "third"});
 	const roots = ["myroot", "mydep", "third"];
 	const error = await t.throwsAsync(topologicalSort(pool, roots));
-	t.deepEqual(error.message, "failed to resolve cyclic dependencies: mydep,third");
+	t.is(error.message, "failed to resolve cyclic dependencies: mydep,third");
 });
 
 test("no dependencies", async (t) => {

--- a/test/lib/lbt/resources/LocatorResourcePool.js
+++ b/test/lib/lbt/resources/LocatorResourcePool.js
@@ -17,8 +17,7 @@ test("wait for resources to finish prepare", async (t) => {
 	});
 	const resourcePool = new LocatorResourcePool();
 	resourcePool.addResource = () => promise;
-	return await resourcePool.prepare([new Resource({path: "mypath"})]).then(() => {
-		t.true(promiseResolved, "addResources promise is resolved before prepare promise is resolved");
-	});
+	await resourcePool.prepare([new Resource({path: "mypath"})]);
+	t.true(promiseResolved, "addResources promise is resolved before prepare promise is resolved");
 });
 

--- a/test/lib/lbt/resources/LocatorResourcePool.js
+++ b/test/lib/lbt/resources/LocatorResourcePool.js
@@ -2,7 +2,7 @@ const test = require("ava");
 const LocatorResourcePool = require("../../../../lib/lbt/resources/LocatorResourcePool");
 const Resource = require("@ui5/fs").Resource;
 
-test("getIgnoreMissingModules", async (t) => {
+test("getIgnoreMissingModules", (t) => {
 	const resourcePool = new LocatorResourcePool({ignoreMissingModules: true});
 	t.true(resourcePool.getIgnoreMissingModules(), "ignoreMissingModules is true");
 });
@@ -17,7 +17,7 @@ test("wait for resources to finish prepare", async (t) => {
 	});
 	const resourcePool = new LocatorResourcePool();
 	resourcePool.addResource = () => promise;
-	return resourcePool.prepare([new Resource({path: "mypath"})]).then(() => {
+	return await resourcePool.prepare([new Resource({path: "mypath"})]).then(() => {
 		t.true(promiseResolved, "addResources promise is resolved before prepare promise is resolved");
 	});
 });

--- a/test/lib/lbt/resources/ModuleInfo.js
+++ b/test/lib/lbt/resources/ModuleInfo.js
@@ -2,7 +2,7 @@ const test = require("ava");
 
 const ModuleInfo = require("../../../../lib/lbt/resources/ModuleInfo");
 
-test("ModuleInfo: constructor", async (t) => {
+test("ModuleInfo: constructor", (t) => {
 	const moduleInfo = new ModuleInfo("myName");
 	t.falsy(moduleInfo.exposedGlobals, "exposedGlobals is not set");
 	t.falsy(moduleInfo.format, "format is not set");
@@ -13,7 +13,7 @@ test("ModuleInfo: constructor", async (t) => {
 	t.deepEqual(moduleInfo.subModules, [], "submodules are empty");
 });
 
-test("ModuleInfo: addSubModule", async (t) => {
+test("ModuleInfo: addSubModule", (t) => {
 	// setup
 	const moduleInfo = new ModuleInfo("myName");
 	moduleInfo.addDependency("otherModule", false);
@@ -30,7 +30,7 @@ test("ModuleInfo: addSubModule", async (t) => {
 	t.deepEqual(moduleInfo.dependencies, ["unknownModule"], "unknownModule dependency is copied over");
 });
 
-test("ModuleInfo: name", async (t) => {
+test("ModuleInfo: name", (t) => {
 	// setup
 	const moduleInfo = new ModuleInfo("myName");
 
@@ -47,7 +47,7 @@ test("ModuleInfo: name", async (t) => {
 	t.is(moduleInfo.name, "newName2", "name was set");
 });
 
-test("ModuleInfo: toString", async (t) => {
+test("ModuleInfo: toString", (t) => {
 	// setup
 	const moduleInfo = new ModuleInfo("myName");
 

--- a/test/lib/lbt/resources/Resource.js
+++ b/test/lib/lbt/resources/Resource.js
@@ -42,12 +42,12 @@ test.serial("Resource: string", async (t) => {
 	t.is(res, "content", "File content returned correctly");
 });
 
-test.serial("Resource: constructor", async (t) => {
+test.serial("Resource: constructor", (t) => {
 	const resource = new Resource({}, "name", "file");
 	t.is(resource.fileSize, -1, "called once");
 });
 
-test.serial("Resource: constructor with stat", async (t) => {
+test.serial("Resource: constructor with stat", (t) => {
 	const resource = new Resource({}, "name", "file", {size: 47});
 	t.is(resource.fileSize, 47, "called once");
 });

--- a/test/lib/lbt/resources/ResourceInfo.js
+++ b/test/lib/lbt/resources/ResourceInfo.js
@@ -2,14 +2,14 @@ const test = require("ava");
 
 const ResourceInfo = require("../../../../lib/lbt/resources/ResourceInfo");
 
-test("ResourceInfo: constructor", async (t) => {
+test("ResourceInfo: constructor", (t) => {
 	const resourceInfo = new ResourceInfo("myName");
 	t.falsy(resourceInfo.module, "module not set");
 	t.falsy(resourceInfo.format, "format not set");
 	t.is(resourceInfo.size, -1, "size not set");
 });
 
-test("ResourceInfo: copyFrom", async (t) => {
+test("ResourceInfo: copyFrom", (t) => {
 	// setup
 	const resourceInfo = new ResourceInfo("myName");
 	const origResourceInfo = new ResourceInfo("origMyName");
@@ -52,7 +52,7 @@ test("ResourceInfo: copyFrom", async (t) => {
 	t.is(resourceInfo.size, 13, "value is copied over");
 });
 
-test("ResourceInfo: toJSON", async (t) => {
+test("ResourceInfo: toJSON", (t) => {
 	const resourceInfo = new ResourceInfo("myName");
 	resourceInfo.i18nName = "i18nName";
 	resourceInfo.i18nLocale = "i18nLocale";

--- a/test/lib/lbt/resources/ResourcePool.js
+++ b/test/lib/lbt/resources/ResourcePool.js
@@ -42,16 +42,16 @@ test("findResources: based on ResourceFilterList", async (t) => {
 	t.deepEqual(resources, [resourceA], "resource a is found");
 });
 
-test("size", async (t) => {
+test("size", (t) => {
 	const resourcePool = new ResourcePool();
-	t.deepEqual(resourcePool.size, 0, "size of empty pool is 0");
+	t.is(resourcePool.size, 0, "size of empty pool is 0");
 
 	const resourceA = {name: "a"};
 	resourcePool.addResource(resourceA);
-	t.deepEqual(resourcePool.size, 1, "size of pool is 1");
+	t.is(resourcePool.size, 1, "size of pool is 1");
 });
 
-test("resources", async (t) => {
+test("resources", (t) => {
 	const resourcePool = new ResourcePool();
 	t.deepEqual(resourcePool.resources, [], "no resources in empty pool");
 
@@ -60,14 +60,14 @@ test("resources", async (t) => {
 	t.deepEqual(resourcePool.resources, [resourceA], "resource a in pool");
 });
 
-test("getIgnoreMissingModules", async (t) => {
+test("getIgnoreMissingModules", (t) => {
 	let resourcePool = new ResourcePool({});
-	t.deepEqual(resourcePool.getIgnoreMissingModules(), false, "returned expected value");
+	t.is(resourcePool.getIgnoreMissingModules(), false, "returned expected value");
 
 	resourcePool = new ResourcePool({
 		ignoreMissingModules: true
 	});
-	t.deepEqual(resourcePool.getIgnoreMissingModules(), true, "returned expected value");
+	t.is(resourcePool.getIgnoreMissingModules(), true, "returned expected value");
 });
 
 
@@ -94,7 +94,7 @@ test.serial("findResourceWithInfo", async (t) => {
 	sinon.stub(resourcePool, "getModuleInfo").resolves("myInfo");
 
 	const resource = await resourcePool.findResourceWithInfo("a");
-	t.deepEqual(resource.info, "myInfo", "info is set correctly");
+	t.is(resource.info, "myInfo", "info is set correctly");
 	sinon.restore();
 });
 
@@ -161,9 +161,9 @@ test("getModuleInfo: determineDependencyInfo for js templateAssembler code", asy
 	const jsResource = await resourcePool.getModuleInfo("a.js");
 	t.is(await resourcePool._dependencyInfos.get(inputJsResource.name), jsResource,
 		"info has been added to _dependencyInfos map");
-	t.deepEqual(jsResource.size, 372);
-	t.deepEqual(jsResource.format, "ui5-define", "contains sap.ui.define therefore should be a ui5-define format");
-	t.deepEqual(jsResource.name, "a.js");
+	t.is(jsResource.size, 372);
+	t.is(jsResource.format, "ui5-define", "contains sap.ui.define therefore should be a ui5-define format");
+	t.is(jsResource.name, "a.js");
 	t.false(jsResource.rawModule);
 	t.deepEqual(jsResource.subModules, []);
 });
@@ -189,18 +189,18 @@ test("getModuleInfo: determineDependencyInfo for xml control and fragment", asyn
 	const xmlControlResource = await resourcePool.getModuleInfo("a.control.xml");
 	t.is(await resourcePool._dependencyInfos.get(inputXmlControlResource.name), xmlControlResource,
 		"info has been added to _dependencyInfos map");
-	t.deepEqual(xmlControlResource.size, 298);
+	t.is(xmlControlResource.size, 298);
 	t.falsy(xmlControlResource.format);
-	t.deepEqual(xmlControlResource.name, "a.control.xml");
+	t.is(xmlControlResource.name, "a.control.xml");
 	t.false(xmlControlResource.rawModule);
 	t.deepEqual(xmlControlResource.subModules, []);
 
 	const xmlFragmentResource = await resourcePool.getModuleInfo("a.fragment.xml");
 	t.is(await resourcePool._dependencyInfos.get(inputXmlFragmentResource.name), xmlFragmentResource,
 		"info has been added to _dependencyInfos map");
-	t.deepEqual(xmlFragmentResource.size, 298);
+	t.is(xmlFragmentResource.size, 298);
 	t.falsy(xmlFragmentResource.format);
-	t.deepEqual(xmlFragmentResource.name, "a.fragment.xml");
+	t.is(xmlFragmentResource.name, "a.fragment.xml");
 	t.false(xmlFragmentResource.rawModule);
 	t.deepEqual(xmlFragmentResource.subModules, []);
 });
@@ -222,15 +222,15 @@ test("getModuleInfo: determineDependencyInfo for xml view", async (t) => {
 	const xmlViewResource = await resourcePool.getModuleInfo("a.view.xml");
 	t.is(await resourcePool._dependencyInfos.get(inputXmlViewResource.name), xmlViewResource,
 		"info has been added to _dependencyInfos map");
-	t.deepEqual(xmlViewResource.size, 315);
+	t.is(xmlViewResource.size, 315);
 	t.falsy(xmlViewResource.format);
-	t.deepEqual(xmlViewResource.name, "a.view.xml");
+	t.is(xmlViewResource.name, "a.view.xml");
 	t.false(xmlViewResource.rawModule);
 	t.deepEqual(xmlViewResource.subModules, []);
 });
 
 
-test("addResource twice", async (t) => {
+test("addResource twice", (t) => {
 	const resourcePool = new ResourcePool();
 	const resourceA = {name: "a"};
 

--- a/test/lib/lbt/utils/ASTUtils.js
+++ b/test/lib/lbt/utils/ASTUtils.js
@@ -91,28 +91,28 @@ test("getStringArray", (t) => {
 		ASTUtils.getStringArray(array);
 	}, {instanceOf: TypeError}, "array contains a number");
 
-	t.deepEqual(error.message, "array element is not a string literal:Literal");
+	t.is(error.message, "array element is not a string literal:Literal");
 
 	const stringArray = parseJS("['a', 'x']").body[0].expression;
 	t.deepEqual(ASTUtils.getStringArray(stringArray), ["a", "x"], "array contains only strings");
 });
 
 test("getLocation", (t) => {
-	t.deepEqual(ASTUtils.getLocation([{value: "module/name"}]), "module/name");
+	t.is(ASTUtils.getLocation([{value: "module/name"}]), "module/name");
 });
 
 test("getPropertyKey", (t) => {
 	// quoted key
 	const quotedProperties = parseJS("var myVar = {'a':'x'}").body[0].declarations[0].init.properties;
-	t.deepEqual(ASTUtils.getPropertyKey(quotedProperties[0]), "a", "sole property key is 'a'");
+	t.is(ASTUtils.getPropertyKey(quotedProperties[0]), "a", "sole property key is 'a'");
 
 	// unquoted key
 	const unQuotedProperties = parseJS("var myVar = {a:'x'}").body[0].declarations[0].init.properties;
-	t.deepEqual(ASTUtils.getPropertyKey(unQuotedProperties[0]), "a", "sole property key is 'a'");
+	t.is(ASTUtils.getPropertyKey(unQuotedProperties[0]), "a", "sole property key is 'a'");
 
 	// quoted key with dash
 	const dashedProperties = parseJS("var myVar = {'my-var': 47}").body[0].declarations[0].init.properties;
-	t.deepEqual(ASTUtils.getPropertyKey(dashedProperties[0]), "my-var", "sole property key is 'my-var'");
+	t.is(ASTUtils.getPropertyKey(dashedProperties[0]), "my-var", "sole property key is 'my-var'");
 });
 
 test("findOwnProperty", (t) => {

--- a/test/lib/lbt/utils/ModuleName.js
+++ b/test/lib/lbt/utils/ModuleName.js
@@ -3,12 +3,12 @@ const ModuleName = require("../../../../lib/lbt/utils/ModuleName");
 
 
 test("fromUI5LegacyName", (t) => {
-	t.deepEqual(ModuleName.fromUI5LegacyName(""), ".js");
-	t.deepEqual(ModuleName.fromUI5LegacyName("a/b"), "a/b.js");
-	t.deepEqual(ModuleName.fromUI5LegacyName("a.b"), "a/b.js");
-	t.deepEqual(ModuleName.fromUI5LegacyName("jquery.sap.b"), "jquery.sap.b.js");
-	t.deepEqual(ModuleName.fromUI5LegacyName("jquery-b"), "jquery-b.js");
-	t.deepEqual(ModuleName.fromUI5LegacyName("jquery-b", ".mjs"), "jquery-b.mjs");
+	t.is(ModuleName.fromUI5LegacyName(""), ".js");
+	t.is(ModuleName.fromUI5LegacyName("a/b"), "a/b.js");
+	t.is(ModuleName.fromUI5LegacyName("a.b"), "a/b.js");
+	t.is(ModuleName.fromUI5LegacyName("jquery.sap.b"), "jquery.sap.b.js");
+	t.is(ModuleName.fromUI5LegacyName("jquery-b"), "jquery-b.js");
+	t.is(ModuleName.fromUI5LegacyName("jquery-b", ".mjs"), "jquery-b.mjs");
 	const jQuerythirdParty = "sap.ui.thirdparty.jquery.jquery-b";
 	const jQuerythirdPartyExpected = "sap/ui/thirdparty/jquery/jquery-b.mjs";
 	t.deepEqual(ModuleName.fromUI5LegacyName(jQuerythirdParty, ".mjs"), jQuerythirdPartyExpected,
@@ -16,16 +16,16 @@ test("fromUI5LegacyName", (t) => {
 });
 
 test("toUI5LegacyName", (t) => {
-	t.deepEqual(ModuleName.toUI5LegacyName(".js"), "");
-	t.deepEqual(ModuleName.toUI5LegacyName("a/b.js"), "a.b");
-	t.deepEqual(ModuleName.toUI5LegacyName("a/b.js"), "a.b");
-	t.deepEqual(ModuleName.toUI5LegacyName("jquery.sap.b.js"), "jquery.sap.b");
-	t.deepEqual(ModuleName.toUI5LegacyName("jquery-b.js"), "jquery-b");
+	t.is(ModuleName.toUI5LegacyName(".js"), "");
+	t.is(ModuleName.toUI5LegacyName("a/b.js"), "a.b");
+	t.is(ModuleName.toUI5LegacyName("a/b.js"), "a.b");
+	t.is(ModuleName.toUI5LegacyName("jquery.sap.b.js"), "jquery.sap.b");
+	t.is(ModuleName.toUI5LegacyName("jquery-b.js"), "jquery-b");
 	const error = t.throws(() => {
 		ModuleName.toUI5LegacyName("jquery-b.mjs");
 	});
 
-	t.deepEqual(error.message, "can't convert a non-JS resource name jquery-b.mjs to a UI5 module name");
+	t.is(error.message, "can't convert a non-JS resource name jquery-b.mjs to a UI5 module name");
 	const jQuerythirdParty = "sap/ui/thirdparty/jquery/jquery-b.js";
 	const jQuerythirdPartyExpected = "sap.ui.thirdparty.jquery.jquery-b";
 	t.deepEqual(ModuleName.toUI5LegacyName(jQuerythirdParty), jQuerythirdPartyExpected,
@@ -33,52 +33,52 @@ test("toUI5LegacyName", (t) => {
 });
 
 test("fromRequireJSName", (t) => {
-	t.deepEqual(ModuleName.fromRequireJSName("a"), "a.js", "adds .js ending");
-	t.deepEqual(ModuleName.fromRequireJSName("x/a"), "x/a.js", "adds .js ending");
+	t.is(ModuleName.fromRequireJSName("a"), "a.js", "adds .js ending");
+	t.is(ModuleName.fromRequireJSName("x/a"), "x/a.js", "adds .js ending");
 });
 
 test("toRequireJSName", (t) => {
-	t.deepEqual(ModuleName.toRequireJSName("a.js"), "a", "extracts module name a");
-	t.deepEqual(ModuleName.toRequireJSName("x/a.js"), "x/a", "extracts module name x/a");
+	t.is(ModuleName.toRequireJSName("a.js"), "a", "extracts module name a");
+	t.is(ModuleName.toRequireJSName("x/a.js"), "x/a", "extracts module name x/a");
 
 	const error = t.throws(() => {
 		ModuleName.toRequireJSName("a");
 	});
 
-	t.deepEqual(error.message, "can't convert a non-JS resource name a to a requireJS module name");
+	t.is(error.message, "can't convert a non-JS resource name a to a requireJS module name");
 });
 
 test("getDebugName", (t) => {
-	t.deepEqual(ModuleName.getDebugName("a.controller.js"), "a-dbg.controller.js", "'-dbg' is added");
-	t.deepEqual(ModuleName.getDebugName("a.designtime.js"), "a-dbg.designtime.js", "'-dbg' is added");
-	t.deepEqual(ModuleName.getDebugName("a.fragment.js"), "a-dbg.fragment.js", "'-dbg' is added");
-	t.deepEqual(ModuleName.getDebugName("a.support.js"), "a-dbg.support.js", "'-dbg' is added");
-	t.deepEqual(ModuleName.getDebugName("a.view.js"), "a-dbg.view.js", "'-dbg' is added");
-	t.deepEqual(ModuleName.getDebugName("a.css"), "a-dbg.css", "'-dbg' is added");
+	t.is(ModuleName.getDebugName("a.controller.js"), "a-dbg.controller.js", "'-dbg' is added");
+	t.is(ModuleName.getDebugName("a.designtime.js"), "a-dbg.designtime.js", "'-dbg' is added");
+	t.is(ModuleName.getDebugName("a.fragment.js"), "a-dbg.fragment.js", "'-dbg' is added");
+	t.is(ModuleName.getDebugName("a.support.js"), "a-dbg.support.js", "'-dbg' is added");
+	t.is(ModuleName.getDebugName("a.view.js"), "a-dbg.view.js", "'-dbg' is added");
+	t.is(ModuleName.getDebugName("a.css"), "a-dbg.css", "'-dbg' is added");
 	t.falsy(ModuleName.getDebugName("a"), "non supported file ending");
 	t.falsy(ModuleName.getDebugName("a.mjs"), "non supported file ending");
 });
 
 test("getNonDebugName", (t) => {
-	t.deepEqual(ModuleName.getNonDebugName("a-dbg.controller.js"), "a.controller.js", "contains '-dbg'");
-	t.deepEqual(ModuleName.getNonDebugName("a-dbg.designtime.js"), "a.designtime.js", "contains '-dbg'");
-	t.deepEqual(ModuleName.getNonDebugName("a-dbg.fragment.js"), "a.fragment.js", "contains '-dbg'");
-	t.deepEqual(ModuleName.getNonDebugName("a-dbg.support.js"), "a.support.js", "contains '-dbg'");
-	t.deepEqual(ModuleName.getNonDebugName("a-dbg.view.js"), "a.view.js", "contains '-dbg'");
-	t.deepEqual(ModuleName.getNonDebugName("a-dbg.css"), "a.css", "contains '-dbg'");
+	t.is(ModuleName.getNonDebugName("a-dbg.controller.js"), "a.controller.js", "contains '-dbg'");
+	t.is(ModuleName.getNonDebugName("a-dbg.designtime.js"), "a.designtime.js", "contains '-dbg'");
+	t.is(ModuleName.getNonDebugName("a-dbg.fragment.js"), "a.fragment.js", "contains '-dbg'");
+	t.is(ModuleName.getNonDebugName("a-dbg.support.js"), "a.support.js", "contains '-dbg'");
+	t.is(ModuleName.getNonDebugName("a-dbg.view.js"), "a.view.js", "contains '-dbg'");
+	t.is(ModuleName.getNonDebugName("a-dbg.css"), "a.css", "contains '-dbg'");
 	t.falsy(ModuleName.getNonDebugName("a"), "does not contain '-dbg'");
 	t.falsy(ModuleName.getNonDebugName("a-dbg.mjs"), "does contain '-dbg' but ending is not supported");
 });
 
 test("resolveRelativePath", (t) => {
 	// paths without relative path operators
-	t.deepEqual(ModuleName.resolveRelativePath("a/b/c", "c/x"), "c/x");
-	t.deepEqual(ModuleName.resolveRelativePath("a/b/c.g", "c.g/x"), "c.g/x");
-	t.deepEqual(ModuleName.resolveRelativePath("a/b/c.g", "gg"), "gg");
+	t.is(ModuleName.resolveRelativePath("a/b/c", "c/x"), "c/x");
+	t.is(ModuleName.resolveRelativePath("a/b/c.g", "c.g/x"), "c.g/x");
+	t.is(ModuleName.resolveRelativePath("a/b/c.g", "gg"), "gg");
 	t.falsy(ModuleName.resolveRelativePath("a"));
 
 	// paths without relative path operators (. or ..)
-	t.deepEqual(ModuleName.resolveRelativePath("a/b/c/./g", "./g/./x"), "a/b/c/./g/x");
-	t.deepEqual(ModuleName.resolveRelativePath("a/b/c/:/g", "c.g/x"), "c.g/x");
-	t.deepEqual(ModuleName.resolveRelativePath("a/b/c/../g", "c.g/x"), "c.g/x");
+	t.is(ModuleName.resolveRelativePath("a/b/c/./g", "./g/./x"), "a/b/c/./g/x");
+	t.is(ModuleName.resolveRelativePath("a/b/c/:/g", "c.g/x"), "c.g/x");
+	t.is(ModuleName.resolveRelativePath("a/b/c/../g", "c.g/x"), "c.g/x");
 });

--- a/test/lib/processors/bootstrapHtmlTransformer.js
+++ b/test/lib/processors/bootstrapHtmlTransformer.js
@@ -173,7 +173,7 @@ test.serial("Logs warning when bootstrap script can't be found due to missing ID
 
 	t.deepEqual(processedResources, [resource], "Input resource is returned");
 
-	t.deepEqual(t.context.logWarnSpy.callCount, 1, "One warning should be logged");
+	t.is(t.context.logWarnSpy.callCount, 1, "One warning should be logged");
 	t.true(
 		t.context.logWarnSpy.calledWith(
 			"Skipping bootstrap transformation. Could not find bootstrap script tag with id=sap-ui-bootstrap."),
@@ -210,7 +210,7 @@ test.serial("Logs warning when bootstrap script can't be found due to wrong tag"
 
 	t.deepEqual(processedResources, [resource], "Input resource is returned");
 
-	t.deepEqual(t.context.logWarnSpy.callCount, 1, "One warning should be logged");
+	t.is(t.context.logWarnSpy.callCount, 1, "One warning should be logged");
 	t.true(
 		t.context.logWarnSpy.calledWith(
 			"Skipping bootstrap transformation. Could not find bootstrap script tag with id=sap-ui-bootstrap."),
@@ -237,7 +237,7 @@ console.log("This is not HTML!")`;
 
 	t.deepEqual(processedResources, [resource], "Input resource is returned");
 
-	t.deepEqual(t.context.logWarnSpy.callCount, 1, "One warning should be logged");
+	t.is(t.context.logWarnSpy.callCount, 1, "One warning should be logged");
 	t.true(
 		t.context.logWarnSpy.calledWith(
 			"Skipping bootstrap transformation. Could not find bootstrap script tag with id=sap-ui-bootstrap."),
@@ -274,7 +274,7 @@ test.serial("Logs warning when multiple bootstrap scripts are found", async (t) 
 
 	t.deepEqual(processedResources, [resource], "Input resource is returned");
 
-	t.deepEqual(t.context.logWarnSpy.callCount, 1, "One warning should be logged");
+	t.is(t.context.logWarnSpy.callCount, 1, "One warning should be logged");
 	t.true(
 		t.context.logWarnSpy.calledWith(
 			"Skipping bootstrap transformation. Found multiple bootstrap script tags with id=sap-ui-bootstrap."),

--- a/test/lib/processors/bundlers/flexChangesBundler.js
+++ b/test/lib/processors/bundlers/flexChangesBundler.js
@@ -100,11 +100,11 @@ test("flexChangesBundler with 2 changes", async (t) => {
 		pathPrefix: "mypath"
 	};
 	const aResult = await flexChangesBundler({resources, options});
-	t.deepEqual(aResult.length, 1, "There should be only one element");
+	t.is(aResult.length, 1, "There should be only one element");
 	const oResult = aResult[0];
 
 	// check path
-	t.deepEqual(oResult.getPath(), "mypath/changes/changes-bundle.json", "path should be generated from options");
+	t.is(oResult.getPath(), "mypath/changes/changes-bundle.json", "path should be generated from options");
 
 	// check content
 	const content = await oResult.getString();
@@ -393,11 +393,11 @@ test("flexChangesBundler has ctrl_variant and hasFlexBundleVersion = true", asyn
 		hasFlexBundleVersion: true
 	};
 	const aResult = await flexChangesBundler({resources, options});
-	t.deepEqual(aResult.length, 1, "There should be only one element");
+	t.is(aResult.length, 1, "There should be only one element");
 	const oResult = aResult[0];
 
 	// check path
-	t.deepEqual(oResult.getPath(), "mypath/changes/flexibility-bundle.json", "path should be generated from options");
+	t.is(oResult.getPath(), "mypath/changes/flexibility-bundle.json", "path should be generated from options");
 
 	// check content
 	const content = await oResult.getString();

--- a/test/lib/processors/bundlers/manifestBundler.js
+++ b/test/lib/processors/bundlers/manifestBundler.js
@@ -58,7 +58,7 @@ test.serial("manifestBundler with manifest path not starting with '/resources'",
 
 	await manifestBundler({resources, options});
 
-	t.deepEqual(t.context.addBufferSpy.callCount, 0, "should not be called");
+	t.is(t.context.addBufferSpy.callCount, 0, "should not be called");
 
 	t.is(t.context.logVerboseSpy.callCount, 1);
 	t.deepEqual(t.context.logVerboseSpy.getCall(0).args,
@@ -120,7 +120,7 @@ test.serial("manifestBundler with manifest with i18n string", async (t) => {
 
 	await manifestBundler({resources, options});
 
-	t.deepEqual(t.context.addBufferSpy.callCount, 2);
+	t.is(t.context.addBufferSpy.callCount, 2);
 	t.deepEqual(t.context.addBufferSpy.getCall(0).args,
 		["{\"sap.app\":{\"i18n\":\"i18n-bundle/i18n.properties\"}}", "manifest.json"],
 		"should be called with correct arguments");

--- a/test/lib/processors/jsdoc/apiIndexGenerator.js
+++ b/test/lib/processors/jsdoc/apiIndexGenerator.js
@@ -33,31 +33,31 @@ test.serial("apiIndexGenerator", async (t) => {
 		fs: "custom fs"
 	});
 
-	t.deepEqual(res.length, 4, "Returned one resource");
-	t.deepEqual(res[0], "result resource A", "Returned correct resource");
-	t.deepEqual(res[1], "result resource B", "Returned correct resource");
-	t.deepEqual(res[2], "result resource C", "Returned correct resource");
-	t.deepEqual(res[3], "result resource D", "Returned correct resource");
+	t.is(res.length, 4, "Returned one resource");
+	t.is(res[0], "result resource A", "Returned correct resource");
+	t.is(res[1], "result resource B", "Returned correct resource");
+	t.is(res[2], "result resource C", "Returned correct resource");
+	t.is(res[3], "result resource D", "Returned correct resource");
 
-	t.deepEqual(createApiIndexStub.callCount, 1, "createIndexFiles called once");
-	t.deepEqual(createApiIndexStub.getCall(0).args[0], "/some/path/sap-ui-version.json",
+	t.is(createApiIndexStub.callCount, 1, "createIndexFiles called once");
+	t.is(createApiIndexStub.getCall(0).args[0], "/some/path/sap-ui-version.json",
 		"createIndexFiles called with correct argument #1");
-	t.deepEqual(createApiIndexStub.getCall(0).args[1], "/some/test-resources/path",
+	t.is(createApiIndexStub.getCall(0).args[1], "/some/test-resources/path",
 		"createIndexFiles called with correct argument #2");
-	t.deepEqual(createApiIndexStub.getCall(0).args[2], "/some/path/api-index.json",
+	t.is(createApiIndexStub.getCall(0).args[2], "/some/path/api-index.json",
 		"createIndexFiles called with correct argument #3");
-	t.deepEqual(createApiIndexStub.getCall(0).args[3], "/some/path/api-index-deprecated.json",
+	t.is(createApiIndexStub.getCall(0).args[3], "/some/path/api-index-deprecated.json",
 		"createIndexFiles called with correct argument #4");
-	t.deepEqual(createApiIndexStub.getCall(0).args[4], "/some/path/api-index-experimental.json",
+	t.is(createApiIndexStub.getCall(0).args[4], "/some/path/api-index-experimental.json",
 		"createIndexFiles called with correct argument #5");
-	t.deepEqual(createApiIndexStub.getCall(0).args[5], "/some/path/api-index-since.json",
+	t.is(createApiIndexStub.getCall(0).args[5], "/some/path/api-index-since.json",
 		"createIndexFiles called with correct argument #6");
 	t.deepEqual(createApiIndexStub.getCall(0).args[6], {
 		fs: "custom fs",
 		returnOutputFiles: true
 	}, "createIndexFiles called with correct argument #7");
 
-	t.deepEqual(createResourceStub.callCount, 4, "createResource called once");
+	t.is(createResourceStub.callCount, 4, "createResource called once");
 	t.deepEqual(createResourceStub.getCall(0).args[0], {
 		path: "/some/path/api-index.json",
 		string: "resource content A"
@@ -80,6 +80,6 @@ test.serial("apiIndexGenerator", async (t) => {
 
 test("apiIndexGenerator missing parameters", async (t) => {
 	const error = await t.throwsAsync(apiIndexGenerator());
-	t.deepEqual(error.message, "[apiIndexGenerator]: One or more mandatory parameters not provided",
+	t.is(error.message, "[apiIndexGenerator]: One or more mandatory parameters not provided",
 		"Correct error message thrown");
 });

--- a/test/lib/processors/jsdoc/jsdocGenerator.js
+++ b/test/lib/processors/jsdoc/jsdocGenerator.js
@@ -35,7 +35,7 @@ test("generateJsdocConfig", async (t) => {
 			.replace(backslashRegex, "\\\\");
 
 
-	t.deepEqual(res, `{
+	t.is(res, `{
 		"plugins": ["${pluginPath}"],
 		"opts": {
 			"recurse": true,
@@ -64,7 +64,7 @@ test.serial("writeJsdocConfig", async (t) => {
 		writeFile: (configPath, configContent, callback) => {
 			t.deepEqual(configPath, path.join("/", "some", "path", "jsdoc-config.json"),
 				"Correct config path supplied");
-			t.deepEqual(configContent, "some config", "Correct config content supplied");
+			t.is(configContent, "some config", "Correct config content supplied");
 			callback();
 		}
 	});
@@ -93,10 +93,10 @@ test.serial("buildJsdoc", async (t) => {
 		sourcePath: "/some/path",
 		configPath: "/some/config/path/jsdoc-config.json"
 	});
-	t.deepEqual(cpStub.callCount, 1, "Spawn got called");
+	t.is(cpStub.callCount, 1, "Spawn got called");
 
 	const firstCallArgs = cpStub.getCall(0).args;
-	t.deepEqual(firstCallArgs[0], "node", "Spawn got called with correct process argument");
+	t.is(firstCallArgs[0], "node", "Spawn got called with correct process argument");
 	t.deepEqual(firstCallArgs[1], [
 		require.resolve("jsdoc/jsdoc.js"),
 		"-c",
@@ -119,7 +119,7 @@ test.serial("buildJsdoc", async (t) => {
 		sourcePath: "/some/path",
 		configPath: "/some/config/path/jsdoc-config.json"
 	}));
-	t.deepEqual(error.message, "JSDoc child process closed with code 2");
+	t.is(error.message, "JSDoc child process closed with code 2");
 });
 
 test.serial("jsdocGenerator", async (t) => {
@@ -142,10 +142,10 @@ test.serial("jsdocGenerator", async (t) => {
 		}
 	});
 
-	t.deepEqual(res.length, 1, "Returned 1 resource");
-	t.deepEqual(res[0], "some resource", "Returned 1 resource");
+	t.is(res.length, 1, "Returned 1 resource");
+	t.is(res[0], "some resource", "Returned 1 resource");
 
-	t.deepEqual(generateJsdocConfigStub.callCount, 1, "generateJsdocConfig called once");
+	t.is(generateJsdocConfigStub.callCount, 1, "generateJsdocConfig called once");
 	t.deepEqual(generateJsdocConfigStub.getCall(0).args[0], {
 		targetPath: "/some/target/path",
 		tmpPath: "/some/tmp/path",
@@ -155,13 +155,13 @@ test.serial("jsdocGenerator", async (t) => {
 		variants: ["apijson"]
 	}, "generateJsdocConfig called with correct arguments");
 
-	t.deepEqual(writeJsdocConfigStub.callCount, 1, "writeJsdocConfig called once");
-	t.deepEqual(writeJsdocConfigStub.getCall(0).args[0], "/some/tmp/path",
+	t.is(writeJsdocConfigStub.callCount, 1, "writeJsdocConfig called once");
+	t.is(writeJsdocConfigStub.getCall(0).args[0], "/some/tmp/path",
 		"writeJsdocConfig called with correct tmpPath argument");
-	t.deepEqual(writeJsdocConfigStub.getCall(0).args[1], "some config",
+	t.is(writeJsdocConfigStub.getCall(0).args[1], "some config",
 		"writeJsdocConfig called with correct config argument");
 
-	t.deepEqual(buildJsdocStub.callCount, 1, "buildJsdoc called once");
+	t.is(buildJsdocStub.callCount, 1, "buildJsdoc called once");
 	t.deepEqual(buildJsdocStub.getCall(0).args[0], {
 		sourcePath: "/some/source/path",
 		configPath: "/some/config/path"
@@ -171,7 +171,7 @@ test.serial("jsdocGenerator", async (t) => {
 		fsBasePath: "/some/target/path",
 		virBasePath: "/"
 	}, "createAdapter called with correct arguments");
-	t.deepEqual(byPathStub.getCall(0).args[0], "/test-resources/some/project/name/designtime/api.json",
+	t.is(byPathStub.getCall(0).args[0], "/test-resources/some/project/name/designtime/api.json",
 		"byPath called with correct path for api.json");
 
 

--- a/test/lib/processors/jsdoc/sdkTransformer.js
+++ b/test/lib/processors/jsdoc/sdkTransformer.js
@@ -26,28 +26,28 @@ test.serial("sdkTransformer", async (t) => {
 		fs: "custom fs"
 	});
 
-	t.deepEqual(res.length, 1, "Returned one resource");
-	t.deepEqual(res[0], "result resource", "Returned one resource");
+	t.is(res.length, 1, "Returned one resource");
+	t.is(res[0], "result resource", "Returned one resource");
 
-	t.deepEqual(transformerStub.callCount, 1, "generateJsdocConfig called once");
-	t.deepEqual(transformerStub.getCall(0).args[0], "/some/path/api.json",
+	t.is(transformerStub.callCount, 1, "generateJsdocConfig called once");
+	t.is(transformerStub.getCall(0).args[0], "/some/path/api.json",
 		"transform-apijson-for-sdk called with correct argument #1");
-	t.deepEqual(transformerStub.getCall(0).args[1], "/ignore/this/path/resource/will/be/returned",
+	t.is(transformerStub.getCall(0).args[1], "/ignore/this/path/resource/will/be/returned",
 		"transform-apijson-for-sdk called with correct argument #2");
-	t.deepEqual(transformerStub.getCall(0).args[2], "/some/path/.library",
+	t.is(transformerStub.getCall(0).args[2], "/some/path/.library",
 		"transform-apijson-for-sdk called with correct argument #3");
 	t.deepEqual(transformerStub.getCall(0).args[3], [
 		"/some/path/x/api.json",
 		"/some/path/y/api.json"
 	], "transform-apijson-for-sdk called with correct argument #4");
-	t.deepEqual(transformerStub.getCall(0).args[4], "",
+	t.is(transformerStub.getCall(0).args[4], "",
 		"transform-apijson-for-sdk called with correct argument #5");
 	t.deepEqual(transformerStub.getCall(0).args[5], {
 		fs: "custom fs",
 		returnOutputFiles: true
 	}, "transform-apijson-for-sdk called with correct argument #6");
 
-	t.deepEqual(createResourceStub.callCount, 1, "createResource called once");
+	t.is(createResourceStub.callCount, 1, "createResource called once");
 	t.deepEqual(createResourceStub.getCall(0).args[0], {
 		path: "/some/other/path/api.json",
 		string: "api.json content"
@@ -58,6 +58,6 @@ test.serial("sdkTransformer", async (t) => {
 
 test("sdkTransformer missing parameters", async (t) => {
 	const error = await t.throwsAsync(sdkTransformer());
-	t.deepEqual(error.message, "[sdkTransformer]: One or more mandatory parameters not provided",
+	t.is(error.message, "[sdkTransformer]: One or more mandatory parameters not provided",
 		"Correct error message thrown");
 });

--- a/test/lib/processors/libraryLessGenerator.js
+++ b/test/lib/processors/libraryLessGenerator.js
@@ -567,7 +567,7 @@ test.serial("LibraryLessGenerator: Throw error when readFile fails", async (t) =
 	t.is(log.error.callCount, 0);
 });
 
-test.serial("LibraryLessGenerator.getPathToRoot", async (t) => {
+test.serial("LibraryLessGenerator.getPathToRoot", (t) => {
 	const {LibraryLessGenerator, log} = t.context;
 
 	t.is(

--- a/test/lib/processors/manifestCreator.js
+++ b/test/lib/processors/manifestCreator.js
@@ -1429,7 +1429,7 @@ test.serial("manifest creation for invalid .library content", async (t) => {
 		libraryResource,
 		resources: []
 	}));
-	t.deepEqual(error.message, `Unencoded <
+	t.is(error.message, `Unencoded <
 Line: 1
 Column: 5
 Char: <`, "error message for unencoded <");

--- a/test/lib/processors/minifier.js
+++ b/test/lib/processors/minifier.js
@@ -101,35 +101,35 @@ ${SOURCE_MAPPING_URL}=test3.designtime.js.map`;
 		`"names":["test3","paramA","variableA","console","log"],"sources":["test3-dbg.designtime.js"],` +
 		`"mappings":"AACA,SAASA,MAAMC,GACd,IAAIC,EAAYD,EAChBE,QAAQC,IAAIF,EACb,CACAF"}`;
 
-	t.deepEqual(resources[0].resource.getPath(), "/test1.controller.js",
+	t.is(resources[0].resource.getPath(), "/test1.controller.js",
 		"Correct resource path for minified content of resource 1");
 	t.deepEqual(await resources[0].resource.getString(), expectedMinified1, "Correct minified content for resource 1");
-	t.deepEqual(resources[0].dbgResource.getPath(), "/test1-dbg.controller.js",
+	t.is(resources[0].dbgResource.getPath(), "/test1-dbg.controller.js",
 		"Correct resource path for debug content of resource 1");
 	t.deepEqual(await resources[0].dbgResource.getString(), content1, "Correct debug content for resource 1");
-	t.deepEqual(resources[0].sourceMapResource.getPath(), "/test1.controller.js.map",
+	t.is(resources[0].sourceMapResource.getPath(), "/test1.controller.js.map",
 		"Correct resource path for source map content of resource 1");
 	t.deepEqual(await resources[0].sourceMapResource.getString(), expectedSourceMap1,
 		"Correct source map content for resource 1");
 
-	t.deepEqual(resources[1].resource.getPath(), "/test2.fragment.js",
+	t.is(resources[1].resource.getPath(), "/test2.fragment.js",
 		"Correct resource path for minified content of resource 2");
 	t.deepEqual(await resources[1].resource.getString(), expectedMinified2, "Correct minified content for resource 2");
-	t.deepEqual(resources[1].dbgResource.getPath(), "/test2-dbg.fragment.js",
+	t.is(resources[1].dbgResource.getPath(), "/test2-dbg.fragment.js",
 		"Correct resource path for debug content of resource 2");
 	t.deepEqual(await resources[1].dbgResource.getString(), content2, "Correct debug content for resource 2");
-	t.deepEqual(resources[1].sourceMapResource.getPath(), "/test2.fragment.js.map",
+	t.is(resources[1].sourceMapResource.getPath(), "/test2.fragment.js.map",
 		"Correct resource path for source map content of resource 2");
 	t.deepEqual(await resources[1].sourceMapResource.getString(), expectedSourceMap2,
 		"Correct source map content for resource 2");
 
-	t.deepEqual(resources[2].resource.getPath(), "/test3.designtime.js",
+	t.is(resources[2].resource.getPath(), "/test3.designtime.js",
 		"Correct resource path for minified content of resource 3");
 	t.deepEqual(await resources[2].resource.getString(), expectedMinified3, "Correct minified content for resource 3");
-	t.deepEqual(resources[2].dbgResource.getPath(), "/test3-dbg.designtime.js",
+	t.is(resources[2].dbgResource.getPath(), "/test3-dbg.designtime.js",
 		"Correct resource path for debug content of resource 3");
 	t.deepEqual(await resources[2].dbgResource.getString(), content3, "Correct debug content for resource 3");
-	t.deepEqual(resources[2].sourceMapResource.getPath(), "/test3.designtime.js.map",
+	t.is(resources[2].sourceMapResource.getPath(), "/test3.designtime.js.map",
 		"Correct resource path for source map content of resource 3");
 	t.deepEqual(await resources[2].sourceMapResource.getString(), expectedSourceMap3,
 		"Correct source map content for resource 3");

--- a/test/lib/processors/nonAsciiEscaper.js
+++ b/test/lib/processors/nonAsciiEscaper.js
@@ -116,7 +116,7 @@ test("Invalid encoding", async (t) => {
 
 
 test("getEncodingFromAlias", (t) => {
-	t.is("utf8", nonAsciiEscaper.getEncodingFromAlias("UTF-8"));
+	t.is(nonAsciiEscaper.getEncodingFromAlias("UTF-8"), "utf8");
 });
 
 test("getEncodingFromAlias invalid", (t) => {

--- a/test/lib/processors/resourceListCreator.js
+++ b/test/lib/processors/resourceListCreator.js
@@ -502,7 +502,7 @@ sap.ui.require.preload({
 
 	// XMLTemplateAnalyzer should only be called once, which means that the view was only analyzed once
 	t.is(XMLTemplateAnalyzerAnalyzeViewSpy.callCount, 1);
-	t.deepEqual(XMLTemplateAnalyzerAnalyzeViewSpy.getCall(0).args[1]._name,
+	t.is(XMLTemplateAnalyzerAnalyzeViewSpy.getCall(0).args[1]._name,
 		"my/app/View1.view.xml");
 
 	t.is(resourcesJson.length, 1, "One resources.json should be returned");

--- a/test/lib/processors/stringReplacer.js
+++ b/test/lib/processors/stringReplacer.js
@@ -50,6 +50,7 @@ test.serial("Replaces string pattern from resource stream", async (t) => {
 
 // Skip test in Node v8 as unicode handling of streams seems to be broken
 test[
+	// eslint-disable-next-line ava/no-unknown-modifiers
 	process.version.startsWith("v8.") ? "skip" : "serial"
 ]("Correctly processes utf8 characters within separate chunks", async (t) => {
 	const utf8string = "Κυ";

--- a/test/lib/processors/versionInfoGenerator.js
+++ b/test/lib/processors/versionInfoGenerator.js
@@ -7,11 +7,6 @@ const logger = require("@ui5/logger");
 let versionInfoGenerator = require("../../../lib/processors/versionInfoGenerator");
 
 
-test("versionInfoGenerator missing parameters", async (t) => {
-	const error = await t.throwsAsync(versionInfoGenerator({options: {}}));
-	t.deepEqual(error.message, "[versionInfoGenerator]: Missing options parameters");
-});
-
 test.beforeEach((t) => {
 	t.context.warnLogStub = sinon.stub();
 	t.context.infoLogStub = sinon.stub();
@@ -30,6 +25,11 @@ test.beforeEach((t) => {
 test.afterEach.always((t) => {
 	mock.stopAll();
 	sinon.restore();
+});
+
+test("versionInfoGenerator missing parameters", async (t) => {
+	const error = await t.throwsAsync(versionInfoGenerator({options: {}}));
+	t.is(error.message, "[versionInfoGenerator]: Missing options parameters");
 });
 
 const assertVersionInfoContent = (t, oExpectedVersionInfo, sActualContent) => {

--- a/test/lib/tasks/buildThemes.integration.js
+++ b/test/lib/tasks/buildThemes.integration.js
@@ -54,27 +54,27 @@ test("integration: simple", async (t) => {
 			inputPattern: "/resources/super/duper/looper/themes/**/library.source.less"
 		}
 	});
-	return await Promise.all([
+
+	const [cssResource, cssRtlResource, parametersResource] = await Promise.all([
 		writer.byPath(cssPath),
 		writer.byPath(cssRtlPath),
 		writer.byPath(parametersPath)
-	]).then(([cssResource, cssRtlResource, parametersResource]) => {
-		t.truthy(cssResource, "CSS resource has been created");
-		t.truthy(cssRtlResource, "CSS right-to-left resource has been created");
-		t.truthy(parametersResource, "Parameters JSON resource has been created");
+	]);
 
-		return Promise.all([
-			cssResource.getBuffer(),
-			cssRtlResource.getBuffer(),
-			parametersResource.getBuffer()
-		]);
-	}).then(([cssBuffer, cssRtlBuffer, parametersBuffer]) => {
-		t.deepEqual(cssBuffer.toString(), cssExpected, "Correct CSS content");
-		t.deepEqual(cssRtlBuffer.toString(), cssRtlExpected, "Correct CSS right-to-left content");
-		t.deepEqual(parametersBuffer.toString(), parametersExpected, "Correct parameters JSON content");
-	});
+	t.truthy(cssResource, "CSS resource has been created");
+	t.truthy(cssRtlResource, "CSS right-to-left resource has been created");
+	t.truthy(parametersResource, "Parameters JSON resource has been created");
+
+	const [cssBuffer, cssRtlBuffer, parametersBuffer] = await Promise.all([
+		cssResource.getBuffer(),
+		cssRtlResource.getBuffer(),
+		parametersResource.getBuffer()
+	]);
+
+	t.deepEqual(cssBuffer.toString(), cssExpected, "Correct CSS content");
+	t.deepEqual(cssRtlBuffer.toString(), cssRtlExpected, "Correct CSS right-to-left content");
+	t.deepEqual(parametersBuffer.toString(), parametersExpected, "Correct parameters JSON content");
 });
-
 test("integration: imports", async (t) => {
 	const reader = resourceFactory.createAdapter({
 		virBasePath: "/"
@@ -136,23 +136,23 @@ test("integration: imports", async (t) => {
 		}
 	});
 
-	return await Promise.all([
+	const [cssResource, cssRtlResource, parametersResource] = await Promise.all([
 		writer.byPath(cssPath),
 		writer.byPath(cssRtlPath),
 		writer.byPath(parametersPath)
-	]).then(([cssResource, cssRtlResource, parametersResource]) => {
-		t.truthy(cssResource, "CSS resource has been created");
-		t.truthy(cssRtlResource, "CSS right-to-left resource has been created");
-		t.truthy(parametersResource, "Parameters JSON resource has been created");
+	]);
 
-		return Promise.all([
-			cssResource.getBuffer(),
-			cssRtlResource.getBuffer(),
-			parametersResource.getBuffer()
-		]);
-	}).then(([cssBuffer, cssRtlBuffer, parametersBuffer]) => {
-		t.deepEqual(cssBuffer.toString(), cssExpected, "Correct CSS content");
-		t.deepEqual(cssRtlBuffer.toString(), cssRtlExpected, "Correct CSS right-to-left content");
-		t.deepEqual(parametersBuffer.toString(), parametersExpected, "Correct parameters JSON content");
-	});
+	t.truthy(cssResource, "CSS resource has been created");
+	t.truthy(cssRtlResource, "CSS right-to-left resource has been created");
+	t.truthy(parametersResource, "Parameters JSON resource has been created");
+
+	const [cssBuffer, cssRtlBuffer, parametersBuffer] = await Promise.all([
+		cssResource.getBuffer(),
+		cssRtlResource.getBuffer(),
+		parametersResource.getBuffer()
+	]);
+
+	t.deepEqual(cssBuffer.toString(), cssExpected, "Correct CSS content");
+	t.deepEqual(cssRtlBuffer.toString(), cssRtlExpected, "Correct CSS right-to-left content");
+	t.deepEqual(parametersBuffer.toString(), parametersExpected, "Correct parameters JSON content");
 });

--- a/test/lib/tasks/buildThemes.integration.js
+++ b/test/lib/tasks/buildThemes.integration.js
@@ -5,7 +5,7 @@ const ui5Fs = require("@ui5/fs");
 const resourceFactory = ui5Fs.resourceFactory;
 const DuplexCollection = ui5Fs.DuplexCollection;
 
-test("integration: simple", (t) => {
+test("integration: simple", async (t) => {
 	const reader = resourceFactory.createAdapter({
 		virBasePath: "/"
 	});
@@ -46,38 +46,36 @@ test("integration: simple", (t) => {
 		path: lessPath,
 		string: content
 	});
-	return reader.write(resource).then(() => {
-		return buildThemes({
-			workspace: duplexCollection,
-			dependencies: dependencies,
-			options: {
-				inputPattern: "/resources/super/duper/looper/themes/**/library.source.less"
-			}
-		}).then(() => {
-			return Promise.all([
-				writer.byPath(cssPath),
-				writer.byPath(cssRtlPath),
-				writer.byPath(parametersPath)
-			]);
-		}).then(([cssResource, cssRtlResource, parametersResource]) => {
-			t.truthy(cssResource, "CSS resource has been created");
-			t.truthy(cssRtlResource, "CSS right-to-left resource has been created");
-			t.truthy(parametersResource, "Parameters JSON resource has been created");
+	await reader.write(resource);
+	await buildThemes({
+		workspace: duplexCollection,
+		dependencies: dependencies,
+		options: {
+			inputPattern: "/resources/super/duper/looper/themes/**/library.source.less"
+		}
+	});
+	return await Promise.all([
+		writer.byPath(cssPath),
+		writer.byPath(cssRtlPath),
+		writer.byPath(parametersPath)
+	]).then(([cssResource, cssRtlResource, parametersResource]) => {
+		t.truthy(cssResource, "CSS resource has been created");
+		t.truthy(cssRtlResource, "CSS right-to-left resource has been created");
+		t.truthy(parametersResource, "Parameters JSON resource has been created");
 
-			return Promise.all([
-				cssResource.getBuffer(),
-				cssRtlResource.getBuffer(),
-				parametersResource.getBuffer()
-			]);
-		}).then(([cssBuffer, cssRtlBuffer, parametersBuffer]) => {
-			t.deepEqual(cssBuffer.toString(), cssExpected, "Correct CSS content");
-			t.deepEqual(cssRtlBuffer.toString(), cssRtlExpected, "Correct CSS right-to-left content");
-			t.deepEqual(parametersBuffer.toString(), parametersExpected, "Correct parameters JSON content");
-		});
+		return Promise.all([
+			cssResource.getBuffer(),
+			cssRtlResource.getBuffer(),
+			parametersResource.getBuffer()
+		]);
+	}).then(([cssBuffer, cssRtlBuffer, parametersBuffer]) => {
+		t.deepEqual(cssBuffer.toString(), cssExpected, "Correct CSS content");
+		t.deepEqual(cssRtlBuffer.toString(), cssRtlExpected, "Correct CSS right-to-left content");
+		t.deepEqual(parametersBuffer.toString(), parametersExpected, "Correct parameters JSON content");
 	});
 });
 
-test("integration: imports", (t) => {
+test("integration: imports", async (t) => {
 	const reader = resourceFactory.createAdapter({
 		virBasePath: "/"
 	});
@@ -126,35 +124,35 @@ test("integration: imports", (t) => {
 		string: lessVariablesContent
 	});
 
-	return Promise.all([lessResource, lessVariablesResource].map((resource) => {
+	await Promise.all([lessResource, lessVariablesResource].map((resource) => {
 		return reader.write(resource);
-	})).then(() => {
-		return buildThemes({
-			workspace: duplexCollection,
-			dependencies: dependencies,
-			options: {
-				inputPattern: "/resources/super/duper/looper/themes/**/library.source.less"
-			}
-		}).then(() => {
-			return Promise.all([
-				writer.byPath(cssPath),
-				writer.byPath(cssRtlPath),
-				writer.byPath(parametersPath)
-			]);
-		}).then(([cssResource, cssRtlResource, parametersResource]) => {
-			t.truthy(cssResource, "CSS resource has been created");
-			t.truthy(cssRtlResource, "CSS right-to-left resource has been created");
-			t.truthy(parametersResource, "Parameters JSON resource has been created");
+	}));
 
-			return Promise.all([
-				cssResource.getBuffer(),
-				cssRtlResource.getBuffer(),
-				parametersResource.getBuffer()
-			]);
-		}).then(([cssBuffer, cssRtlBuffer, parametersBuffer]) => {
-			t.deepEqual(cssBuffer.toString(), cssExpected, "Correct CSS content");
-			t.deepEqual(cssRtlBuffer.toString(), cssRtlExpected, "Correct CSS right-to-left content");
-			t.deepEqual(parametersBuffer.toString(), parametersExpected, "Correct parameters JSON content");
-		});
+	await buildThemes({
+		workspace: duplexCollection,
+		dependencies: dependencies,
+		options: {
+			inputPattern: "/resources/super/duper/looper/themes/**/library.source.less"
+		}
+	});
+
+	return await Promise.all([
+		writer.byPath(cssPath),
+		writer.byPath(cssRtlPath),
+		writer.byPath(parametersPath)
+	]).then(([cssResource, cssRtlResource, parametersResource]) => {
+		t.truthy(cssResource, "CSS resource has been created");
+		t.truthy(cssRtlResource, "CSS right-to-left resource has been created");
+		t.truthy(parametersResource, "Parameters JSON resource has been created");
+
+		return Promise.all([
+			cssResource.getBuffer(),
+			cssRtlResource.getBuffer(),
+			parametersResource.getBuffer()
+		]);
+	}).then(([cssBuffer, cssRtlBuffer, parametersBuffer]) => {
+		t.deepEqual(cssBuffer.toString(), cssExpected, "Correct CSS content");
+		t.deepEqual(cssRtlBuffer.toString(), cssRtlExpected, "Correct CSS right-to-left content");
+		t.deepEqual(parametersBuffer.toString(), parametersExpected, "Correct parameters JSON content");
 	});
 });

--- a/test/lib/tasks/buildThemes.js
+++ b/test/lib/tasks/buildThemes.js
@@ -10,11 +10,6 @@ test.before(() => {
 	require("@ui5/logger").setLevel("verbose");
 });
 
-test.afterEach.always((t) => {
-	mock.stopAll();
-	sinon.restore();
-});
-
 test.beforeEach((t) => {
 	// Stubbing processors/themeBuilder
 	t.context.themeBuilderStub = sinon.stub();
@@ -33,6 +28,11 @@ test.beforeEach((t) => {
 
 	// Re-require tested module
 	buildThemes = mock.reRequire("../../../lib/tasks/buildThemes");
+});
+
+test.afterEach.always((t) => {
+	mock.stopAll();
+	sinon.restore();
 });
 
 test.afterEach.always((t) => {
@@ -74,7 +74,7 @@ test.serial("buildThemes", async (t) => {
 		}
 	});
 
-	t.deepEqual(t.context.themeBuilderStub.callCount, 1,
+	t.is(t.context.themeBuilderStub.callCount, 1,
 		"Processor should be called once");
 
 	t.deepEqual(t.context.themeBuilderStub.getCall(0).args[0], {
@@ -86,7 +86,7 @@ test.serial("buildThemes", async (t) => {
 		}
 	}, "Processor should be called with expected arguments");
 
-	t.deepEqual(workspace.write.callCount, 3,
+	t.is(workspace.write.callCount, 3,
 		"workspace.write should be called 3 times");
 	t.true(workspace.write.calledWithExactly(cssResource));
 	t.true(workspace.write.calledWithExactly(cssRtlResource));
@@ -129,7 +129,7 @@ test.serial("buildThemes (compress = false)", async (t) => {
 		}
 	});
 
-	t.deepEqual(t.context.themeBuilderStub.callCount, 1,
+	t.is(t.context.themeBuilderStub.callCount, 1,
 		"Processor should be called once");
 
 	t.deepEqual(t.context.themeBuilderStub.getCall(0).args[0], {
@@ -141,7 +141,7 @@ test.serial("buildThemes (compress = false)", async (t) => {
 		}
 	}, "Processor should be called with expected arguments");
 
-	t.deepEqual(workspace.write.callCount, 3,
+	t.is(workspace.write.callCount, 3,
 		"workspace.write should be called 3 times");
 	t.true(workspace.write.calledWithExactly(cssResource));
 	t.true(workspace.write.calledWithExactly(cssRtlResource));
@@ -191,7 +191,7 @@ test.serial("buildThemes (cssVariables = true)", async (t) => {
 		}
 	});
 
-	t.deepEqual(t.context.themeBuilderStub.callCount, 1,
+	t.is(t.context.themeBuilderStub.callCount, 1,
 		"Processor should be called once");
 
 	t.deepEqual(t.context.themeBuilderStub.getCall(0).args[0], {
@@ -203,7 +203,7 @@ test.serial("buildThemes (cssVariables = true)", async (t) => {
 		}
 	}, "Processor should be called with expected arguments");
 
-	t.deepEqual(workspace.write.callCount, 7,
+	t.is(workspace.write.callCount, 7,
 		"workspace.write should be called 7 times");
 	t.true(workspace.write.calledWithExactly(cssResource));
 	t.true(workspace.write.calledWithExactly(cssRtlResource));
@@ -272,7 +272,7 @@ test.serial("buildThemes (filtering libraries)", async (t) => {
 		}
 	});
 
-	t.deepEqual(t.context.themeBuilderStub.callCount, 1,
+	t.is(t.context.themeBuilderStub.callCount, 1,
 		"Processor should be called once");
 
 	t.deepEqual(t.context.themeBuilderStub.getCall(0).args[0], {
@@ -287,7 +287,7 @@ test.serial("buildThemes (filtering libraries)", async (t) => {
 		}
 	}, "Processor should be called with expected arguments");
 
-	t.deepEqual(workspace.write.callCount, 1,
+	t.is(workspace.write.callCount, 1,
 		"workspace.write should be called once");
 });
 
@@ -351,7 +351,7 @@ test.serial("buildThemes (filtering themes)", async (t) => {
 		}
 	});
 
-	t.deepEqual(t.context.themeBuilderStub.callCount, 1,
+	t.is(t.context.themeBuilderStub.callCount, 1,
 		"Processor should be called once");
 
 	t.deepEqual(t.context.themeBuilderStub.getCall(0).args[0], {
@@ -366,7 +366,7 @@ test.serial("buildThemes (filtering themes)", async (t) => {
 		}
 	}, "Processor should be called with expected arguments");
 
-	t.deepEqual(workspace.write.callCount, 1,
+	t.is(workspace.write.callCount, 1,
 		"workspace.write should be called once");
 });
 
@@ -472,7 +472,7 @@ test.serial("buildThemes (filtering libraries + themes)", async (t) => {
 		}
 	});
 
-	t.deepEqual(t.context.themeBuilderStub.callCount, 1,
+	t.is(t.context.themeBuilderStub.callCount, 1,
 		"Processor should be called once");
 
 	t.deepEqual(t.context.themeBuilderStub.getCall(0).args[0], {
@@ -489,6 +489,6 @@ test.serial("buildThemes (filtering libraries + themes)", async (t) => {
 		}
 	}, "Processor should be called with expected arguments");
 
-	t.deepEqual(workspace.write.callCount, 1,
+	t.is(workspace.write.callCount, 1,
 		"workspace.write should be called once");
 });

--- a/test/lib/tasks/buildThemes.js
+++ b/test/lib/tasks/buildThemes.js
@@ -31,11 +31,6 @@ test.beforeEach((t) => {
 });
 
 test.afterEach.always((t) => {
-	mock.stopAll();
-	sinon.restore();
-});
-
-test.afterEach.always((t) => {
 	sinon.restore();
 	mock.stopAll();
 });

--- a/test/lib/tasks/bundlers/generateLibraryPreload.integration.js
+++ b/test/lib/tasks/bundlers/generateLibraryPreload.integration.js
@@ -52,7 +52,7 @@ test("integration: build library.d with library preload", async (t) => {
 	assert.directoryDeepEqual(destPath, expectedPath);
 
 	// Check for all file contents
-	t.deepEqual(expectedFiles.length, 5, "5 files are expected");
+	t.is(expectedFiles.length, 5, "5 files are expected");
 	expectedFiles.forEach((expectedFile) => {
 		const relativeFile = path.relative(expectedPath, expectedFile);
 		const destFile = path.join(destPath, relativeFile);

--- a/test/lib/tasks/bundlers/generateManifestBundle.js
+++ b/test/lib/tasks/bundlers/generateManifestBundle.js
@@ -26,11 +26,11 @@ test.serial("generateManifestBundle", async (t) => {
 			namespace: "some/project"
 		}
 	});
-	t.deepEqual(byGlobStub.callCount, 1, "workspace.byGlob got called once");
-	t.deepEqual(byGlobStub.getCall(0).args[0], "/resources/some/project/**/{manifest.json,*.properties}",
+	t.is(byGlobStub.callCount, 1, "workspace.byGlob got called once");
+	t.is(byGlobStub.getCall(0).args[0], "/resources/some/project/**/{manifest.json,*.properties}",
 		"workspace.byGlob got called with the correct arguments");
 
-	t.deepEqual(manifestBundlerStub.callCount, 1, "manifestBundler got called once");
+	t.is(manifestBundlerStub.callCount, 1, "manifestBundler got called once");
 	t.deepEqual(manifestBundlerStub.getCall(0).args[0], {
 		resources: ["some resource", "some other resource"],
 		options: {
@@ -41,10 +41,10 @@ test.serial("generateManifestBundle", async (t) => {
 		}
 	}, "manifestBundler got called with the correct arguments");
 
-	t.deepEqual(writeStub.callCount, 2, "workspace.write got called twice");
-	t.deepEqual(writeStub.getCall(0).args[0], "some new resource",
+	t.is(writeStub.callCount, 2, "workspace.write got called twice");
+	t.is(writeStub.getCall(0).args[0], "some new resource",
 		"workspace.write got called with the correct arguments");
-	t.deepEqual(writeStub.getCall(1).args[0], "some other new resource",
+	t.is(writeStub.getCall(1).args[0], "some other new resource",
 		"workspace.write got called with the correct arguments");
 
 	mock.stop("../../../../lib/processors/bundlers/manifestBundler");
@@ -68,17 +68,17 @@ test.serial("generateManifestBundle with no resources", async (t) => {
 			namespace: "some/project"
 		}
 	});
-	t.deepEqual(byGlobStub.callCount, 1, "workspace.byGlob got called once");
-	t.deepEqual(byGlobStub.getCall(0).args[0], "/resources/some/project/**/{manifest.json,*.properties}",
+	t.is(byGlobStub.callCount, 1, "workspace.byGlob got called once");
+	t.is(byGlobStub.getCall(0).args[0], "/resources/some/project/**/{manifest.json,*.properties}",
 		"workspace.byGlob got called with the correct arguments");
 
-	t.deepEqual(manifestBundlerStub.callCount, 0, "manifestBundler not called");
+	t.is(manifestBundlerStub.callCount, 0, "manifestBundler not called");
 
 	mock.stop("../../../../lib/processors/bundlers/manifestBundler");
 });
 
 test("generateManifestBundle with missing parameters", async (t) => {
 	const error = await t.throwsAsync(generateManifestBundle({}));
-	t.deepEqual(error.message, "[generateManifestBundle]: One or more mandatory options not provided",
+	t.is(error.message, "[generateManifestBundle]: One or more mandatory options not provided",
 		"Rejected with correct error message");
 });

--- a/test/lib/tasks/bundlers/generateStandaloneAppBundle.js
+++ b/test/lib/tasks/bundlers/generateStandaloneAppBundle.js
@@ -59,10 +59,10 @@ test.serial("execute module bundler and write results", async (t) => {
 	};
 	await generateStandaloneAppBundle(params);
 
-	t.deepEqual(t.context.moduleBundlerStub.callCount, 2);
+	t.is(t.context.moduleBundlerStub.callCount, 2);
 
 	const {resources, options} = t.context.moduleBundlerStub.getCall(0).args[0];
-	t.deepEqual(resources.length, 4, "moduleBundler got supplied with 4 resources");
+	t.is(resources.length, 4, "moduleBundler got supplied with 4 resources");
 	t.deepEqual(options.bundleDefinition.sections[0].filters, [
 		"jquery.sap.global.js"
 	], "Correct filter in first bundle definition section");
@@ -105,10 +105,10 @@ test.serial("execute module bundler and write results without namespace", async 
 	};
 	await generateStandaloneAppBundle(params);
 
-	t.deepEqual(t.context.moduleBundlerStub.callCount, 2);
+	t.is(t.context.moduleBundlerStub.callCount, 2);
 
 	const {resources, options} = t.context.moduleBundlerStub.getCall(0).args[0];
-	t.deepEqual(resources.length, 4, "moduleBundler got supplied with 4 resources");
+	t.is(resources.length, 4, "moduleBundler got supplied with 4 resources");
 	t.deepEqual(options.bundleDefinition.sections[0].filters, [
 		"jquery.sap.global.js"
 	], "Correct filter in first bundle definition section");
@@ -151,10 +151,10 @@ test.serial("execute module bundler and write results in evo mode", async (t) =>
 	};
 	await generateStandaloneAppBundle(params);
 
-	t.deepEqual(t.context.moduleBundlerStub.callCount, 2);
+	t.is(t.context.moduleBundlerStub.callCount, 2);
 
 	const {resources, options} = t.context.moduleBundlerStub.getCall(0).args[0];
-	t.deepEqual(resources.length, 4, "moduleBundler got supplied with 4 resources");
+	t.is(resources.length, 4, "moduleBundler got supplied with 4 resources");
 	t.deepEqual(options.bundleDefinition.sections[0].filters, [
 		"ui5loader-autoconfig.js"
 	], "Evo mode active - Correct filter in first bundle definition section");

--- a/test/lib/tasks/escapeNonAsciiCharacters.js
+++ b/test/lib/tasks/escapeNonAsciiCharacters.js
@@ -5,7 +5,7 @@ const ui5Fs = require("@ui5/fs");
 const resourceFactory = ui5Fs.resourceFactory;
 const DuplexCollection = ui5Fs.DuplexCollection;
 
-test("integration: escape non ascii characters (utf8, default)", (t) => {
+test("integration: escape non ascii characters (utf8, default)", async (t) => {
 	const reader = resourceFactory.createAdapter({
 		virBasePath: "/"
 	});
@@ -33,28 +33,25 @@ city=Ort:`;
 		string: content
 	});
 
-	return workspace.write(resource).then(() => {
-		return escapeNonAsciiCharacters({
-			workspace,
-			options: {
-				encoding: "UTF-8",
-				pattern: "/**/*.properties"
-			}
-		}).then(() => {
-			return writer.byPath("/i18n.properties").then((resource) => {
-				if (!resource) {
-					t.fail("Could not find /i18n.properties in target");
-				} else {
-					return resource.getString();
-				}
-			});
-		}).then((result) => {
-			return t.deepEqual(result, expected);
-		});
+	await workspace.write(resource);
+	await escapeNonAsciiCharacters({
+		workspace,
+		options: {
+			encoding: "UTF-8",
+			pattern: "/**/*.properties"
+		}
 	});
+
+	const escapedResource = await writer.byPath("/i18n.properties");
+
+	if (!escapedResource) {
+		t.fail("Could not find /i18n.properties in target");
+	} else {
+		t.deepEqual(await escapedResource.getString(), expected);
+	}
 });
 
-test("integration: escape non ascii characters source encoding being (ISO-8859-1)", (t) => {
+test("integration: escape non ascii characters source encoding being (ISO-8859-1)", async (t) => {
 	const reader = resourceFactory.createAdapter({
 		virBasePath: "/"
 	});
@@ -83,25 +80,22 @@ city=Ort:`;
 		buffer: content
 	});
 
-	return workspace.write(resource).then(() => {
-		return escapeNonAsciiCharacters({
-			workspace,
-			options: {
-				encoding: "ISO-8859-1",
-				pattern: "/**/*.properties"
-			}
-		}).then(() => {
-			return writer.byPath("/i18n.properties").then((resource) => {
-				if (!resource) {
-					t.fail("Could not find /i18n.properties in target");
-				} else {
-					return resource.getString();
-				}
-			});
-		}).then((result) => {
-			return t.deepEqual(result, expected);
-		});
+	await workspace.write(resource);
+	await escapeNonAsciiCharacters({
+		workspace,
+		options: {
+			encoding: "ISO-8859-1",
+			pattern: "/**/*.properties"
+		}
 	});
+
+	const escapedResource = await writer.byPath("/i18n.properties");
+
+	if (!escapedResource) {
+		t.fail("Could not find /i18n.properties in target");
+	} else {
+		t.deepEqual(await escapedResource.getString(), expected);
+	}
 });
 
 test("integration: escape non ascii characters source encoding being empty", async (t) => {

--- a/test/lib/tasks/generateResourcesJson.js
+++ b/test/lib/tasks/generateResourcesJson.js
@@ -69,7 +69,7 @@ test.serial("empty resources (sap.ui.core)", async (t) => {
 			projectName: "sap.ui.core"
 		}
 	});
-	t.deepEqual(result, undefined, "no resources returned");
+	t.is(result, undefined, "no resources returned");
 	t.is(resourceListCreatorStub.callCount, 1);
 	t.deepEqual(t.context.resourceListCreatorStub.getCall(0).args[0].resources, [], "no resources are passed");
 	const expectedOptions = {
@@ -94,7 +94,7 @@ test.serial("empty resources (my.lib)", async (t) => {
 			projectName: "my.lib"
 		}
 	});
-	t.deepEqual(result, undefined, "no resources returned");
+	t.is(result, undefined, "no resources returned");
 	t.is(t.context.resourceListCreatorStub.callCount, 1);
 	t.deepEqual(t.context.resourceListCreatorStub.getCall(0).args[0].resources, [], "no resources are passed");
 	const expectedOptions = {};
@@ -116,7 +116,7 @@ test.serial("empty resources (my.lib with dependencies)", async (t) => {
 			projectName: "my.lib"
 		}
 	});
-	t.deepEqual(result, undefined, "no resources returned");
+	t.is(result, undefined, "no resources returned");
 	t.is(t.context.resourceListCreatorStub.callCount, 1);
 	t.deepEqual(t.context.resourceListCreatorStub.getCall(0).args[0].resources, [], "no resources are passed");
 	const expectedOptions = {};
@@ -179,7 +179,7 @@ test.serial("Resources omitted from build result should be ignored", async (t) =
 	t.deepEqual(taskUtil.getTag.getCall(3).args, [dependencyResource1, "TEST-OmitFromBuildResult-TEST"]);
 	t.deepEqual(taskUtil.getTag.getCall(4).args, [dependencyResource2, "TEST-OmitFromBuildResult-TEST"]);
 
-	t.deepEqual(result, undefined, "no resources returned");
+	t.is(result, undefined, "no resources returned");
 	t.is(t.context.resourceListCreatorStub.callCount, 1);
 	t.deepEqual(t.context.resourceListCreatorStub.getCall(0).args[0].resources,
 		[resource1, resource3], "only resources 1 and 3 are passed");

--- a/test/lib/tasks/generateVersionInfo.js
+++ b/test/lib/tasks/generateVersionInfo.js
@@ -158,6 +158,7 @@ test.serial("integration: Library without i18n bundle file", async (t) => {
 
 // MB: No idea what the below test is supposed to check, but apparently
 // I fixed the missing options parameter
+// eslint-disable-next-line ava/no-skip-test
 test.serial.skip("integration: Library without i18n bundle file failure", async (t) => {
 	t.context.workspace = createWorkspace();
 	t.context.dependencies = createDependencies();

--- a/test/lib/tasks/jsdoc/executeJsdocSdkTransformation.js
+++ b/test/lib/tasks/jsdoc/executeJsdocSdkTransformation.js
@@ -61,21 +61,21 @@ test.serial("executeJsdocSdkTransformation", async (t) => {
 			dotLibraryPattern: "some .library pattern"
 		}
 	});
-	t.deepEqual(byGlobWorkspaceStub.callCount, 2, "workspace.byGlob got called twice");
-	t.deepEqual(byGlobWorkspaceStub.getCall(0).args[0], "/test-resources/**/designtime/api.json",
+	t.is(byGlobWorkspaceStub.callCount, 2, "workspace.byGlob got called twice");
+	t.is(byGlobWorkspaceStub.getCall(0).args[0], "/test-resources/**/designtime/api.json",
 		"first workspace.byGlob call with correct arguments");
-	t.deepEqual(byGlobWorkspaceStub.getCall(1).args[0], "some .library pattern",
+	t.is(byGlobWorkspaceStub.getCall(1).args[0], "some .library pattern",
 		"second workspace.byGlob call with correct arguments");
 
-	t.deepEqual(byGlobDependenciesStub.callCount, 1, "dependencies.byGlob got called once");
-	t.deepEqual(byGlobDependenciesStub.getCall(0).args[0], "/test-resources/**/designtime/api.json",
+	t.is(byGlobDependenciesStub.callCount, 1, "dependencies.byGlob got called once");
+	t.is(byGlobDependenciesStub.getCall(0).args[0], "/test-resources/**/designtime/api.json",
 		"dependencies.byGlob got called with correct arguments");
 
-	t.deepEqual(fsInterfaceStub.callCount, 1, "fsInterface got called once");
+	t.is(fsInterfaceStub.callCount, 1, "fsInterface got called once");
 	t.true(fsInterfaceStub.getCall(0).args[0] instanceof ReaderCollectionPrioritizedStubClass,
 		"fsInterface got called with an instance of ReaderCollectionPrioritizedStubClass");
 
-	t.deepEqual(sdkTransformerStub.callCount, 1, "sdkTransformer processor got called once");
+	t.is(sdkTransformerStub.callCount, 1, "sdkTransformer processor got called once");
 	t.deepEqual(sdkTransformerStub.getCall(0).args[0], {
 		apiJsonPath: "workspace/api.json",
 		dotLibraryPath: "workspace/.library",
@@ -87,9 +87,9 @@ test.serial("executeJsdocSdkTransformation", async (t) => {
 		fs: "custom fs"
 	}, "sdkTransformer got called with correct arguments");
 
-	t.deepEqual(writeStub.callCount, 2, "Write got called twice");
-	t.deepEqual(writeStub.getCall(0).args[0], "resource A", "Write got called with correct arguments");
-	t.deepEqual(writeStub.getCall(1).args[0], "resource B", "Write got called with correct arguments");
+	t.is(writeStub.callCount, 2, "Write got called twice");
+	t.is(writeStub.getCall(0).args[0], "resource A", "Write got called with correct arguments");
+	t.is(writeStub.getCall(1).args[0], "resource B", "Write got called with correct arguments");
 });
 
 test("executeJsdocSdkTransformation with missing parameters", async (t) => {
@@ -134,8 +134,8 @@ test.serial("executeJsdocSdkTransformation with missing project api.json (skips 
 		}
 	});
 
-	t.deepEqual(infoLogStub.callCount, 1, "One message has been logged");
-	t.deepEqual(infoLogStub.getCall(0).args[0],
+	t.is(infoLogStub.callCount, 1, "One message has been logged");
+	t.is(infoLogStub.getCall(0).args[0],
 		"Failed to locate api.json resource for project some.project. Skipping SDK Transformation...",
 		"Correct message has been logged");
 });
@@ -171,7 +171,7 @@ test("executeJsdocSdkTransformation too many project api.json resources", async 
 			dotLibraryPattern: "some .library pattern"
 		}
 	}));
-	t.deepEqual(error.message,
+	t.is(error.message,
 		"[executeJsdocSdkTransformation]: Found more than one api.json resources for project some.project.",
 		"Correct error message thrown");
 });
@@ -203,7 +203,7 @@ test("executeJsdocSdkTransformation missing project .library", async (t) => {
 			dotLibraryPattern: "some .library pattern"
 		}
 	}));
-	t.deepEqual(error.message,
+	t.is(error.message,
 		"[executeJsdocSdkTransformation]: Failed to locate .library resource for project some.project.",
 		"Correct error message thrown");
 });
@@ -239,7 +239,7 @@ test("executeJsdocSdkTransformation too many project .library resources", async 
 			dotLibraryPattern: "some .library pattern"
 		}
 	}));
-	t.deepEqual(error.message,
+	t.is(error.message,
 		"[executeJsdocSdkTransformation]: Found more than one .library resources for project some.project.",
 		"Correct error message thrown");
 });

--- a/test/lib/tasks/jsdoc/generateApiIndex.js
+++ b/test/lib/tasks/jsdoc/generateApiIndex.js
@@ -44,11 +44,11 @@ test.serial("generateApiIndex", async (t) => {
 		}
 	});
 
-	t.deepEqual(fsInterfaceStub.callCount, 1, "fsInterface got called once");
+	t.is(fsInterfaceStub.callCount, 1, "fsInterface got called once");
 	t.true(fsInterfaceStub.getCall(0).args[0] instanceof ReaderCollectionPrioritizedStubClass,
 		"fsInterface got called with an instance of ReaderCollectionPrioritizedStubClass");
 
-	t.deepEqual(apiIndexGeneratorStub.callCount, 1, "apiIndexGenerator processor got called once");
+	t.is(apiIndexGeneratorStub.callCount, 1, "apiIndexGenerator processor got called once");
 	t.deepEqual(apiIndexGeneratorStub.getCall(0).args[0], {
 		versionInfoPath: "/resources/sap-ui-version.json",
 		testResourcesRootPath: "/test-resources",
@@ -59,9 +59,9 @@ test.serial("generateApiIndex", async (t) => {
 		fs: "custom fs"
 	}, "apiIndexGenerator got called with correct arguments");
 
-	t.deepEqual(writeStub.callCount, 2, "Write got called twice");
-	t.deepEqual(writeStub.getCall(0).args[0], "resource A", "Write got called with correct arguments");
-	t.deepEqual(writeStub.getCall(1).args[0], "resource B", "Write got called with correct arguments");
+	t.is(writeStub.callCount, 2, "Write got called twice");
+	t.is(writeStub.getCall(0).args[0], "resource A", "Write got called with correct arguments");
+	t.is(writeStub.getCall(1).args[0], "resource B", "Write got called with correct arguments");
 });
 
 test("generateApiIndex with missing parameters", async (t) => {

--- a/test/lib/tasks/jsdoc/generateJsdoc.js
+++ b/test/lib/tasks/jsdoc/generateJsdoc.js
@@ -23,12 +23,12 @@ test.serial("createTmpDir successful", async (t) => {
 
 	const tmpRootPath = path.join(os.tmpdir(), "ui5-tooling");
 
-	t.deepEqual(makeDirStub.callCount, 1, "One directory got created");
+	t.is(makeDirStub.callCount, 1, "One directory got created");
 	t.deepEqual(makeDirStub.getCall(0).args[0], tmpRootPath, "Correct tmp root dir got created");
 
-	t.deepEqual(mkdtempStub.callCount, 1, "mkdtemp is called once");
+	t.is(mkdtempStub.callCount, 1, "mkdtemp is called once");
 	t.deepEqual(mkdtempStub.getCall(0).args[0], path.join(tmpRootPath, "jsdoc-somenam3space-"));
-	t.deepEqual(res, "some/path", "Correct path returned");
+	t.is(res, "some/path", "Correct path returned");
 
 	mock.stop("make-dir");
 });
@@ -44,12 +44,12 @@ test.serial("createTmpDir error", async (t) => {
 
 	const tmpRootPath = path.join(os.tmpdir(), "ui5-tooling");
 
-	t.deepEqual(makeDirStub.callCount, 1, "One directory got created");
+	t.is(makeDirStub.callCount, 1, "One directory got created");
 	t.deepEqual(makeDirStub.getCall(0).args[0], tmpRootPath, "Correct tmp root dir got created");
 
-	t.deepEqual(mkdtempStub.callCount, 1, "mkdtemp is called once");
+	t.is(mkdtempStub.callCount, 1, "mkdtemp is called once");
 	t.deepEqual(mkdtempStub.getCall(0).args[0], path.join(tmpRootPath, "jsdoc-somenamespace-"));
-	t.deepEqual(res.message, "Dir creation failed", "Dir creation failed");
+	t.is(res.message, "Dir creation failed", "Dir creation failed");
 
 	mock.stop("make-dir");
 });
@@ -66,10 +66,10 @@ test.serial("createTmpDirs", async (t) => {
 
 	const res = await generateJsdoc._createTmpDirs("some.namespace");
 
-	t.deepEqual(createTmpDirStub.callCount, 1, "creteTmpDir called once");
-	t.deepEqual(createTmpDirStub.getCall(0).args[0], "some.namespace", "creteTmpDir called with correct argument");
+	t.is(createTmpDirStub.callCount, 1, "creteTmpDir called once");
+	t.is(createTmpDirStub.getCall(0).args[0], "some.namespace", "creteTmpDir called with correct argument");
 
-	t.deepEqual(makeDirStub.callCount, 3, "Three directory got created");
+	t.is(makeDirStub.callCount, 3, "Three directory got created");
 	t.deepEqual(makeDirStub.getCall(0).args[0], path.join("/", "some", "path", "src"),
 		"Correct srcdir path got created");
 	t.deepEqual(makeDirStub.getCall(1).args[0], path.join("/", "some", "path", "target"),
@@ -82,7 +82,7 @@ test.serial("createTmpDirs", async (t) => {
 	t.deepEqual(res.tmpPath, path.join("/", "some", "path", "tmp"), "Correct temporary tmp dir path returned");
 
 	res.cleanup();
-	t.deepEqual(rimrafStub.callCount, 1, "Cleanup callback: rimraf called once");
+	t.is(rimrafStub.callCount, 1, "Cleanup callback: rimraf called once");
 	t.deepEqual(rimrafStub.getCall(0).args[0], path.join("/", "some", "path"),
 		"Cleanup callback: rimraf called with correct path");
 
@@ -100,7 +100,7 @@ test.serial("writeResourcesToDir with byGlobSource", async (t) => {
 		workspace: {
 			// stub byGlobSource
 			byGlobSource: (pattern) => {
-				t.deepEqual(pattern, "some pattern", "Glob with correct pattern");
+				t.is(pattern, "some pattern", "Glob with correct pattern");
 				return Promise.resolve(["resource A", "resource B"]);
 			}
 		},
@@ -113,9 +113,9 @@ test.serial("writeResourcesToDir with byGlobSource", async (t) => {
 		virBasePath: "/resources/"
 	}, "createAdapter called with correct arguments");
 
-	t.deepEqual(writeStub.callCount, 2, "Write got called four times");
-	t.deepEqual(writeStub.getCall(0).args[0], "resource A", "Write got called for resource A");
-	t.deepEqual(writeStub.getCall(1).args[0], "resource B", "Write got called for resource B");
+	t.is(writeStub.callCount, 2, "Write got called four times");
+	t.is(writeStub.getCall(0).args[0], "resource A", "Write got called for resource A");
+	t.is(writeStub.getCall(1).args[0], "resource B", "Write got called for resource B");
 });
 
 test.serial("writeResourcesToDir with byGlob", async (t) => {
@@ -127,7 +127,7 @@ test.serial("writeResourcesToDir with byGlob", async (t) => {
 	await generateJsdoc._writeResourcesToDir({
 		workspace: {
 			byGlob: (pattern) => {
-				t.deepEqual(pattern, "some pattern", "Glob with correct pattern");
+				t.is(pattern, "some pattern", "Glob with correct pattern");
 				return Promise.resolve(["resource A", "resource B"]);
 			}
 		},
@@ -140,9 +140,9 @@ test.serial("writeResourcesToDir with byGlob", async (t) => {
 		virBasePath: "/resources/"
 	}, "createAdapter called with correct arguments");
 
-	t.deepEqual(writeStub.callCount, 2, "Write got called four times");
-	t.deepEqual(writeStub.getCall(0).args[0], "resource A", "Write got called for resource A");
-	t.deepEqual(writeStub.getCall(1).args[0], "resource B", "Write got called for resource B");
+	t.is(writeStub.callCount, 2, "Write got called four times");
+	t.is(writeStub.getCall(0).args[0], "resource A", "Write got called for resource A");
+	t.is(writeStub.getCall(1).args[0], "resource B", "Write got called for resource B");
 });
 
 test.serial("writeDependencyApisToDir with byGlob", async (t) => {
@@ -176,7 +176,7 @@ test.serial("writeDependencyApisToDir with byGlob", async (t) => {
 	await generateJsdoc._writeDependencyApisToDir({
 		dependencies: {
 			byGlob: (pattern) => {
-				t.deepEqual(pattern, "/test-resources/**/designtime/api.json",
+				t.is(pattern, "/test-resources/**/designtime/api.json",
 					"Dependency api.json glob with correct pattern");
 				return Promise.resolve([initialResourceA, initialResourceB]);
 			}
@@ -184,23 +184,23 @@ test.serial("writeDependencyApisToDir with byGlob", async (t) => {
 		targetPath: path.join("/", "some", "target", "path")
 	});
 
-	t.deepEqual(cloneStubA.callCount, 1, "resource A got cloned once");
-	t.deepEqual(cloneStubB.callCount, 1, "resource B got cloned once");
+	t.is(cloneStubA.callCount, 1, "resource A got cloned once");
+	t.is(cloneStubB.callCount, 1, "resource B got cloned once");
 
-	t.deepEqual(setPathStubA.callCount, 1, "Path of cloned resource A got changed");
-	t.deepEqual(setPathStubA.getCall(0).args[0], "/api-0.json", "Path of cloned resource A got changed correctly");
+	t.is(setPathStubA.callCount, 1, "Path of cloned resource A got changed");
+	t.is(setPathStubA.getCall(0).args[0], "/api-0.json", "Path of cloned resource A got changed correctly");
 
-	t.deepEqual(setPathStubB.callCount, 1, "Path of cloned resource B got changed");
-	t.deepEqual(setPathStubB.getCall(0).args[0], "/api-1.json", "Path of cloned resource B got changed correctly");
+	t.is(setPathStubB.callCount, 1, "Path of cloned resource B got changed");
+	t.is(setPathStubB.getCall(0).args[0], "/api-1.json", "Path of cloned resource B got changed correctly");
 
 	t.deepEqual(createAdapterStub.getCall(0).args[0], {
 		fsBasePath: path.join("/", "some", "target", "path"),
 		virBasePath: "/"
 	}, "createAdapter called with correct arguments");
 
-	t.deepEqual(writeStub.callCount, 2, "Write got called four times");
-	t.deepEqual(writeStub.getCall(0).args[0].id, "resource A", "Write got called for resource A");
-	t.deepEqual(writeStub.getCall(1).args[0].id, "resource B", "Write got called for resource B");
+	t.is(writeStub.callCount, 2, "Write got called four times");
+	t.is(writeStub.getCall(0).args[0].id, "resource A", "Write got called for resource A");
+	t.is(writeStub.getCall(1).args[0].id, "resource B", "Write got called for resource B");
 });
 
 test.serial("generateJsdoc", async (t) => {
@@ -239,28 +239,28 @@ test.serial("generateJsdoc", async (t) => {
 		}
 	});
 
-	t.deepEqual(createTmpDirsStub.callCount, 1, "createTmpDirs got called once");
-	t.deepEqual(createTmpDirsStub.getCall(0).args[0], "some.project",
+	t.is(createTmpDirsStub.callCount, 1, "createTmpDirs got called once");
+	t.is(createTmpDirsStub.getCall(0).args[0], "some.project",
 		"createTmpDirs got called with correct arguments");
 
-	t.deepEqual(registerCleanupTaskStub.callCount, 1, "registerCleanupTask called once");
+	t.is(registerCleanupTaskStub.callCount, 1, "registerCleanupTask called once");
 	t.deepEqual(registerCleanupTaskStub.getCall(0).args[0], cleanupStub,
 		"registerCleanupTask called with correct argument");
 
-	t.deepEqual(writeResourcesToDirStub.callCount, 1, "writeResourcesToDir got called once");
+	t.is(writeResourcesToDirStub.callCount, 1, "writeResourcesToDir got called once");
 	t.deepEqual(writeResourcesToDirStub.getCall(0).args[0], {
 		workspace,
 		pattern: "some pattern",
 		targetPath: path.join("/", "some", "source", "path") // one's target is another one's source
 	}, "writeResourcesToDir got called with correct arguments");
 
-	t.deepEqual(writeDependencyApisToDirStub.callCount, 1, "writeDependencyApisToDir got called once");
+	t.is(writeDependencyApisToDirStub.callCount, 1, "writeDependencyApisToDir got called once");
 	t.deepEqual(writeDependencyApisToDirStub.getCall(0).args[0], {
 		dependencies: "dependencies",
 		targetPath: path.join("/", "some", "tmp", "path", "dependency-apis")
 	}, "writeDependencyApisToDir got called with correct arguments");
 
-	t.deepEqual(jsdocGeneratorStub.callCount, 1, "jsdocGenerator processor got called once");
+	t.is(jsdocGeneratorStub.callCount, 1, "jsdocGenerator processor got called once");
 	t.deepEqual(jsdocGeneratorStub.getCall(0).args[0], {
 		sourcePath: path.join("/", "some", "source", "path"),
 		targetPath: path.join("/", "some", "target", "path"),
@@ -273,9 +273,9 @@ test.serial("generateJsdoc", async (t) => {
 		}
 	}, "jsdocGenerator got called with correct arguments");
 
-	t.deepEqual(writeStub.callCount, 2, "Write got called twice");
-	t.deepEqual(writeStub.getCall(0).args[0], "resource A", "Write got called with correct arguments");
-	t.deepEqual(writeStub.getCall(1).args[0], "resource B", "Write got called with correct arguments");
+	t.is(writeStub.callCount, 2, "Write got called twice");
+	t.is(writeStub.getCall(0).args[0], "resource A", "Write got called with correct arguments");
+	t.is(writeStub.getCall(1).args[0], "resource B", "Write got called with correct arguments");
 
 	mock.stop("../../../../lib/processors/jsdoc/jsdocGenerator");
 });
@@ -321,16 +321,16 @@ test.serial("generateJsdoc with missing resources", async (t) => {
 		}
 	});
 
-	t.deepEqual(registerCleanupTaskStub.callCount, 1, "registerCleanupTask called once");
+	t.is(registerCleanupTaskStub.callCount, 1, "registerCleanupTask called once");
 	t.deepEqual(registerCleanupTaskStub.getCall(0).args[0], cleanupStub,
 		"registerCleanupTask called with correct argument");
 
-	t.deepEqual(infoLogStub.callCount, 1, "One message has been logged");
+	t.is(infoLogStub.callCount, 1, "One message has been logged");
 	t.deepEqual(infoLogStub.getCall(0).args[0], "Failed to find any input resources for project some.project " +
 		"using pattern some pattern. Skipping JSDoc generation...",
 	"Correct message has been logged");
 
-	t.deepEqual(jsdocGeneratorStub.callCount, 0, "jsdocGenerator processor has *not* been called");
+	t.is(jsdocGeneratorStub.callCount, 0, "jsdocGenerator processor has *not* been called");
 
 	mock.stop("../../../../lib/processors/jsdoc/jsdocGenerator");
 });
@@ -343,6 +343,6 @@ test.serial("generateJsdoc no parameters", async (t) => {
 
 test.serial("generateJsdoc missing parameters", async (t) => {
 	const error = await t.throwsAsync(generateJsdoc({}));
-	t.deepEqual(error.message, "[generateJsdoc]: One or more mandatory options not provided",
+	t.is(error.message, "[generateJsdoc]: One or more mandatory options not provided",
 		"Correct error message thrown");
 });

--- a/test/lib/tasks/replaceBuildtime.js
+++ b/test/lib/tasks/replaceBuildtime.js
@@ -5,7 +5,7 @@ const ui5Fs = require("@ui5/fs");
 const resourceFactory = ui5Fs.resourceFactory;
 const DuplexCollection = ui5Fs.DuplexCollection;
 
-test("integration: replace version", (t) => {
+test("integration: replace version", async (t) => {
 	const reader = resourceFactory.createAdapter({
 		virBasePath: "/"
 	});
@@ -23,27 +23,24 @@ test("integration: replace version", (t) => {
 	});
 
 	const workspace = new DuplexCollection({reader, writer});
-	return reader.write(resource).then(() => {
-		return replaceBuildtime({
-			workspace,
-			options: {
-				pattern: "/test.js"
-			}
-		}).then(() => {
-			return writer.byPath("/test.js").then((resource) => {
-				if (!resource) {
-					t.fail("Could not find /test.js in target");
-				} else {
-					return resource.getBuffer();
-				}
-			});
-		}).then((buffer) => {
-			const actualContent = buffer.toString();
-			t.not(actualContent, content, "placeholder is overridden");
-
-			const values = actualContent.split(": ");
-			t.is(values[0], expectedPrefix, "prefix is unmodified");
-			t.true(expectedDatePattern.test(values[1]), "date matches the given pattern");
-		});
+	await reader.write(resource);
+	await replaceBuildtime({
+		workspace,
+		options: {
+			pattern: "/test.js"
+		}
 	});
+	const transformedResource = await writer.byPath("/test.js");
+
+	if (!transformedResource) {
+		t.fail("Could not find /test.js in target");
+	} else {
+		const buffer = await transformedResource.getBuffer();
+		const actualContent = buffer.toString();
+		t.not(actualContent, content, "placeholder is overridden");
+
+		const values = actualContent.split(": ");
+		t.is(values[0], expectedPrefix, "prefix is unmodified");
+		t.regex(values[1], expectedDatePattern, "date matches the given pattern");
+	}
 });

--- a/test/lib/tasks/replaceCopyright.js
+++ b/test/lib/tasks/replaceCopyright.js
@@ -5,7 +5,7 @@ const ui5Fs = require("@ui5/fs");
 const resourceFactory = ui5Fs.resourceFactory;
 const DuplexCollection = ui5Fs.DuplexCollection;
 
-test("integration: replace copyright", (t) => {
+test("integration: replace copyright", async (t) => {
 	const reader = resourceFactory.createAdapter({
 		virBasePath: "/"
 	});
@@ -38,29 +38,27 @@ console.log('HelloWorld');`;
 		string: content
 	});
 
-	return workspace.write(resource).then(() => {
-		return replaceCopyright({
-			workspace,
-			options: {
-				copyright: copyright,
-				pattern: "/**/*.js"
-			}
-		}).then(() => {
-			return writer.byPath("/test.js").then((resource) => {
-				if (!resource) {
-					t.fail("Could not find /test.js in target");
-				} else {
-					return resource.getString();
-				}
-			});
-		}).then((result) => {
-			return t.deepEqual(result, expected);
-		});
+	await workspace.write(resource);
+
+	await replaceCopyright({
+		workspace,
+		options: {
+			copyright: copyright,
+			pattern: "/**/*.js"
+		}
 	});
+
+	const transformedResource = await writer.byPath("/test.js");
+
+	if (!transformedResource) {
+		t.fail("Could not find /test.js in target");
+	} else {
+		t.deepEqual(await transformedResource.getString(), expected);
+	}
 });
 
 
-test("test.xml: replace @copyright@", (t) => {
+test("test.xml: replace @copyright@", async (t) => {
 	const reader = resourceFactory.createAdapter({
 		virBasePath: "/"
 	});
@@ -90,23 +88,19 @@ test("test.xml: replace @copyright@", (t) => {
 		string: content
 	});
 
-	return reader.write(resource).then(() => {
-		return replaceCopyright({
-			workspace,
-			options: {
-				pattern: "/**/*.xml",
-				copyright: copyright
-			}
-		}).then(() => {
-			return writer.byPath("/test.xml").then((resource) => {
-				if (!resource) {
-					t.fail("Could not find /test.xml in target");
-				} else {
-					return resource.getString();
-				}
-			});
-		}).then((result) => {
-			return t.deepEqual(result, expected);
-		});
+	await reader.write(resource);
+	await replaceCopyright({
+		workspace,
+		options: {
+			pattern: "/**/*.xml",
+			copyright: copyright
+		}
 	});
+	const transformedResource = await writer.byPath("/test.xml");
+
+	if (!transformedResource) {
+		t.fail("Could not find /test.xml in target");
+	} else {
+		t.deepEqual(await transformedResource.getString(), expected);
+	}
 });

--- a/test/lib/tasks/taskRepository.js
+++ b/test/lib/tasks/taskRepository.js
@@ -41,7 +41,7 @@ test("Unknown task retrieval", (t) => {
 	const error = t.throws(() => {
 		taskRepository.getTask("not-existing");
 	});
-	t.deepEqual(error.message, "taskRepository: Unknown Task not-existing", "Correct exception");
+	t.is(error.message, "taskRepository: Unknown Task not-existing", "Correct exception");
 });
 
 test("Removed task retrieval", (t) => {

--- a/test/lib/tasks/transformBootstrapHtml.js
+++ b/test/lib/tasks/transformBootstrapHtml.js
@@ -35,7 +35,7 @@ test.serial("Transforms index.html resource", async (t) => {
 
 	const workspace = {
 		byPath: (actualPath) => {
-			t.deepEqual(actualPath, "/resources/sap/ui/demo/app/index.html",
+			t.is(actualPath, "/resources/sap/ui/demo/app/index.html",
 				"Reads index.html file from application namespace.");
 			return Promise.resolve(resource);
 		},
@@ -55,7 +55,7 @@ test.serial("Transforms index.html resource", async (t) => {
 		}
 	});
 
-	t.deepEqual(t.context.bootstrapHtmlTransformerStub.callCount, 1,
+	t.is(t.context.bootstrapHtmlTransformerStub.callCount, 1,
 		"Processor should be called once");
 
 	t.true(t.context.bootstrapHtmlTransformerStub.calledWithExactly({
@@ -75,7 +75,7 @@ test.serial("Transforms index.html resource without namespace", async (t) => {
 
 	const workspace = {
 		byPath: (actualPath) => {
-			t.deepEqual(actualPath, "/index.html",
+			t.is(actualPath, "/index.html",
 				"Reads index.html file from application namespace.");
 			return Promise.resolve(resource);
 		},
@@ -94,7 +94,7 @@ test.serial("Transforms index.html resource without namespace", async (t) => {
 		}
 	});
 
-	t.deepEqual(t.context.bootstrapHtmlTransformerStub.callCount, 1,
+	t.is(t.context.bootstrapHtmlTransformerStub.callCount, 1,
 		"Processor should be called once");
 
 	t.true(t.context.bootstrapHtmlTransformerStub.calledWithExactly({
@@ -112,7 +112,7 @@ test.serial("No index.html resource exists", async (t) => {
 
 	const workspace = {
 		byPath: (actualPath) => {
-			t.deepEqual(actualPath, "/resources/sap/ui/demo/app/index.html",
+			t.is(actualPath, "/resources/sap/ui/demo/app/index.html",
 				"Reads index.html file from application namespace.");
 			return Promise.resolve(null);
 		},
@@ -132,7 +132,7 @@ test.serial("No index.html resource exists", async (t) => {
 	t.true(t.context.bootstrapHtmlTransformerStub.notCalled,
 		"Processor should not be called");
 
-	t.deepEqual(t.context.logWarnSpy.callCount, 1, "One warning should be logged");
+	t.is(t.context.logWarnSpy.callCount, 1, "One warning should be logged");
 	t.true(
 		t.context.logWarnSpy.calledWith(
 			`Skipping bootstrap transformation due to missing index.html in project "sap.ui.demo.app".`),


### PR DESCRIPTION
Introducing [eslint-plugin-ava](https://github.com/avajs/eslint-plugin-ava/) to avoid common pitfalls when writing powerful ava tests.

- Add plugin to eslint config and package.json
- Restructure current code base to latest recommendations