### PR TITLE
Revert es5-ext downgrade by bumping escope to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
 				"@ui5/fs": "^3.0.0-alpha.6",
 				"@ui5/logger": "^3.0.1-alpha.2",
 				"cheerio": "1.0.0-rc.9",
-				"es5-ext": "<=0.10.53",
-				"es6-set": "<=0.1.5",
 				"escape-unicode": "^0.2.0",
 				"escope": "^3.6.0",
 				"espree": "^9.3.1",
@@ -3053,13 +3051,17 @@
 			}
 		},
 		"node_modules/es5-ext": {
-			"version": "0.10.53",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-			"integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+			"version": "0.10.61",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+			"integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+			"hasInstallScript": true,
 			"dependencies": {
-				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.3",
-				"next-tick": "~1.0.0"
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/es6-error": {
@@ -5849,9 +5851,9 @@
 			"dev": true
 		},
 		"node_modules/next-tick": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
 		},
 		"node_modules/nise": {
 			"version": "5.1.1",
@@ -11629,13 +11631,13 @@
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.53",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-			"integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+			"version": "0.10.61",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+			"integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
 			"requires": {
-				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.3",
-				"next-tick": "~1.0.0"
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"next-tick": "^1.1.0"
 			}
 		},
 		"es6-error": {
@@ -13812,9 +13814,9 @@
 			"dev": true
 		},
 		"next-tick": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
 		},
 		"nise": {
 			"version": "5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@ui5/logger": "^3.0.1-alpha.2",
 				"cheerio": "1.0.0-rc.9",
 				"escape-unicode": "^0.2.0",
-				"escope": "^3.6.0",
+				"escope": "^4.0.0",
 				"espree": "^9.3.1",
 				"graceful-fs": "^4.2.9",
 				"jsdoc": "^3.6.7",
@@ -915,6 +915,21 @@
 			"engines": {
 				"node": ">= 16.13.2",
 				"npm": ">= 8"
+			}
+		},
+		"node_modules/@ui5/builder/node_modules/escope": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+			"integrity": "sha512-75IUQsusDdalQEW/G/2esa87J7raqdJF+Ca0/Xm5C3Q58Nr4yVYjZGp/P1+2xiEVgXRrA39dpRb8LcshajbqDQ==",
+			"dev": true,
+			"dependencies": {
+				"es6-map": "^0.1.3",
+				"es6-weak-map": "^2.0.1",
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/@ui5/fs": {
@@ -2525,6 +2540,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
 			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+			"dev": true,
 			"dependencies": {
 				"es5-ext": "^0.10.50",
 				"type": "^1.0.1"
@@ -3051,9 +3067,10 @@
 			}
 		},
 		"node_modules/es5-ext": {
-			"version": "0.10.61",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-			"integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+			"version": "0.10.62",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+			"integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
 				"es6-iterator": "^2.0.3",
@@ -3074,6 +3091,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
 			"integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+			"dev": true,
 			"dependencies": {
 				"d": "1",
 				"es5-ext": "^0.10.35",
@@ -3084,6 +3102,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha512-mz3UqCh0uPCIqsw1SSAkB/p0rOzF/M0V++vyN7JqlPtSW/VsYgQBvVvqMLmfBuyMzTpLnNqi6JmcSizs4jy19A==",
+			"dev": true,
 			"dependencies": {
 				"d": "1",
 				"es5-ext": "~0.10.14",
@@ -3109,30 +3128,33 @@
 			}
 		},
 		"node_modules/es6-set": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-			"integrity": "sha512-7S8YXIcUfPMOr3rqJBVMePAbRsD1nWeSMQ86K/lDI76S3WKXz+KWILvTIPbTroubOkZTGh+b+7/xIIphZXNYbA==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.6.tgz",
+			"integrity": "sha512-TE3LgGLDIBX332jq3ypv6bcOpkLO0AslAQo7p2VqX/1N46YNsvIWgvjojjSEnWEGWMhr1qUbYeTSir5J6mFHOw==",
+			"dev": true,
 			"dependencies": {
-				"d": "1",
-				"es5-ext": "~0.10.14",
-				"es6-iterator": "~2.0.1",
-				"es6-symbol": "3.1.1",
-				"event-emitter": "~0.3.5"
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.62",
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "^3.1.3",
+				"event-emitter": "^0.3.5",
+				"type": "^2.7.2"
+			},
+			"engines": {
+				"node": ">=0.12"
 			}
 		},
-		"node_modules/es6-set/node_modules/es6-symbol": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-			"integrity": "sha512-exfuQY8UGtn/N+gL1iKkH8fpNd5sJ760nJq6mmZAHldfxMD5kX07lbQuYlspoXsuknXNv9Fb7y2GsPOnQIbxHg==",
-			"dependencies": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
-			}
+		"node_modules/es6-set/node_modules/type": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+			"integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+			"dev": true
 		},
 		"node_modules/es6-symbol": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
 			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+			"dev": true,
 			"dependencies": {
 				"d": "^1.0.1",
 				"ext": "^1.1.2"
@@ -3142,6 +3164,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
 			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+			"dev": true,
 			"dependencies": {
 				"d": "1",
 				"es5-ext": "^0.10.46",
@@ -3187,17 +3210,15 @@
 			}
 		},
 		"node_modules/escope": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-			"integrity": "sha512-75IUQsusDdalQEW/G/2esa87J7raqdJF+Ca0/Xm5C3Q58Nr4yVYjZGp/P1+2xiEVgXRrA39dpRb8LcshajbqDQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escope/-/escope-4.0.0.tgz",
+			"integrity": "sha512-E36qlD/r6RJHVpPKArgMoMlNJzoRJFH8z/cAZlI9lbc45zB3+S7i9k6e/MNb+7bZQzNEa6r8WKN3BovpeIBwgA==",
 			"dependencies": {
-				"es6-map": "^0.1.3",
-				"es6-weak-map": "^2.0.1",
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
 			},
 			"engines": {
-				"node": ">=0.4.0"
+				"node": ">=4.0"
 			}
 		},
 		"node_modules/eslint": {
@@ -3594,6 +3615,7 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+			"dev": true,
 			"dependencies": {
 				"d": "1",
 				"es5-ext": "~0.10.14"
@@ -3606,17 +3628,19 @@
 			"dev": true
 		},
 		"node_modules/ext": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-			"integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+			"integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+			"dev": true,
 			"dependencies": {
-				"type": "^2.5.0"
+				"type": "^2.7.2"
 			}
 		},
 		"node_modules/ext/node_modules/type": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-			"integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+			"integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+			"dev": true
 		},
 		"node_modules/extended-emitter": {
 			"version": "1.1.0",
@@ -5853,7 +5877,8 @@
 		"node_modules/next-tick": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+			"dev": true
 		},
 		"node_modules/nise": {
 			"version": "5.1.1",
@@ -8740,7 +8765,8 @@
 		"node_modules/type": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+			"dev": true
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -9938,6 +9964,20 @@
 				"terser": "^5.14.2",
 				"xml2js": "^0.4.23",
 				"yazl": "^2.5.1"
+			},
+			"dependencies": {
+				"escope": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+					"integrity": "sha512-75IUQsusDdalQEW/G/2esa87J7raqdJF+Ca0/Xm5C3Q58Nr4yVYjZGp/P1+2xiEVgXRrA39dpRb8LcshajbqDQ==",
+					"dev": true,
+					"requires": {
+						"es6-map": "^0.1.3",
+						"es6-weak-map": "^2.0.1",
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				}
 			}
 		},
 		"@ui5/fs": {
@@ -11191,6 +11231,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
 			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+			"dev": true,
 			"requires": {
 				"es5-ext": "^0.10.50",
 				"type": "^1.0.1"
@@ -11631,9 +11672,10 @@
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.61",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-			"integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+			"version": "0.10.62",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+			"integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+			"dev": true,
 			"requires": {
 				"es6-iterator": "^2.0.3",
 				"es6-symbol": "^3.1.3",
@@ -11650,6 +11692,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
 			"integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "^0.10.35",
@@ -11660,6 +11703,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha512-mz3UqCh0uPCIqsw1SSAkB/p0rOzF/M0V++vyN7JqlPtSW/VsYgQBvVvqMLmfBuyMzTpLnNqi6JmcSizs4jy19A==",
+			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "~0.10.14",
@@ -11685,25 +11729,24 @@
 			}
 		},
 		"es6-set": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-			"integrity": "sha512-7S8YXIcUfPMOr3rqJBVMePAbRsD1nWeSMQ86K/lDI76S3WKXz+KWILvTIPbTroubOkZTGh+b+7/xIIphZXNYbA==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.6.tgz",
+			"integrity": "sha512-TE3LgGLDIBX332jq3ypv6bcOpkLO0AslAQo7p2VqX/1N46YNsvIWgvjojjSEnWEGWMhr1qUbYeTSir5J6mFHOw==",
+			"dev": true,
 			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14",
-				"es6-iterator": "~2.0.1",
-				"es6-symbol": "3.1.1",
-				"event-emitter": "~0.3.5"
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.62",
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "^3.1.3",
+				"event-emitter": "^0.3.5",
+				"type": "^2.7.2"
 			},
 			"dependencies": {
-				"es6-symbol": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-					"integrity": "sha512-exfuQY8UGtn/N+gL1iKkH8fpNd5sJ760nJq6mmZAHldfxMD5kX07lbQuYlspoXsuknXNv9Fb7y2GsPOnQIbxHg==",
-					"requires": {
-						"d": "1",
-						"es5-ext": "~0.10.14"
-					}
+				"type": {
+					"version": "2.7.2",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+					"integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+					"dev": true
 				}
 			}
 		},
@@ -11711,6 +11754,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
 			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+			"dev": true,
 			"requires": {
 				"d": "^1.0.1",
 				"ext": "^1.1.2"
@@ -11720,6 +11764,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
 			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "^0.10.46",
@@ -11750,12 +11795,10 @@
 			"integrity": "sha512-7jMQuKb8nm0h/9HYLfu4NCLFwoUsd5XO6OZ1z86PbKcMf8zDK1m7nFR0iA2CCShq4TSValaLIveE8T1UBxgALQ=="
 		},
 		"escope": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-			"integrity": "sha512-75IUQsusDdalQEW/G/2esa87J7raqdJF+Ca0/Xm5C3Q58Nr4yVYjZGp/P1+2xiEVgXRrA39dpRb8LcshajbqDQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escope/-/escope-4.0.0.tgz",
+			"integrity": "sha512-E36qlD/r6RJHVpPKArgMoMlNJzoRJFH8z/cAZlI9lbc45zB3+S7i9k6e/MNb+7bZQzNEa6r8WKN3BovpeIBwgA==",
 			"requires": {
-				"es6-map": "^0.1.3",
-				"es6-weak-map": "^2.0.1",
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
 			}
@@ -12043,6 +12086,7 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "~0.10.14"
@@ -12055,17 +12099,19 @@
 			"dev": true
 		},
 		"ext": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-			"integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+			"integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+			"dev": true,
 			"requires": {
-				"type": "^2.5.0"
+				"type": "^2.7.2"
 			},
 			"dependencies": {
 				"type": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-					"integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+					"version": "2.7.2",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+					"integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+					"dev": true
 				}
 			}
 		},
@@ -13816,7 +13862,8 @@
 		"next-tick": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+			"dev": true
 		},
 		"nise": {
 			"version": "5.1.1",
@@ -16085,7 +16132,8 @@
 		"type": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"version": "git-chglog --sort semver --next-tag v$npm_package_version -o CHANGELOG.md && git add CHANGELOG.md",
 		"postversion": "git push --follow-tags",
 		"release-note": "git-chglog --sort semver -c .chglog/release-config.yml v$npm_package_version",
-		"depcheck": "depcheck --ignores docdash,es5-ext,es6-set --ignore-patterns lib/processors/jsdoc/lib/ui5"
+		"depcheck": "depcheck --ignores docdash --ignore-patterns lib/processors/jsdoc/lib/ui5"
 	},
 	"files": [
 		"index.js",
@@ -109,8 +109,6 @@
 		"@ui5/fs": "^3.0.0-alpha.6",
 		"@ui5/logger": "^3.0.1-alpha.2",
 		"cheerio": "1.0.0-rc.9",
-		"es5-ext": "<=0.10.53",
-		"es6-set": "<=0.1.5",
 		"escape-unicode": "^0.2.0",
 		"escope": "^3.6.0",
 		"espree": "^9.3.1",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 		"@ui5/logger": "^3.0.1-alpha.2",
 		"cheerio": "1.0.0-rc.9",
 		"escape-unicode": "^0.2.0",
-		"escope": "^3.6.0",
+		"escope": "^4.0.0",
 		"espree": "^9.3.1",
 		"graceful-fs": "^4.2.9",
 		"jsdoc": "^3.6.7",


### PR DESCRIPTION
https://github.com/SAP/ui5-builder/pull/800 for the next branch.

Due to the dev-dependency to ui5-project, the escope@3.6.0 is still present in the package-lock.json, but as a **dev** dependency only. This will be resolved after the next release of ui5-project#next