### PR TITLE
[INTERNAL] Fix tests for invalid JSON and themeBuilder

### DIFF
--- a/test/lib/lbt/bundle/Builder.js
+++ b/test/lib/lbt/bundle/Builder.js
@@ -51,8 +51,8 @@ test.serial("writePreloadModule: with invalid json content", async (t) => {
 	t.is(verboseLogStub.firstCall.args[0], "Failed to parse JSON file %s. Ignoring error, skipping compression.",
 		"first verbose log argument 0 is correct");
 	t.is(verboseLogStub.firstCall.args[1], "invalid.json", "first verbose log argument 1 is correct");
-	t.deepEqual(verboseLogStub.secondCall.args[0], new SyntaxError("Unexpected token { in JSON at position 19"),
-		"second verbose log");
+	t.true(verboseLogStub.secondCall.args[0] instanceof SyntaxError, "second verbose log with SyntaxError");
+	t.regex(verboseLogStub.secondCall.args[0].message, /JSON/, "second verbose log about incorrect JSON");
 
 	t.true(result, "result is true");
 	t.is(writeStub.callCount, 1, "Writer is called once");

--- a/test/lib/processors/themeBuilder.js
+++ b/test/lib/processors/themeBuilder.js
@@ -5,7 +5,7 @@ import fsInterface from "@ui5/fs/fsInterface";
 import themeBuilderProcessor from "../../../lib/processors/themeBuilder.js";
 import {ThemeBuilder} from "../../../lib/processors/themeBuilder.js";
 
-function prepareResources({library} = {}) {
+async function prepareResources({library} = {}) {
 	const input =
 `@someColor: black;
 .someClass {
@@ -29,7 +29,7 @@ function prepareResources({library} = {}) {
 		string: input
 	});
 
-	memoryAdapter.write(resource);
+	await memoryAdapter.write(resource);
 
 	return {
 		resource,
@@ -116,7 +116,7 @@ function getExpectedResults({compress, library, cssVariables}) {
 }
 
 test("Processor: Builds a less file (default options)", async (t) => {
-	const {resource, memoryAdapter} = prepareResources();
+	const {resource, memoryAdapter} = await prepareResources();
 
 	const [cssResource, cssRtlResource, jsonResource] = await themeBuilderProcessor({
 		resources: [resource],
@@ -136,7 +136,7 @@ test("Processor: Builds a less file (default options)", async (t) => {
 });
 
 test("Processor: Builds a less file (compress = true)", async (t) => {
-	const {resource, memoryAdapter} = prepareResources();
+	const {resource, memoryAdapter} = await prepareResources();
 
 	const [cssResource, cssRtlResource, jsonResource] = await themeBuilderProcessor({
 		resources: [resource],
@@ -153,7 +153,7 @@ test("Processor: Builds a less file (compress = true)", async (t) => {
 });
 
 test("Processor: Builds a less file (compress = false)", async (t) => {
-	const {resource, memoryAdapter} = prepareResources();
+	const {resource, memoryAdapter} = await prepareResources();
 
 	const [cssResource, cssRtlResource, jsonResource] = await themeBuilderProcessor({
 		resources: [resource],
@@ -170,7 +170,7 @@ test("Processor: Builds a less file (compress = false)", async (t) => {
 });
 
 test("Processor: Builds a less file (no library)", async (t) => {
-	const {resource, memoryAdapter} = prepareResources({library: false});
+	const {resource, memoryAdapter} = await prepareResources({library: false});
 
 	const [cssResource, cssRtlResource, jsonResource] = await themeBuilderProcessor({
 		resources: [resource],
@@ -187,7 +187,7 @@ test("Processor: Builds a less file (no library)", async (t) => {
 });
 
 test("ThemeBuilder: Builds a less file", async (t) => {
-	const {resource, memoryAdapter} = prepareResources();
+	const {resource, memoryAdapter} = await prepareResources();
 
 	const themeBuilder = new ThemeBuilder({fs: fsInterface(memoryAdapter)});
 
@@ -200,7 +200,7 @@ test("ThemeBuilder: Builds a less file", async (t) => {
 });
 
 test("ThemeBuilder: Builds a less file (compress = true)", async (t) => {
-	const {resource, memoryAdapter} = prepareResources();
+	const {resource, memoryAdapter} = await prepareResources();
 
 	const themeBuilder = new ThemeBuilder({fs: fsInterface(memoryAdapter)});
 
@@ -215,7 +215,7 @@ test("ThemeBuilder: Builds a less file (compress = true)", async (t) => {
 });
 
 test("ThemeBuilder: Builds a less file (compress = false)", async (t) => {
-	const {resource, memoryAdapter} = prepareResources();
+	const {resource, memoryAdapter} = await prepareResources();
 
 	const themeBuilder = new ThemeBuilder({fs: fsInterface(memoryAdapter)});
 
@@ -230,7 +230,7 @@ test("ThemeBuilder: Builds a less file (compress = false)", async (t) => {
 });
 
 test("ThemeBuilder: Builds a less file (no library)", async (t) => {
-	const {resource, memoryAdapter} = prepareResources({library: false});
+	const {resource, memoryAdapter} = await prepareResources({library: false});
 
 	const themeBuilder = new ThemeBuilder({fs: fsInterface(memoryAdapter)});
 
@@ -245,7 +245,7 @@ test("ThemeBuilder: Builds a less file (no library)", async (t) => {
 });
 
 test("Processor: Builds a less file (cssVariables = true)", async (t) => {
-	const {resource, memoryAdapter} = prepareResources();
+	const {resource, memoryAdapter} = await prepareResources();
 
 	const [
 		cssResource,


### PR DESCRIPTION
Node 19 has a new error message for invalid JSON. Instead of
"Unexpected token o in JSON at position 1" it now reads
"Unexpected token 'o', "no json" is not valid JSON"

Theme builder failed due to missing `await` which now showed up due to https://github.com/SAP/ui5-fs/pull/407