### PR TITLE
[FIX] transformApiJson: Fix regression in UI5 Tooling scenario

### DIFF
--- a/lib/processors/jsdoc/lib/transformApiJson.js
+++ b/lib/processors/jsdoc/lib/transformApiJson.js
@@ -989,11 +989,12 @@ function transformer(sInputFile, sOutputFile, sLibraryFile, vDependencyAPIFiles,
 			const {sources} = options;
 			let {librarySrcDir, libraryTestDir} = options;
 
-			// Using path.join to normalize POSIX paths to Windows paths on Windows
-			librarySrcDir = path.join(librarySrcDir);
-			libraryTestDir = path.join(libraryTestDir);
-
 			if (Array.isArray(sources) && typeof librarySrcDir === "string" && typeof libraryTestDir === "string") {
+
+				// Using path.join to normalize POSIX paths to Windows paths on Windows
+				librarySrcDir = path.join(librarySrcDir);
+				libraryTestDir = path.join(libraryTestDir);
+
 				/**
 				 * Calculate prefix to check
 				 *


### PR DESCRIPTION
Caused by https://github.com/SAP/ui5-builder/pull/793/commits/d48d2ba171f4da0bbed26473e3e7b94fde59bca9

(cherry picked from https://github.com/SAP/openui5/commit/d3bcca92ff86fb3c5d4b2610ada50f7d85af2a51)
(cherry picked from commit 7d0ac119078d4e04afb646df3b9ee16dfff511b2)
