### PR TITLE
[INTERNAL] lib/jsdoc: do not write 'module' info for borrowed APIs

### DIFF
--- a/lib/processors/jsdoc/lib/ui5/plugin.cjs
+++ b/lib/processors/jsdoc/lib/ui5/plugin.cjs
@@ -507,9 +507,10 @@ function stripChainWrappers(rootNode, path) {
 
 function isTemplateLiteralWithoutExpression(node) {
 	return (
-		node?.type === Syntax.TemplateLiteral &&
-		node?.expressions?.length === 0 &&
-		node?.quasis?.length === 1
+		node &&
+		node.type === Syntax.TemplateLiteral &&
+		node.expressions && node.expressions.length === 0 &&
+		node.quasis && node.quasis.length === 1
 	);
 }
 
@@ -801,9 +802,11 @@ function convertValueWithRaw(node, type, propertyName) {
 		}
 
 	} else if ( isTemplateLiteralWithoutExpression(node) ) {
+		let value = node.quasis[0].value || {};
+
 		return {
-			value: node?.quasis?.[0]?.value?.cooked,
-			raw: node?.quasis?.[0]?.value?.raw,
+			value: value.cooked,
+			raw: value.raw,
 		};
 	}
 
@@ -2495,6 +2498,7 @@ exports.handlers = {
 			e.doclet.meta.__shortpath = getRelativePath(filepath);
 			_ui5data.resource = currentModule.resource;
 			_ui5data.module = currentModule.name || currentModule.module;
+			_ui5data.initialLongname = e.doclet.longname;
 
 			const localDecl = findLocalDeclaration(e.doclet.meta.lineno, e.doclet.meta.columnno);
 			if ( localDecl ) {

--- a/lib/processors/jsdoc/lib/ui5/template/publish.cjs
+++ b/lib/processors/jsdoc/lib/ui5/template/publish.cjs
@@ -2877,7 +2877,11 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 		}
 		tag("method");
 		attrib("name", name || member.name);
-		if ( member.__ui5.module && member.__ui5.module !== symbol.__ui5.module ) {
+		// write out module and export only when the module is different from the module of the parent entity
+		// and when the member was not cloned (e.g. because it is borrowed)
+		if ( member.__ui5.module
+			 && member.__ui5.module !== symbol.__ui5.module
+			 && member.__ui5.initialLongname === member.longname ) {
 			attrib("module", member.__ui5.module);
 			attrib("export", member.__ui5.globalOnly ? GLOBAL_ONLY : member.__ui5.export, '', true);
 		}


### PR DESCRIPTION
When an API is borrowed by another entity, JSDoc creates a deep clone of the original symbol and makes it a member of the borrowing entity.

As the origin info ('module', 'resource' and 'export') is also cloned but usually doesn't match the origin info of the borrowing entity, the template so far decided to write out 'module' and 'export' properties for all borrowed APIs.

This change tries to detect such clones (by remembering the symbol's longname when the origin info is attached) and filters them out when writing the origin info for a member.

As origin info for members currently is not evaluated anywhere, this change should have no side effects. But it helps to clean-up the schema for api.json files as an origin info for members has to be allowed only in very special cases, not for all members.

Cherry picked from SAP/openui5@9d3fccd91.