### PR TITLE
[INTERNAL] taskRepository: Enhance API for better ui5-project integration

### DIFF
--- a/lib/tasks/taskRepository.js
+++ b/lib/tasks/taskRepository.js
@@ -100,22 +100,21 @@ export function getRemovedTaskNames() {
 
 // Using CommonsJS require as importing json files causes an ExperimentalWarning
 const require = createRequire(import.meta.url);
-async function getVersion(pkg) {
+function getVersion(pkg) {
 	return require(`${pkg}/package.json`).version;
 }
 
 /**
- * Object containing the versions of the current module and relevant dependencies
+ * Object containing the versions of the ui5-builder module and relevant dependencies
  *
  * @private
  * @typedef {object} @ui5/builder/tasks/taskRepository~Versions
- * @property {Function} builderVersion Version of the ui5-builder module
- * @property {Function} fsVersion Version of the ui5-fs module in use
+ * @property {string} builderVersion Version of the ui5-builder module
+ * @property {string} fsVersion Version of the ui5-fs module in use
  */
 
 /**
- * Returns a list of the names of all tasks that have been removed
- * in this or previous versions of ui5-builder.
+ * Provides version information on all relevant modules, used by ui5-builder
  *
  * @private
  * @static
@@ -123,7 +122,7 @@ async function getVersion(pkg) {
  */
 export async function getVersions() {
 	return {
-		builderVersion: await getVersion("@ui5/builder"),
-		fsVersion: await getVersion("@ui5/fs"),
+		builderVersion: getVersion("@ui5/builder"),
+		fsVersion: getVersion("@ui5/fs"),
 	};
 }

--- a/lib/tasks/taskRepository.js
+++ b/lib/tasks/taskRepository.js
@@ -1,3 +1,18 @@
+import {createRequire} from "node:module";
+
+/**
+ * Repository providing access to all UI5 Builder tasks and various metadata required by the build process.
+ * This module is designed to be imported by @ui5/project or to be passed as a private parameter
+ * to the <code>build</code> function of a [@ui5/project/graph/ProjectGraph]{@link @ui5/project/graph/ProjectGraph}.
+ *
+ * For other use cases, it is recommended to import the required tasks directly.
+ *
+ * Therefore, all API of this module is private.
+ *
+ * @private
+ * @module @ui5/builder/tasks/taskRepository
+ */
+
 const taskInfos = {
 	replaceCopyright: {path: "./replaceCopyright.js"},
 	replaceVersion: {path: "./replaceVersion.js"},
@@ -21,11 +36,29 @@ const taskInfos = {
 	generateCachebusterInfo: {path: "./generateCachebusterInfo.js"}
 };
 
+
+/**
+ * TaskInfo object returned by the getTask function
+ *
+ * @private
+ * @typedef {object} @ui5/builder/tasks/taskRepository~TaskInfo
+ * @property {Function} task Task function
+ */
+
+/**
+ * Returns the module for a given task name
+ *
+ * @private
+ * @static
+ * @param {string} taskName Name of the task to retrieve
+ * @throws {Error} In case the specified task does not exist
+ * @returns {Promise<@ui5/builder/tasks/taskRepository~TaskInfo>} Object containing the task module
+ */
 export async function getTask(taskName) {
 	const taskInfo = taskInfos[taskName];
 
 	if (!taskInfo) {
-		if (["createDebugFiles", "uglify", "generateManifestBundle"].includes(taskName)) {
+		if (getRemovedTaskNames().includes(taskName)) {
 			throw new Error(
 				`Standard task ${taskName} has been removed in UI5 Tooling 3.0. ` +
 				`Please see the migration guide at https://sap.github.io/ui5-tooling/updates/migrate-v3/`);
@@ -42,6 +75,55 @@ export async function getTask(taskName) {
 	}
 }
 
+/**
+ * Returns a list of the names of all available tasks
+ *
+ * @private
+ * @static
+ * @returns {string[]} Array containing the names of all available tasks
+ */
 export function getAllTaskNames() {
 	return Object.keys(taskInfos);
+}
+
+/**
+ * Returns a list of the names of all tasks that have been removed
+ * in this or previous versions of ui5-builder.
+ *
+ * @private
+ * @static
+ * @returns {string[]} Array containing the names of all removed tasks
+ */
+export function getRemovedTaskNames() {
+	return ["createDebugFiles", "uglify", "generateManifestBundle"];
+}
+
+// Using CommonsJS require as importing json files causes an ExperimentalWarning
+const require = createRequire(import.meta.url);
+async function getVersion(pkg) {
+	return require(`${pkg}/package.json`).version;
+}
+
+/**
+ * Object containing the versions of the current module and relevant dependencies
+ *
+ * @private
+ * @typedef {object} @ui5/builder/tasks/taskRepository~Versions
+ * @property {Function} builderVersion Version of the ui5-builder module
+ * @property {Function} fsVersion Version of the ui5-fs module in use
+ */
+
+/**
+ * Returns a list of the names of all tasks that have been removed
+ * in this or previous versions of ui5-builder.
+ *
+ * @private
+ * @static
+ * @returns {@ui5/builder/tasks/taskRepository~Versions} Object containing version information
+ */
+export async function getVersions() {
+	return {
+		builderVersion: await getVersion("@ui5/builder"),
+		fsVersion: await getVersion("@ui5/fs"),
+	};
 }

--- a/test/lib/tasks/taskRepository.js
+++ b/test/lib/tasks/taskRepository.js
@@ -1,5 +1,6 @@
 import test from "ava";
-import {getTask, getAllTaskNames} from "../../../lib/tasks/taskRepository.js";
+import semver from "semver";
+import {getTask, getAllTaskNames, getRemovedTaskNames, getVersions} from "../../../lib/tasks/taskRepository.js";
 
 test("Task retrieval", async (t) => {
 	const escapeNonAsciiCharacters = (await import("../../../lib/tasks/escapeNonAsciiCharacters.js")).default;
@@ -60,4 +61,15 @@ test("Removed task retrieval", async (t) => {
 		`Standard task generateManifestBundle has been removed in UI5 Tooling 3.0. ` +
 		`Please see the migration guide at https://sap.github.io/ui5-tooling/updates/migrate-v3/`,
 		"Correct exception");
+});
+
+test("getRemovedTaskNames", (t) => {
+	t.deepEqual(getRemovedTaskNames(), ["createDebugFiles", "uglify", "generateManifestBundle"],
+		"Returned correct list of removed tasks");
+});
+
+test("getVersions", async (t) => {
+	const versions = await getVersions();
+	t.not(semver.valid(versions.builderVersion), null, "builder version should be set and valid");
+	t.not(semver.valid(versions.fsVersion), null, "fs version should be set and valid");
 });


### PR DESCRIPTION
This is to allow ui5-project to use a taskRepository instance as the
only reference to ui5-builder. This especially eases testing, as a
custom instance can be injected in ui5-project ProjectGraph.

* Add a function to get a list of tasks that have been removed in this
  version of ui5-builder
* Add a function to get the effective versions of the @ui5/builder
  module the taskRepository instance belongs to and the used @ui5/fs