### PR TITLE
[BREAKING] JSDoc: Fail build when jsdoc command failed

### DIFF
--- a/lib/processors/jsdoc/jsdocGenerator.js
+++ b/lib/processors/jsdoc/jsdocGenerator.js
@@ -178,7 +178,7 @@ async function buildJsdoc({sourcePath, configPath}) {
 	});
 
 	if (exitCode !== 0) {
-		throw new Error(`JSDoc child process exited with code ${exitCode}`);
+		throw new Error(`JSDoc reported an error, check the log for issues (exit code: ${exitCode})`);
 	}
 }
 

--- a/lib/processors/jsdoc/jsdocGenerator.js
+++ b/lib/processors/jsdoc/jsdocGenerator.js
@@ -170,18 +170,16 @@ async function buildJsdoc({sourcePath, configPath}) {
 		"--verbose",
 		sourcePath
 	];
-	return new Promise((resolve, reject) => {
+	const exitCode = await new Promise((resolve /* , reject */) => {
 		const child = spawn("node", args, {
 			stdio: ["ignore", "ignore", "inherit"]
 		});
-		child.on("close", function(code) {
-			if (code === 0 || code === 1) {
-				resolve();
-			} else {
-				reject(new Error(`JSDoc child process closed with code ${code}`));
-			}
-		});
+		child.on("close", resolve);
 	});
+
+	if (exitCode !== 0) {
+		throw new Error(`JSDoc child process exited with code ${exitCode}`);
+	}
 }
 
 jsdocGenerator._generateJsdocConfig = generateJsdocConfig;

--- a/test/lib/processors/jsdoc/jsdocGenerator.js
+++ b/test/lib/processors/jsdoc/jsdocGenerator.js
@@ -114,10 +114,12 @@ test.serial("buildJsdoc", async (t) => {
 
 	// Re-execute with exit code 1
 	exitCode = 1;
-	await t.notThrowsAsync(jsdocGenerator._buildJsdoc({
+	await t.throwsAsync(jsdocGenerator._buildJsdoc({
 		sourcePath: "/some/path",
 		configPath: "/some/config/path/jsdoc-config.json"
-	}));
+	}), {
+		message: "JSDoc child process exited with code 1"
+	});
 
 	// Re-execute with exit code 2
 	exitCode = 2;
@@ -125,7 +127,7 @@ test.serial("buildJsdoc", async (t) => {
 		sourcePath: "/some/path",
 		configPath: "/some/config/path/jsdoc-config.json"
 	}));
-	t.is(error.message, "JSDoc child process closed with code 2");
+	t.is(error.message, "JSDoc child process exited with code 2");
 });
 
 test.serial("jsdocGenerator", async (t) => {

--- a/test/lib/processors/jsdoc/jsdocGenerator.js
+++ b/test/lib/processors/jsdoc/jsdocGenerator.js
@@ -118,7 +118,7 @@ test.serial("buildJsdoc", async (t) => {
 		sourcePath: "/some/path",
 		configPath: "/some/config/path/jsdoc-config.json"
 	}), {
-		message: "JSDoc child process exited with code 1"
+		message: "JSDoc reported an error, check the log for issues (exit code: 1)"
 	});
 
 	// Re-execute with exit code 2
@@ -127,7 +127,7 @@ test.serial("buildJsdoc", async (t) => {
 		sourcePath: "/some/path",
 		configPath: "/some/config/path/jsdoc-config.json"
 	}));
-	t.is(error.message, "JSDoc child process exited with code 2");
+	t.is(error.message, "JSDoc reported an error, check the log for issues (exit code: 2)");
 });
 
 test.serial("jsdocGenerator", async (t) => {


### PR DESCRIPTION
BREAKING CHANGE:
The `jsdocGenerator` processor and the corresponding `generateJsdoc` task will now throw an error when JSDoc reports an error (exit code != 0). This will also fail the build when running `ui5 build jsdoc`.

JIRA: CPOUI5FOUNDATION-530
