### PR TITLE
[INTERNAL] generateBundle: Replace AbstractReader#filter with resourceFactory#createFilterReader

### DIFF
--- a/lib/tasks/bundlers/generateBundle.js
+++ b/lib/tasks/bundlers/generateBundle.js
@@ -87,8 +87,11 @@ export default async function({
 		// Omit -dbg files for optimize bundles and vice versa
 		const filterTag = optimize ?
 			taskUtil.STANDARD_TAGS.IsDebugVariant : taskUtil.STANDARD_TAGS.HasDebugVariant;
-		combo = await combo.filter(function(resource) {
-			return !taskUtil.getTag(resource, filterTag);
+		combo = taskUtil.resourceFactory.createFilterReader({
+			reader: combo,
+			callback: function(resource) {
+				return !taskUtil.getTag(resource, filterTag);
+			}
 		});
 	}
 


### PR DESCRIPTION
Was missed in https://github.com/SAP/ui5-builder/pull/846