### PR TITLE
[INTERNAL] Adopt consistency check of EnrichedVisitorKeys

### DIFF
--- a/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -19,7 +19,7 @@ const log = logger.getLogger("lbt:analyzer:JSModuleAnalyzer");
 
 // ------------------------------------------------------------------------------------------------------------------
 
-const EnrichedVisitorKeys = (function() {
+export const EnrichedVisitorKeys = (function() {
 	function toBeDone() {
 		return null;
 	}
@@ -184,36 +184,23 @@ const EnrichedVisitorKeys = (function() {
 
 	// merge with 'official' visitor keys
 	Object.keys(VisitorKeys).forEach( (type) => {
-		// Ignore deprecated keys:
-		// - ExperimentalSpreadProperty => SpreadElement
-		// - ExperimentalRestProperty => RestElement
-		// They are about to be removed, see: https://github.com/eslint/eslint-visitor-keys/pull/36
-		if (type === "ExperimentalSpreadProperty" || type === "ExperimentalRestProperty") {
-			return;
-		}
-		// Ignore JSX visitor-keys because they aren't used.
-		if (type.startsWith("JSX")) {
-			return;
-		}
-
 		const visitorKeys = VisitorKeys[type];
 		const condKeys = TempKeys[type];
-		if ( condKeys === undefined ) {
-			// configuration missing in ConditionalKeys, maybe a new syntax ?
-			throw new Error(`unknown estree node type '${type}', new syntax?`);
-		} else if ( Array.isArray(condKeys) ) {
+		if ( Array.isArray(condKeys) ) {
 			// check configured keys against visitor keys
 			condKeys.forEach( (key) => {
-				if ( visitorKeys.indexOf(key) < 0 ) {
+				if ( !visitorKeys.includes(key) ) {
 					throw new Error(`configuration for type '${type}' contains unknown key '${key}'`);
 				}
 			});
 			TempKeys[type] = visitorKeys.map( (key) => ({
 				key: key,
-				conditional: condKeys.indexOf(key) >= 0
+				conditional: condKeys.includes(key)
 			}) );
-		} else {
+		} else if (condKeys === null) {
 			// this is a 'toBeDone' node type, keep null and complain at runtime when such a node occurs
+		} else {
+			// undefined => ignored node type (see JSModuleAnalyzer consistency test)
 		}
 	});
 
@@ -749,7 +736,7 @@ class JSModuleAnalyzer {
 				const value = getStringValue(item);
 				if ( value !== undefined ) {
 					// ignore special AMD dependencies (require, exports, module)
-					if ( SPECIAL_AMD_DEPENDENCIES.indexOf(value) >= 0 ) {
+					if ( SPECIAL_AMD_DEPENDENCIES.includes(value) ) {
 						return;
 					}
 					let requiredModule;

--- a/lib/lbt/utils/parseUtils.js
+++ b/lib/lbt/utils/parseUtils.js
@@ -3,11 +3,19 @@ import {parse} from "espree";
 
 const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
 
+/*
+ * NOTE: After updating the ecmaVersion:
+ * - Adopt JSModuleAnalyzer to handle new Syntax / VisitorKeys.
+ * - Adjust the JSModuleAnalyzer test "Check for consistency between VisitorKeys and EnrichedVisitorKeys"
+ *   (See comments in test for details)
+*/
+export const ecmaVersion = 2022;
+
 export function parseJS(code, userOptions = {}) {
 	// allowed options and their defaults
 	const options = {
 		comment: false,
-		ecmaVersion: 2022, // NOTE: Adopt JSModuleAnalyzer.js to allow new Syntax when upgrading to newer ECMA versions
+		ecmaVersion,
 		range: false,
 		sourceType: "script",
 	};


### PR DESCRIPTION
This change solves the issue of having runtime exceptions when new
VisitorKeys are available via minor version updates of espree.

Instead, a unit test is added to ensure all new VisitorKeys are handled
when updating the ecmaVersion.

We only expect to have new Syntax / VisitorKeys once we update the
ecmaVersion in use, so it shouldn't be an issue when we don't
immediately handle them.
