### PR TITLE
[INTERNAL] Tasks: Handle empty dependencies reader

### DIFF
--- a/lib/tasks/buildThemes.js
+++ b/lib/tasks/buildThemes.js
@@ -18,7 +18,7 @@ const log = logger.getLogger("builder:tasks:buildThemes");
  *
  * @param {object} parameters Parameters
  * @param {@ui5/fs/DuplexCollection} parameters.workspace DuplexCollection to read and write files
- * @param {@ui5/fs/AbstractReader} parameters.dependencies Reader or Collection to read dependency files
+ * @param {@ui5/fs/AbstractReader} [parameters.dependencies] Reader or Collection to read dependency files
  * @param {object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
  * @param {string} parameters.options.inputPattern Search pattern for *.less files to be built
@@ -34,10 +34,14 @@ export default async function({
 		projectName, inputPattern, librariesPattern, themesPattern, compress, cssVariables
 	}
 }) {
-	const combo = new ReaderCollectionPrioritized({
-		name: `theme - prioritize workspace over dependencies: ${projectName}`,
-		readers: [workspace, dependencies]
-	});
+	let combo = workspace;
+	if (dependencies) {
+		// Create a prioritized reader to include resources of dependencies if available
+		combo = new ReaderCollectionPrioritized({
+			name: `theme - prioritize workspace over dependencies: ${projectName}`,
+			readers: [workspace, dependencies]
+		});
+	}
 
 	compress = compress === undefined ? true : compress;
 

--- a/lib/tasks/bundlers/generateBundle.js
+++ b/lib/tasks/bundlers/generateBundle.js
@@ -17,7 +17,7 @@ import ReaderCollectionPrioritized from "@ui5/fs/ReaderCollectionPrioritized";
  *
  * @param {object} parameters Parameters
  * @param {@ui5/fs/DuplexCollection} parameters.workspace DuplexCollection to read and write files
- * @param {@ui5/fs/ReaderCollection} parameters.dependencies Collection to read dependency files
+ * @param {@ui5/fs/ReaderCollection} [parameters.dependencies] Collection to read dependency files
  * @param {@ui5/project/build/helpers/TaskUtil|object} [parameters.taskUtil] TaskUtil
  * @param {object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
@@ -31,10 +31,14 @@ import ReaderCollectionPrioritized from "@ui5/fs/ReaderCollectionPrioritized";
 export default async function({
 	workspace, dependencies, taskUtil, options: {projectName, bundleDefinition, bundleOptions}
 }) {
-	let combo = new ReaderCollectionPrioritized({
-		name: `generateBundle - prioritize workspace over dependencies: ${projectName}`,
-		readers: [workspace, dependencies]
-	});
+	let combo = workspace;
+	if (dependencies) {
+		// Create a prioritized reader to include resources of dependencies if available
+		combo = new ReaderCollectionPrioritized({
+			name: `generateBundle - prioritize workspace over dependencies: ${projectName}`,
+			readers: [workspace, dependencies]
+		});
+	}
 
 	const optimize = !bundleOptions || bundleOptions.optimize !== false;
 	if (taskUtil) {

--- a/lib/tasks/bundlers/generateStandaloneAppBundle.js
+++ b/lib/tasks/bundlers/generateStandaloneAppBundle.js
@@ -91,6 +91,10 @@ export default async function({workspace, dependencies, taskUtil, options}) {
 			`unable to generate complete bundles for such projects.`);
 	}
 
+	if (!dependencies) {
+		throw new Error(`Unable to create self contained bundle: No dependencies provided`);
+	}
+
 	const combo = new ReaderCollectionPrioritized({
 		name: `generateStandaloneAppBundle - prioritize workspace over dependencies: ${projectName}`,
 		readers: [workspace, dependencies]

--- a/lib/tasks/generateThemeDesignerResources.js
+++ b/lib/tasks/generateThemeDesignerResources.js
@@ -205,7 +205,7 @@ async function generateCssVariablesLess({workspace, combo, namespace}) {
  *
  * @param {object} parameters Parameters
  * @param {@ui5/fs/DuplexCollection} parameters.workspace DuplexCollection to read and write files
- * @param {@ui5/fs/AbstractReader} parameters.dependencies Reader or Collection to read dependency files
+ * @param {@ui5/fs/AbstractReader} [parameters.dependencies] Reader or Collection to read dependency files
  * @param {object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
  * @param {string} parameters.options.version Project version
@@ -255,10 +255,13 @@ export default async function({workspace, dependencies, options}) {
 		return;
 	}
 
-	const combo = new ReaderCollectionPrioritized({
-		name: `generateThemeDesignerResources - prioritize workspace over dependencies: ${projectName}`,
-		readers: [workspace, dependencies]
-	});
+	let combo = workspace;
+	if (!dependencies) {
+		combo = new ReaderCollectionPrioritized({
+			name: `generateThemeDesignerResources - prioritize workspace over dependencies: ${projectName}`,
+			readers: [workspace, dependencies]
+		});
+	}
 
 	// theme .theming files
 	const themeDotThemingFiles = await Promise.all(

--- a/lib/tasks/generateVersionInfo.js
+++ b/lib/tasks/generateVersionInfo.js
@@ -23,6 +23,10 @@ const MANIFEST_JSON = "manifest.json";
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written
  */
 export default async ({workspace, dependencies, options: {rootProject, pattern}}) => {
+	if (!dependencies) {
+		throw new Error(`Unable to generate sap-ui-version.json: No dependencies provided`);
+	}
+
 	const resources = await dependencies.byGlob(pattern);
 
 	const libraryInfosPromises = resources.map((dotLibResource) => {

--- a/lib/tasks/jsdoc/executeJsdocSdkTransformation.js
+++ b/lib/tasks/jsdoc/executeJsdocSdkTransformation.js
@@ -20,7 +20,7 @@ import sdkTransformer from "../../processors/jsdoc/sdkTransformer.js";
  *
  * @param {object} parameters Parameters
  * @param {@ui5/fs/DuplexCollection} parameters.workspace DuplexCollection to read and write files
- * @param {@ui5/fs/AbstractReader} parameters.dependencies Reader or Collection to read dependency files
+ * @param {@ui5/fs/AbstractReader} [parameters.dependencies] Reader or Collection to read dependency files
  * @param {object} parameters.options Options
  * @param {string|Array} parameters.options.dotLibraryPattern Pattern to locate the .library resource to be processed
  * @param {string} parameters.options.projectName Project name
@@ -36,7 +36,7 @@ const executeJsdocSdkTransformation = async function(
 	const [apiJsons, dotLibraries, depApiJsons] = await Promise.all([
 		workspace.byGlob("/test-resources/**/designtime/api.json"),
 		workspace.byGlob(dotLibraryPattern),
-		dependencies.byGlob("/test-resources/**/designtime/api.json")
+		dependencies ? dependencies.byGlob("/test-resources/**/designtime/api.json") : []
 	]);
 	if (!apiJsons.length) {
 		log.info(`Failed to locate api.json resource for project ${projectName}. ` +
@@ -54,10 +54,13 @@ const executeJsdocSdkTransformation = async function(
 			`${projectName}.`);
 	}
 
-	const combo = new ReaderCollectionPrioritized({
-		name: `executeJsdocSdkTransformation - custom workspace + dependencies FS: ${projectName}`,
-		readers: [workspace, dependencies]
-	});
+	let combo = workspace;
+	if (dependencies) {
+		combo = new ReaderCollectionPrioritized({
+			name: `executeJsdocSdkTransformation - custom workspace + dependencies FS: ${projectName}`,
+			readers: [workspace, dependencies]
+		});
+	}
 
 	const apiJsonPath = apiJsons[0].getPath();
 	const dotLibraryPath = dotLibraries[0].getPath();

--- a/lib/tasks/jsdoc/generateJsdoc.js
+++ b/lib/tasks/jsdoc/generateJsdoc.js
@@ -35,7 +35,7 @@ import {createAdapter} from "@ui5/fs/resourceFactory";
  *
  * @param {object} parameters Parameters
  * @param {@ui5/fs/DuplexCollection} parameters.workspace DuplexCollection to read and write files
- * @param {@ui5/fs/AbstractReader} parameters.dependencies Reader or Collection to read dependency files
+ * @param {@ui5/fs/AbstractReader} [parameters.dependencies] Reader or Collection to read dependency files
  * @param {module:@ui5/builder/tasks/jsdoc/generateJsdoc~GenerateJsdocOptions} parameters.options Options
  * @param {@ui5/project/build/helpers/TaskUtil|object} [parameters.taskUtil] TaskUtil
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written
@@ -172,11 +172,14 @@ const utils = {
 	 *
 	 * @private
 	 * @param {object} parameters Parameters
-	 * @param {@ui5/fs/AbstractReader} parameters.dependencies Reader or Collection to read dependency files
+	 * @param {@ui5/fs/AbstractReader} [parameters.dependencies] Reader or Collection to read dependency files
 	 * @param {string} parameters.targetPath Path to write the resources to
 	 * @returns {Promise<number>} Promise resolving with number of resources written to given directory
 	 */
 	writeDependencyApisToDir: async function({dependencies, targetPath}) {
+		if (!dependencies) {
+			return 0;
+		}
 		const depApis = await dependencies.byGlob("/test-resources/**/designtime/api.json");
 
 		// Clone resources before changing their path


### PR DESCRIPTION
If a project has no dependencies, https://github.com/SAP/ui5-fs/pull/455
would lead to tasks being provided with no dependencies reader at all
(opposing to one that does not find any resources, as it is today).