### PR TITLE
[INTERNAL] Refactor log-calls

### DIFF
--- a/lib/lbt/analyzer/ComponentAnalyzer.js
+++ b/lib/lbt/analyzer/ComponentAnalyzer.js
@@ -57,10 +57,11 @@ class ComponentAnalyzer {
 				const fileContent = await manifestResource.buffer();
 				this._analyzeManifest( JSON.parse(fileContent.toString()), info );
 			} else {
-				log.verbose("No manifest found for '%s', skipping analysis", resource.name);
+				log.verbose(`No manifest found for '${resource.name}', skipping analysis`);
 			}
 		} catch (err) {
-			log.error("an error occurred while analyzing component %s (ignored)", resource.name, err.stack);
+			log.error(`An error occurred while analyzing component ${resource.name} (ignored): ${err.message}`);
+			log.verbose(err.stack);
 		}
 
 		return info;
@@ -137,20 +138,20 @@ class ComponentAnalyzer {
 		if ( ui5.rootView ) {
 			const module = this._getRootViewModule(ui5.rootView);
 			if (module) {
-				log.verbose("adding root view dependency ", module);
+				log.verbose(`Adding root view dependency ${module}`);
 				info.addDependency( module );
 			}
 		}
 
 		each( ui5.dependencies && ui5.dependencies.libs, (options, lib) => {
 			const module = fromUI5LegacyName(lib, "/library.js");
-			log.verbose("adding library dependency ", module, options.lazy || false);
+			log.verbose(`Adding library dependency ${module} - lazy: ${options.lazy || false}`);
 			info.addDependency( module, options.lazy ); // lazy -> conditional dependency
 		});
 
 		each( ui5.dependencies && ui5.dependencies.components, (options, component) => {
 			const module = fromUI5LegacyName(component, "/Component.js");
-			log.verbose("adding component dependency ", module, options.lazy || false);
+			log.verbose(`Adding component dependency ${module} - lazy: ${options.lazy || false}`);
 			info.addDependency( module, options.lazy ); // lazy -> conditional dependency
 		});
 
@@ -202,7 +203,7 @@ class ComponentAnalyzer {
 				return;
 			}
 			const module = fromUI5LegacyName( modelType );
-			log.verbose("derived model implementation dependency ", module);
+			log.verbose(`Derived model implementation dependency ${module}`);
 			info.addDependency(module);
 		});
 
@@ -214,15 +215,15 @@ class ComponentAnalyzer {
 			if (routing.routes) {
 				const routerClassName = routingConfig.routerClass || "sap.ui.core.routing.Router";
 				const routerClassModule = fromUI5LegacyName(routerClassName);
-				log.verbose(`adding router dependency '${routerClassModule}'`);
+				log.verbose(`Adding router dependency '${routerClassModule}'`);
 				info.addDependency(routerClassModule);
 			} else if (routing.targets) {
 				const targetsModule = routingConfig.targetsClass || "sap/ui/core/routing/Targets.js";
-				log.verbose(`adding routing targets dependency '${targetsModule}'`);
+				log.verbose(`Adding routing targets dependency '${targetsModule}'`);
 				info.addDependency(targetsModule);
 
 				const viewsModule = "sap/ui/core/routing/Views.js";
-				log.verbose(`adding routing views dependency '${viewsModule}'`);
+				log.verbose(`Adding routing views dependency '${viewsModule}'`);
 				info.addDependency(viewsModule);
 			}
 
@@ -235,7 +236,7 @@ class ComponentAnalyzer {
 						const module = fromUI5LegacyName(
 							(config.viewPath ? config.viewPath + "." : "") +
 							config.viewName, ".view." + config.viewType.toLowerCase() );
-						log.verbose("converting routing target '%s' to view dependency '%s'", targetName, module);
+						log.verbose(`Converting routing target '${targetName}' to view dependency '${module}'`);
 						// TODO make this a conditional dependency, depending on the route pattern?
 						info.addDependency(module);
 					}

--- a/lib/lbt/analyzer/FioriElementsAnalyzer.js
+++ b/lib/lbt/analyzer/FioriElementsAnalyzer.js
@@ -100,10 +100,11 @@ class FioriElementsAnalyzer {
 				const fileContent = await manifestResource.buffer();
 				await this._analyzeManifest( JSON.parse(fileContent.toString()), info );
 			} else {
-				log.verbose("No manifest found for '%s', skipping analysis", resource.name);
+				log.verbose(`No manifest found for '${resource.name}', skipping analysis`);
 			}
 		} catch (err) {
-			log.error("an error occurred while analyzing template app %s (ignored)", resource.name, err);
+			log.error(`An error occurred while analyzing template app ${resource.name} (ignored): ${err.message}`);
+			log.verbose(err.stack);
 		}
 
 		return info;
@@ -131,7 +132,7 @@ class FioriElementsAnalyzer {
 					if ( actionCfg.template ) {
 						const module = fromUI5LegacyName( "sap.fe.templates." +
 										actionCfg.template + ".Component" );
-						log.verbose("template app: add dependency to template component %s", module);
+						log.verbose(`Template app: Add dependency to template component ${module}`);
 						info.addDependency(module);
 						promises.push( this._analyzeTemplateComponent(module, actionCfg, info) );
 					}
@@ -152,7 +153,7 @@ class FioriElementsAnalyzer {
 								pageConfig.component.settings.templateName) || defaultTemplateName;
 		if ( templateName ) {
 			const templateModuleName = fromUI5LegacyName( templateName, ".view.xml" );
-			log.verbose("template app: add dependency to template view %s", templateModuleName);
+			log.verbose(`Template app: Add dependency to template view ${templateModuleName}`);
 			appInfo.addDependency(templateModuleName);
 		}
 	}

--- a/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -178,7 +178,7 @@ export const EnrichedVisitorKeys = (function() {
 	// check for unknown keys in our configuration
 	for ( const type in TempKeys ) {
 		if ( VisitorKeys[type] === undefined ) {
-			throw new Error("configuration contains unknown node type '" + type + "'");
+			throw new Error(`Configuration contains unknown node type '${type}'`);
 		}
 	}
 
@@ -190,7 +190,7 @@ export const EnrichedVisitorKeys = (function() {
 			// check configured keys against visitor keys
 			condKeys.forEach( (key) => {
 				if ( !visitorKeys.includes(key) ) {
-					throw new Error(`configuration for type '${type}' contains unknown key '${key}'`);
+					throw new Error(`Configuration for type '${type}' contains unknown key '${key}'`);
 				}
 			});
 			TempKeys[type] = visitorKeys.map( (key) => ({
@@ -301,7 +301,7 @@ class JSModuleAnalyzer {
 					if ( comment.value.startsWith("@ui5-bundle-raw-include ") ) {
 						const subModule = comment.value.slice("@ui5-bundle-raw-include ".length);
 						info.addSubModule(subModule);
-						log.verbose(`bundle include directive ${subModule}`);
+						log.verbose(`Bundle include directive ${subModule}`);
 					} else if ( comment.value.startsWith("@ui5-bundle ") ) {
 						const bundleName = comment.value.slice("@ui5-bundle ".length);
 						if (comment.start === 0) {
@@ -310,9 +310,9 @@ class JSModuleAnalyzer {
 						} else {
 							setMainModuleInfo(bundleName, null);
 						}
-						log.verbose(`bundle name directive ${bundleName}`);
+						log.verbose(`Bundle name directive ${bundleName}`);
 					} else {
-						log.warn(`unrecognized bundle directive ${comment.value}`);
+						log.warn(`Unrecognized bundle directive ${comment.value}`);
 					}
 				}
 			});
@@ -363,7 +363,7 @@ class JSModuleAnalyzer {
 		// hoisted functions
 		function setMainModuleInfo(name, description) {
 			if ( mainModuleFound ) {
-				throw new Error("conflicting main modules found (unnamed + named)");
+				throw new Error("Conflicting main modules found (unnamed + named)");
 			}
 			mainModuleFound = true;
 			info.name = name;
@@ -524,7 +524,7 @@ class JSModuleAnalyzer {
 
 			default:
 				if ( condKeys == null ) {
-					log.error("Unhandled AST node type " + node.type, node);
+					log.error(`Unhandled AST node type ${node.type}`, node);
 					throw new Error(`Unhandled AST node type ${node.type}`);
 				}
 				// default visit
@@ -547,17 +547,18 @@ class JSModuleAnalyzer {
 						setMainModuleInfo(name, getDocumentation(node));
 					} else if ( nModuleDeclarations > 1 && name === info.name ) {
 						// ignore duplicate declarations (e.g. in behavior file of design time controls)
-						log.warn(`duplicate declaration of module name at ${getLocation(args)} in ${name}`);
+						log.warn(`Duplicate declaration of module name at ${getLocation(args)} in ${name}`);
 					} else {
 						// otherwise it is just a submodule declaration
 						info.addSubModule(name);
 					}
 					return;
 				} else {
-					log.error("jQuery.sap.declare: module name could not be determined from first argument:", args[0]);
+					log.error(
+						`jQuery.sap.declare: Module name could not be determined from first argument: ${args[0]}`);
 				}
 			} else {
-				log.error("jQuery.sap.declare: module name could not be determined, no arguments are given");
+				log.error("jQuery.sap.declare: Module name could not be determined, no arguments are given");
 			}
 		}
 
@@ -594,11 +595,11 @@ class JSModuleAnalyzer {
 				nUnnamedDefines++;
 				if ( nUnnamedDefines > 1 ) {
 					throw new Error(
-						"if multiple modules are contained in a file, only one of them may omit the module ID " +
+						"If multiple modules are contained in a file, only one of them may omit the module ID " +
 						name + " " + nUnnamedDefines);
 				}
 				if ( defaultName == null ) {
-					throw new Error("unnamed module found, but no default name given");
+					throw new Error("Unnamed module found, but no default name given");
 				}
 				name = defaultName;
 				// the first unnamed module definition qualifies as main module
@@ -617,7 +618,7 @@ class JSModuleAnalyzer {
 			const nArgs = args.length;
 
 			if ( nArgs > 0 && args[0].type == Syntax.OBJECT ) {
-				log.verbose("jQuery.sap.require: cannot evaluate complex require (view/controller)");
+				log.verbose("jQuery.sap.require: Cannot evaluate complex require (view/controller)");
 			} else {
 				// UI5 signature with one or many required modules
 				for (let i = 0; i < nArgs; i++) {
@@ -638,11 +639,11 @@ class JSModuleAnalyzer {
 							info.addDependency(requiredModuleName2, true);
 						}
 						if ( consequentValue === undefined || alternateValue === undefined ) {
-							log.verbose("jQuery.sap.require: cannot evaluate dynamic arguments: ", arg && arg.type);
+							log.verbose(`jQuery.sap.require: Cannot evaluate dynamic arguments: ${arg && arg.type}`);
 							info.dynamicDependencies = true;
 						}
 					} else {
-						log.verbose("jQuery.sap.require: cannot evaluate dynamic arguments: ", arg && arg.type);
+						log.verbose(`jQuery.sap.require: Cannot evaluate dynamic arguments: ${arg && arg.type}`);
 						info.dynamicDependencies = true;
 					}
 				}
@@ -661,7 +662,7 @@ class JSModuleAnalyzer {
 					const moduleName = fromRequireJSName( value );
 					info.addDependency(moduleName, conditional);
 				} else {
-					log.verbose("sap.ui.requireSync: cannot evaluate dynamic arguments: ", args[i] && args[i].type);
+					log.verbose(`sap.ui.requireSync: Cannot evaluate dynamic arguments: ${args[i] && args[i].type}`);
 					info.dynamicDependencies = true;
 				}
 			}
@@ -726,7 +727,7 @@ class JSModuleAnalyzer {
 					info.addSubModule(moduleName);
 				});
 			} else {
-				log.verbose("Cannot evaluate registerPreloadedModules: '%s'", modules && modules.type);
+				log.verbose(`Cannot evaluate registerPreloadedModules: ${modules && modules.type}`);
 			}
 		}
 
@@ -747,7 +748,7 @@ class JSModuleAnalyzer {
 					}
 					info.addDependency( requiredModule, conditional );
 				} else {
-					log.verbose("sap.ui.require/sap.ui.define: cannot evaluate dynamic argument: ", item && item.type);
+					log.verbose(`sap.ui.require/sap.ui.define: Cannot evaluate dynamic argument: ${item && item.type}`);
 					info.dynamicDependencies = true;
 				}
 			});

--- a/lib/lbt/analyzer/SmartTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/SmartTemplateAnalyzer.js
@@ -59,11 +59,11 @@ class TemplateComponentAnalyzer {
 				const fileContent = await manifestResource.buffer();
 				await this._analyzeManifest( JSON.parse(fileContent.toString()), info );
 			} else {
-				log.verbose("No manifest found for '%s', skipping analysis", resource.name);
+				log.verbose(`No manifest found for '${resource.name}', skipping analysis`);
 			}
 		} catch (err) {
-			log.error("an error occurred while analyzing template app %s (ignored):", resource.name);
-			log.error(err.stack);
+			log.error(`An error occurred while analyzing template app ${resource.name} (ignored): ${err.message}`);
+			log.verbose(err.stack);
 		}
 
 		return info;
@@ -85,7 +85,7 @@ class TemplateComponentAnalyzer {
 		function recursePage(page) {
 			if ( page.component && page.component.name ) {
 				const module = fromUI5LegacyName( page.component.name + ".Component" );
-				log.verbose("template app: add dependency to template component %s", module);
+				log.verbose(`Template app: Add dependency to template component ${module}`);
 				info.addDependency(module);
 				promises.push( that._analyzeTemplateComponent(module, page, info) );
 			}
@@ -114,12 +114,12 @@ class TemplateComponentAnalyzer {
 									pageConfig.component.settings.templateName) || defaultTemplateName;
 			if ( templateName ) {
 				const templateModuleName = fromUI5LegacyName( templateName, ".view.xml" );
-				log.verbose("template app: add dependency to template view %s", templateModuleName);
+				log.verbose(`Template app: Add dependency to template view ${templateModuleName}`);
 				appInfo.addDependency(templateModuleName);
 			}
 		} catch (err) {
 			if (this._pool.getIgnoreMissingModules() && err.message.startsWith("resource not found in pool")) {
-				log.verbose("Ignoring missing module as per ResourcePool configuration: " + err.message);
+				log.verbose(`Ignoring missing module as per ResourcePool configuration: ${err.message}`);
 			} else {
 				throw err;
 			}

--- a/lib/lbt/analyzer/XMLCompositeAnalyzer.js
+++ b/lib/lbt/analyzer/XMLCompositeAnalyzer.js
@@ -43,7 +43,7 @@ class XMLCompositeAnalyzer {
 				}
 				if (fragmentName) {
 					const fragmentModule = fromUI5LegacyName(fragmentName, ".control.xml");
-					log.verbose("fragment control: add dependency to template fragment %s", fragmentModule);
+					log.verbose(`Fragment control: Add dependency to template fragment ${fragmentModule}`);
 					info.addDependency(fragmentModule);
 				}
 			}

--- a/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -206,7 +206,7 @@ class XMLTemplateAnalyzer {
 		const resourceBundleName = getAttribute(node, XMLVIEW_RESBUNDLENAME_ATTRIBUTE);
 		if ( resourceBundleName ) {
 			const resourceBundleModuleName = fromUI5LegacyName(resourceBundleName, ".properties");
-			log.verbose("found dependency to resource bundle %s", resourceBundleModuleName);
+			log.verbose(`Found dependency to resource bundle ${resourceBundleModuleName}`);
 			// TODO locale dependent dependencies: this._addDependency(resourceBundleModuleName);
 			this._addDependency( resourceBundleModuleName, this.conditional );
 		}
@@ -269,9 +269,8 @@ class XMLTemplateAnalyzer {
 			// e.g. "{= '{Handler: \'' + ${myActions > handlerModule} + '\'}'}"
 			if ((coreRequire.startsWith("{=") || coreRequire.startsWith("{:=")) && this.templateTag) {
 				log.verbose(
-					`Ignoring core:require: '%s' on Node %s:%s contains ` +
-					`an expression binding and is within a 'template' Node`,
-					coreRequire, node.$ns.uri, node.$ns.local
+					`Ignoring core:require: '${coreRequire}' on Node ${node.$ns.uri}:${node.$ns.local} contains ` +
+					`an expression binding and is within a 'template' Node`
 				);
 				return;
 			}
@@ -280,9 +279,10 @@ class XMLTemplateAnalyzer {
 				requireContext = JSTokenizer.parseJS(coreRequire);
 			} catch (e) {
 				log.error(
-					"Ignoring core:require: '%s' can't be parsed on Node %s:%s",
-					coreRequire, node.$ns.uri, node.$ns.local
+					`Ignoring core:require: '${coreRequire}' can't be parsed on Node ` +
+					`${node.$ns.uri}:${node.$ns.local}: ${e.message}`
 				);
+				log.verbose(e.stack);
 			}
 			if ( requireContext ) {
 				Object.keys(requireContext).forEach((key) => {

--- a/lib/lbt/bundle/AutoSplitter.js
+++ b/lib/lbt/bundle/AutoSplitter.js
@@ -82,8 +82,9 @@ class AutoSplitter {
 		await Promise.all(promises);
 
 		const partSize = Math.floor(totalSize / numberOfParts);
-		log.verbose("total size of modules %d (chars), target size for each of the %d parts: %d (chars)",
-			totalSize, numberOfParts, partSize);
+		log.verbose(
+			`Total size of modules ${totalSize} (chars), target size for each ` +
+			`of the ${numberOfParts} parts: ${partSize} (chars)`);
 
 		// ---- create a separate module definition for each part
 		const splittedModules = [];
@@ -184,7 +185,7 @@ class AutoSplitter {
 			}
 		});
 
-		log.verbose("splitted modules: %s", splittedModules);
+		log.verbose(`Splitted modules: ${splittedModules}`);
 		return splittedModules;
 	}
 

--- a/lib/lbt/bundle/Builder.js
+++ b/lib/lbt/bundle/Builder.js
@@ -98,10 +98,10 @@ class BundleBuilder {
 	async _createBundle(module, options) {
 		const resolvedModule = await this.resolver.resolve(module);
 		if ( options.skipIfEmpty && isEmptyBundle(resolvedModule) ) {
-			log.verbose("  skipping empty bundle " + module.name);
+			log.verbose("  Skipping empty bundle " + module.name);
 			return undefined;
 		}
-		log.verbose("  create '%s'", resolvedModule.name);
+		log.verbose(`  Create '${resolvedModule.name}'`);
 
 		this.options = options || {};
 		this.optimize = !!this.options.optimize;
@@ -131,8 +131,7 @@ class BundleBuilder {
 		let bundleInfos = [];
 		// create all sections in sequence
 		for ( const section of resolvedModule.sections ) {
-			log.verbose("    adding section%s of type %s",
-				section.name ? " '" + section.name + "'" : "", section.mode);
+			log.verbose(`    Adding section${section.name ? " '" + section.name + "'" : ""} of type ${section.mode}`);
 			if ( section.mode === SectionType.BundleInfo ) {
 				bundleInfos.push(section);
 			} else {
@@ -253,8 +252,7 @@ class BundleBuilder {
 				this.outW.writeln("//@ui5-bundle-raw-include " + moduleName);
 				await this.writeRawModule(moduleName, resource);
 				const compressedSize = this.outW.endSegment();
-				log.verbose("    %s (%d,%d)", moduleName,
-					resource.info != null ? resource.info.size : -1, compressedSize);
+				log.verbose(`    ${moduleName} (${resource.info != null ? resource.info.size : -1},${compressedSize})`);
 				if ( section.declareRawModules ) {
 					this.missingRawDeclarations.push(moduleName);
 				}
@@ -262,7 +260,7 @@ class BundleBuilder {
 					this.jqglobalAvailable = true;
 				}
 			} else {
-				log.error("    couldn't find %s", moduleName);
+				log.error(`    Could not find module ${moduleName}`);
 			}
 		}
 	}
@@ -308,11 +306,10 @@ class BundleBuilder {
 					outW.startSegment(module);
 					await this.writePreloadModule(module, resource.info, resource);
 					const compressedSize = outW.endSegment();
-					log.verbose("    %s (%d,%d)", module,
-						resource.info != null ? resource.info.size : -1, compressedSize);
+					log.verbose(`    ${module} (${resource.info != null ? resource.info.size : -1},${compressedSize})`);
 					i++;
 				} else {
-					log.error("    couldn't find %s", module);
+					log.error(`    Could not find module ${module}`);
 				}
 			}
 
@@ -387,8 +384,8 @@ class BundleBuilder {
 						outW.write(moduleContent);
 						outW.ensureNewLine();
 						const compressedSize = outW.endSegment();
-						log.verbose("    %s (%d,%d)", moduleName,
-							resource.info != null ? resource.info.size : -1, compressedSize);
+						log.verbose(
+							`    ${moduleName} (${resource.info != null ? resource.info.size : -1},${compressedSize})`);
 					} else {
 						// keep unprocessed modules
 						remaining.push(moduleName);
@@ -440,8 +437,8 @@ class BundleBuilder {
 			outW.ensureNewLine();
 			outW.write(`}`);
 		} else if ( /\.js$/.test(moduleName) /* implicitly: && info != null && info.requiresTopLevelScope */ ) {
-			log.warn("**** warning: module %s requires top level scope" +
-					" and can only be embedded as a string (requires 'eval')", moduleName);
+			log.warn(
+				`Module ${moduleName} requires top level scope and can only be embedded as a string (requires 'eval')`);
 			outW.write( makeStringLiteral( (await resource.buffer()).toString() ) );
 		} else if ( /\.html$/.test(moduleName) ) {
 			const fileContent = (await resource.buffer()).toString();
@@ -452,7 +449,7 @@ class BundleBuilder {
 				try {
 					fileContent = JSON.stringify( JSON.parse( fileContent) );
 				} catch (e) {
-					log.verbose("Failed to parse JSON file %s. Ignoring error, skipping compression.", moduleName);
+					log.verbose(`Failed to parse JSON file ${moduleName}. Ignoring error, skipping compression.`);
 					log.verbose(e);
 				}
 			}
@@ -475,7 +472,7 @@ class BundleBuilder {
 
 			outW.write( makeStringLiteral( fileContent ) );
 		} else {
-			log.error("don't know how to embed module " + moduleName); // TODO throw?
+			log.error("Don't know how to embed module " + moduleName); // TODO throw?
 		}
 
 		return true;
@@ -512,7 +509,7 @@ class BundleBuilder {
 					throw new Error(`A 'bundleInfo' section is missing the mandatory 'name' property.` );
 				}
 				if (!path.extname(section.name)) {
-					log.warn(`bundleInfo section name '${section.name}' is missing a file extension. ` +
+					log.warn(`BundleInfo section name '${section.name}' is missing a file extension. ` +
 						`The info might not work as expected. ` +
 						`The name must match the bundle filename (incl. extension such as '.js')`);
 				}
@@ -636,7 +633,8 @@ async function rewriteDefine({moduleName, moduleContent, moduleSourceMap}) {
 	try {
 		ast = parseJS(moduleContent, {range: true});
 	} catch (e) {
-		log.error("error while parsing %s: %s", moduleName, e.message);
+		log.error(`Error while parsing ${moduleName}: ${e.message}`);
+		log.verbose(e.stack);
 		return {};
 	}
 

--- a/lib/lbt/bundle/Resolver.js
+++ b/lib/lbt/bundle/Resolver.js
@@ -272,7 +272,7 @@ class BundleResolver {
 
 		// NODE-TODO placeholderValues = vars;
 
-		log.verbose("  resolving bundle definition %s", bundle.name);
+		log.verbose(`  Resolving bundle definition ${bundle.name}`);
 
 		const resolved = new ResolvedBundleDefinition(bundle /* , vars*/);
 
@@ -280,8 +280,8 @@ class BundleResolver {
 
 		bundle.sections.forEach(function(section, index) {
 			previous = previous.then( function() {
-				log.verbose("    resolving section%s of type %s",
-					section.name ? " '" + section.name + "'" : "", section.mode);
+				log.verbose(
+					`    Resolving section${section.name ? " '" + section.name + "'" : ""} of type ${section.mode}`);
 
 				// NODE-TODO long t0=System.nanoTime();
 				const resolvedSection = resolved.sections[index];
@@ -291,12 +291,12 @@ class BundleResolver {
 						if ( section.mode == SectionType.Raw && section.sort !== false ) {
 							// sort the modules in topological order
 							return topologicalSort(pool, modules).then( (modules) => {
-								log.silly("      resolved modules (sorted): %s", modules);
+								log.silly(`      Resolved modules (sorted): ${modules}`);
 								return modules;
 							});
 						}
 
-						log.silly("      resolved modules: %s", modules);
+						log.silly(`      Resolved modules: ${modules}`);
 						return modules;
 					}).then( function(modules) {
 						resolvedSection.modules = modules;
@@ -315,7 +315,7 @@ class BundleResolver {
 		// NODE-TODO if ( PerfMeasurement.ACTIVE ) PerfMeasurement.stop(PerfKeys.RESOLVE_MODULE);
 
 		return previous.then( function() {
-			log.verbose("  resolving bundle done");
+			log.verbose("  Resolving bundle done");
 
 			return resolved;
 		});

--- a/lib/lbt/graph/dependencyGraph.js
+++ b/lib/lbt/graph/dependencyGraph.js
@@ -43,7 +43,7 @@ async function createDependencyGraph(pool, roots, options) {
 			});
 			return Promise.all(p);
 		}, (err) => {
-			log.error("module %s not found in pool:", name, err);
+			log.error(`Module ${name} not found in pool: ${err.message}`);
 		}).then( () => node );
 	}
 

--- a/lib/lbt/graph/dominatorTree.js
+++ b/lib/lbt/graph/dominatorTree.js
@@ -28,7 +28,7 @@ function calculateDominatorTree({n0, nodes}) {
 		}
 	}
 
-	log.verbose("%d modules found, starting dominator tree calculation", nodes.size - 1);
+	log.verbose(`${nodes.size - 1} modules found, starting dominator tree calculation`);
 
 	function countEdges(nodes) {
 		let count = 0;
@@ -43,7 +43,9 @@ function calculateDominatorTree({n0, nodes}) {
 	do {
 		// while changes in any Dom(n)
 
-		log.verbose("%d remaining edges", countEdges(nodes));
+		if (log.isLevelEnabled("verbose")) {
+			log.verbose(`${countEdges(nodes)} remaining edges`);
+		}
 
 		modified = false;
 		for ( const n of nodes.values() ) {
@@ -81,7 +83,7 @@ function calculateDominatorTree({n0, nodes}) {
 		n.visited = false;
 	}
 
-	log.verbose("reduce dominator graph to immediate dominator tree");
+	log.verbose("Reduce dominator graph to immediate dominator tree");
 
 	// use DFS to reduce the dominator graph to the (immediate) dominator tree
 	//
@@ -108,7 +110,7 @@ function calculateDominatorTree({n0, nodes}) {
 	}
 	dfs(n0);
 
-	log.verbose("calculation of dominator tree done");
+	log.verbose("Calculation of dominator tree done");
 
 	return n0;
 }

--- a/lib/lbt/graph/topologicalSort.js
+++ b/lib/lbt/graph/topologicalSort.js
@@ -70,7 +70,7 @@ function createDependencyGraph(pool, moduleNames, indegreeOnly) {
 				});
 				return Promise.all(p);
 			}, (err) => {
-				log.error("module %s not found in pool", moduleName);
+				log.error(`Module ${moduleName} not found in pool`);
 			});
 	});
 
@@ -119,7 +119,7 @@ function topologicalSort(pool, moduleNames) {
 									dependent.outgoing.splice(index, 1);
 								// console.log("removing outgoing %s in %s", node.name, dependent.name);
 								} else {
-									log.error("**** could not find node %s in %s", node.name, dependent.name);
+									log.error(`**** Could not find node ${node.name} in ${dependent.name}`);
 								}
 							});
 						}
@@ -177,7 +177,7 @@ function topologicalSort(pool, moduleNames) {
 					Object.keys(graph)
 						.filter((name) => moduleNames.indexOf(name) < l)
 						.map((name) => graph[name].toString()));
-				throw new Error("failed to resolve cyclic dependencies: " + moduleNames.slice(0, l) );
+				throw new Error("Failed to resolve cyclic dependencies: " + moduleNames.slice(0, l).join(", ") );
 				// NODE-TODO use new CycleFinder(graph).toString() for easier to understand output
 			}
 

--- a/lib/lbt/resources/LibraryFileAnalyzer.js
+++ b/lib/lbt/resources/LibraryFileAnalyzer.js
@@ -64,7 +64,7 @@ export function getDependencyInfos( name, content ) {
 						moduleInfos["raw-module"] && moduleInfos["raw-module"].forEach( (rawModule) => {
 							const rawInfo = createRawInfo(rawModule);
 							if ( rawInfo ) {
-								log.verbose(name + " rawInfo:", JSON.stringify(rawInfo));
+								log.verbose(name + " rawInfo: " + JSON.stringify(rawInfo));
 								infos[rawInfo.name] = rawInfo;
 							}
 						});

--- a/lib/lbt/resources/ResourceCollector.js
+++ b/lib/lbt/resources/ResourceCollector.js
@@ -80,7 +80,7 @@ class ResourceCollector {
 	async visitResource(resource) {
 		const virPath = resource.getPath();
 		if ( !virPath.startsWith("/resources/") ) {
-			log.warn(`non-runtime resource ${virPath} ignored`);
+			log.warn(`Non-runtime resource ${virPath} ignored`);
 			return;
 		}
 		const name = virPath.slice("/resources/".length);
@@ -102,7 +102,7 @@ class ResourceCollector {
 			// .theming files are not always present therefore this check is relevant for the library.source.less
 			if ( name.match("(?:[^/]+/)*themes/[^/]+/(?:\\.theming|library\\.source\\.less)") &&
 					!this._themePackages.has(prefix) ) {
-				// log.info("found new theme package %s", prefix);
+				// log.info("Found new theme package %s", prefix);
 				this._themePackages.set(prefix, new ResourceInfoList(prefix));
 			}
 		}
@@ -141,7 +141,7 @@ class ResourceCollector {
 					try {
 						subModuleInfo = await this._pool.getModuleInfo(subModule);
 					} catch (err) {
-						log.verbose(`	missing submodule ${subModule} included by ${moduleInfo.name}`);
+						log.verbose(`	Missing submodule ${subModule} included by ${moduleInfo.name}`);
 					}
 					if (subModuleInfo) {
 						// Inherit subModule dependencies
@@ -207,14 +207,14 @@ class ResourceCollector {
 		for (const [name, info] of this._resources.entries()) {
 			if ( debugFilter.matches(name) ) {
 				info.isDebug = true;
-				log.verbose(`  found potential debug resource '${name}'`);
+				log.verbose(`  Found potential debug resource '${name}'`);
 			}
 
 			// log.verbose(`  checking ${name}`);
 			let m;
 			if ( m = LOCALE.exec(name) ) {
 				const baseName = m[1] + m[3];
-				log.verbose(`  found potential i18n resource '${name}', base name is '${baseName}', locale is ${m[2]}`);
+				log.verbose(`  Found potential i18n resource '${name}', base name is '${baseName}', locale is ${m[2]}`);
 				info.i18nName = baseName; // e.g. "i18n.properties"
 				info.i18nLocale = m[2]; // e.g. "de"
 				baseNames.add(baseName);
@@ -225,7 +225,7 @@ class ResourceCollector {
 				if ( this._themePackages.has(m[0]) ) {
 					const theme = m[2];
 					info.theme = theme;
-					log.verbose(`  found potential theme resource '${name}', theme ${theme}`);
+					log.verbose(`  Found potential theme resource '${name}', theme ${theme}`);
 				}
 			}
 
@@ -255,17 +255,17 @@ class ResourceCollector {
 
 			if ( mergeFilter.matches(name) ) {
 				info.merged = true;
-				log.verbose(`  found potential merged resource '${name}'`);
+				log.verbose(`  Found potential merged resource '${name}'`);
 			}
 
 			if ( designtimeFilter.matches(name) ) {
 				info.designtime = true;
-				log.verbose(`  found potential designtime resource '${name}'`);
+				log.verbose(`  Found potential designtime resource '${name}'`);
 			}
 
 			if ( supportFilter.matches(name) ) {
 				info.support = true;
-				log.verbose(`  found potential support resource '${name}'`);
+				log.verbose(`  Found potential support resource '${name}'`);
 			}
 		}
 
@@ -320,7 +320,7 @@ class ResourceCollector {
 
 	createOrphanFilters() {
 		log.verbose(
-			`  configured external resources filters (resources outside the namespace): ` +
+			`  Configured external resources filters (resources outside the namespace): ` +
 			`${this._externalResources == null ? "(none)" : this._externalResources}`);
 
 		const filtersByComponent = new Map();
@@ -333,7 +333,7 @@ class ResourceCollector {
 				} else if ( !component.endsWith("/") ) {
 					component += "/";
 				}
-				log.verbose(`	resulting filter list for '${component}': '${packageFilters}'`);
+				log.verbose(`	Resulting filter list for '${component}': '${packageFilters}'`);
 				filtersByComponent.set(component, packageFilters);
 			}
 		}

--- a/lib/lbt/resources/ResourceFilterList.js
+++ b/lib/lbt/resources/ResourceFilterList.js
@@ -100,7 +100,7 @@ export default class ResourceFilterList {
 		this.matchers = [];
 		this.matchByDefault = true;
 		this.fileTypes = makeFileTypePattern(fileTypes);
-		log.verbose(`filetypes: ${fileTypes}`);
+		log.verbose(`Filetypes: ${fileTypes}`);
 		this.addFilters(filters);
 	}
 

--- a/lib/lbt/resources/ResourcePool.js
+++ b/lib/lbt/resources/ResourcePool.js
@@ -63,14 +63,16 @@ async function determineDependencyInfo(resource, rawInfo, pool) {
 		try {
 			ast = parseJS(code, {comment: true});
 		} catch (err) {
-			log.error("failed to parse %s: %s", resource.name, err.message);
+			log.error(`Failed to parse ${resource.name}: ${err.message}`);
+			log.verbose(err.stack);
 		}
 		if (ast) {
 			try {
 				jsAnalyzer.analyze(ast, resource.name, info);
 				new XMLCompositeAnalyzer(pool).analyze(ast, resource.name, info);
 			} catch (error) {
-				log.error("failed to analyze %s: %s", resource.name, error.stack);
+				log.error(`Failed to analyze ${resource.name}: ${error.message}`);
+				log.verbose(error.stack);
 			}
 		}
 		if ( rawInfo ) {
@@ -149,7 +151,7 @@ class ResourcePool {
 	 */
 	addResource( resource ) {
 		if ( this._resourcesByName.has(resource.name) ) {
-			log.warn("duplicate resource " + resource.name);
+			log.warn("Duplicate resource " + resource.name);
 			// TODO return and let the first one always win?
 		}
 

--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -193,7 +193,7 @@ async function createManifest(
 
 			const manifestResource = libBundle.findResource(manifestPath.substring(libraryPathPrefix.length));
 			if ( manifestResource == null ) {
-				log.verbose("  component has no accompanying manifest.json, don't list it as 'embedded'");
+				log.verbose("  Component has no accompanying manifest.json, don't list it as 'embedded'");
 				return false;
 			}
 			return true;
@@ -204,19 +204,19 @@ async function createManifest(
 			const components = libBundle.getResources(/^\/(?:[^/]+\/)*Component\.js$/);
 			for (const comp of components) {
 				const componentPath = posixPath.dirname(comp.getPath());
-				log.verbose("checking component at %s", componentPath);
+				log.verbose(`Checking component at ${componentPath}`);
 				if ( componentPath.startsWith(libraryPathPrefix) && hasManifest(componentPath) ) {
 					result.push( componentPath.substring(libraryPathPrefix.length) );
 				} else if ( libraryPathPrefix === "/resources/sap/apf/" ) {
-					log.verbose("Package %s contains both '*.library' and 'Component.js'. " +
-						"This is a known issue but can't be solved due to backward compatibility.", componentPath);
+					log.verbose(`Package ${componentPath} contains both '*.library' and 'Component.js'. ` +
+						`This is a known issue but can't be solved due to backward compatibility.`);
 				} else if (
 					libraryPathPrefix === (componentPath + "/") &&
 					libraryPathPrefix !== "/resources/sap/ui/core/"
 				) {
-					log.error("Package %s contains both '*.library' and 'Component.js'. " +
-						"This is not supported by manifests, therefore the component won't be " +
-						"listed in the library's manifest.", componentPath);
+					log.error(`Package ${componentPath} contains both '*.library' and 'Component.js'. ` +
+						`This is not supported by manifests, therefore the component won't be ` +
+						`listed in the library's manifest.`);
 				}
 			}
 			return result.sort();
@@ -308,7 +308,7 @@ async function createManifest(
 		let i18n;
 		if (typeof i18nText === "string") {
 			i18n = createI18nSection(i18nText, i18nToSupportedLocales);
-			log.verbose(`sap.app/i18n taken from .library appData: '%s'`, i18nText);
+			log.verbose(`sap.app/i18n taken from .library appData: '${i18nText}'`);
 		}
 		const sapApp = {
 			_version: sectionVersion(APP_DESCRIPTOR_V3_SECTION_SAP_APP),
@@ -328,10 +328,10 @@ async function createManifest(
 			openSourceComponents: openSourceComponents()
 		};
 
-		log.verbose("  sap.app/id taken from .library: '%s'", sapApp.id);
-		log.verbose("  sap.app/embeds determined from resources: '%s'", sapApp.embeds);
-		log.verbose("  sap.app/i18n taken from .library appData: '%s'", sapApp.i18n);
-		log.verbose("  sap.app/ach taken from .library appData/ownership: '%s'", sapApp.ach);
+		log.verbose(`  sap.app/id taken from .library: '${sapApp.id}'`);
+		log.verbose(`  sap.app/embeds determined from resources:`, sapApp.embeds);
+		log.verbose(`  sap.app/i18n taken from .library appData:`, sapApp.i18n);
+		log.verbose(`  sap.app/ach taken from .library appData/ownership: '${sapApp.ach}'`);
 
 		return sapApp;
 	}
@@ -382,7 +382,7 @@ async function createManifest(
 			supportedThemes: collectThemes()
 		};
 
-		log.verbose("  sap.ui/supportedThemes determined from resources: '%s'", sapUi.supportedThemes);
+		log.verbose(`  sap.ui/supportedThemes determined from resources: '${sapUi.supportedThemes.join(", ")}'`);
 
 		return sapUi;
 	}
@@ -406,7 +406,7 @@ async function createManifest(
 					};
 				}
 			}
-			log.verbose("  sap.ui5/dependencies/libs determined from .library dependencies: '%s'", dependencies.libs);
+			log.verbose(`  sap.ui5/dependencies/libs determined from .library dependencies:`, dependencies.libs);
 			return dependencies;
 		}
 
@@ -417,18 +417,17 @@ async function createManifest(
 					cozy: getBooleanAttribute(contentDensitiesElement, "cozy"),
 					compact: getBooleanAttribute(contentDensitiesElement, "compact")
 				};
-				log.verbose("  sap.ui5/contentDensities property taken from .library appData: '%s'", contentDensities);
+				log.verbose(`  sap.ui5/contentDensities property taken from .library appData:`, contentDensities);
 				return contentDensities;
 			}
 		}
 
 		function createLibraryMetadata() {
 			if ( descriptorVersion.compare(APP_DESCRIPTOR_V10) < 0 ) {
-				log.verbose("  target descriptor version %s: skipping sap.ui5/library information",
-					descriptorVersion);
+				log.verbose(`  Target descriptor version ${descriptorVersion}: skipping sap.ui5/library information`);
 			}
 
-			log.verbose("  target descriptor version %s: include sap.ui5/library information", descriptorVersion);
+			log.verbose(`  Target descriptor version ${descriptorVersion}: include sap.ui5/library information`);
 
 			const sapUi5AppData = findChild(manifestAppData, "sap.ui5");
 			const libraryAppData = findChild(sapUi5AppData, "library");
@@ -465,11 +464,11 @@ async function createManifest(
 				if ( cssElement != null ) {
 					const css = cssElement._;
 					if ( css === "false" ) {
-						log.verbose("  sap.ui5/library/css property taken from .library appData: '%s'", false);
+						log.verbose(`  sap.ui5/library/css property taken from .library appData: 'false'`);
 						return false;
 					}
 				} else if ( libraryJSInfo.noLibraryCSS ) {
-					log.verbose("  sap.ui5/library/css property extracted from library.js: '%s'", false);
+					log.verbose(`  sap.ui5/library/css property extracted from library.js: 'false'`);
 					return false;
 				}
 			}
@@ -636,7 +635,7 @@ export default function({libraryResource, resources, getProjectVersion, options}
 	// check whether a manifest exists already
 	const manifestResource = libBundle.findResource("manifest.json");
 	if ( manifestResource != null ) {
-		log.verbose("Library manifest already exists at '%s', skipping generation", manifestResource.getPath());
+		log.verbose(`Library manifest already exists at '${manifestResource.getPath()}', skipping generation`);
 		return Promise.resolve(null); // a fulfillment of null indicates that no manifest has been created
 	}
 

--- a/lib/processors/resourceListCreator.js
+++ b/lib/processors/resourceListCreator.js
@@ -138,7 +138,7 @@ export default async function({resources, dependencyResources = [], options}) {
 	const visitPromises = resources.map((resource) => collector.visitResource(resource));
 
 	await Promise.all(visitPromises);
-	log.verbose(`	found ${collector.resources.size} resources`);
+	log.verbose(`	Found ${collector.resources.size} resources`);
 
 	// determine additional information for the found resources
 	if ( options && options.externalResources ) {
@@ -159,7 +159,7 @@ export default async function({resources, dependencyResources = [], options}) {
 
 	// write out resources.json files
 	for (const [prefix, list] of collector.components.entries()) {
-		log.verbose(`	writing '${prefix}resources.json'`);
+		log.verbose(`	Writing '${prefix}resources.json'`);
 
 		const contentString = makeResourcesJSON(list, prefix);
 
@@ -169,7 +169,7 @@ export default async function({resources, dependencyResources = [], options}) {
 		}));
 	}
 	for (const [prefix, list] of collector.themePackages.entries()) {
-		log.verbose(`	writing '${prefix}resources.json'`);
+		log.verbose(`	Writing '${prefix}resources.json'`);
 
 		const contentString = makeResourcesJSON(list, prefix);
 

--- a/lib/processors/themeBuilder.js
+++ b/lib/processors/themeBuilder.js
@@ -45,7 +45,7 @@ export class ThemeBuilder {
 		const files = [];
 
 		const compile = (resource) => {
-			log.verbose("Compiling %s", resource.getPath());
+			log.verbose(`Compiling ${resource.getPath()}`);
 
 			let libraryName;
 			const libraryMatch = libraryMatchPattern.exec(resource.getPath());

--- a/lib/processors/versionInfoGenerator.js
+++ b/lib/processors/versionInfoGenerator.js
@@ -101,20 +101,19 @@ const processManifest = async (manifestResource) => {
  */
 const isBundledWithLibrary = (embeddedBy, componentPath, libraryPathPrefix) => {
 	if (typeof embeddedBy === "undefined") {
-		log.verbose("  component doesn't declare 'sap.app/embeddedBy', don't list it as 'embedded'");
+		log.verbose("  Component doesn't declare 'sap.app/embeddedBy', don't list it as 'embedded'");
 		return false;
 	}
 	if (typeof embeddedBy !== "string") {
 		log.error(
-			"  component '%s': property 'sap.app/embeddedBy' is of type '%s' (expected 'string'), " +
-			"it won't be listed as 'embedded'", componentPath, typeof embeddedBy
-		);
+			`  Component '${componentPath}': property 'sap.app/embeddedBy' is of type '${typeof embeddedBy}' ` +
+			`(expected 'string'), it won't be listed as 'embedded'`);
 		return false;
 	}
 	if ( !embeddedBy.length ) {
 		log.error(
-			"  component '%s': property 'sap.app/embeddedBy' has an empty string value (which is invalid), " +
-			"it won't be listed as 'embedded'", componentPath
+			`  Component '${componentPath}': property 'sap.app/embeddedBy' has an empty string value ` +
+			`(which is invalid), it won't be listed as 'embedded'`
 		);
 		return false;
 	}
@@ -123,12 +122,11 @@ const isBundledWithLibrary = (embeddedBy, componentPath, libraryPathPrefix) => {
 		resolvedEmbeddedBy = resolvedEmbeddedBy + "/";
 	}
 	if ( libraryPathPrefix === resolvedEmbeddedBy ) {
-		log.verbose("  component's 'sap.app/embeddedBy' property points to library, list it as 'embedded'");
+		log.verbose("  Component's 'sap.app/embeddedBy' property points to library, list it as 'embedded'");
 		return true;
 	} else {
 		log.verbose(
-			"  component's 'sap.app/embeddedBy' points to '%s', don't list it as 'embedded'", resolvedEmbeddedBy
-		);
+			`  Component's 'sap.app/embeddedBy' points to '${resolvedEmbeddedBy}', don't list it as 'embedded'`);
 		return false;
 	}
 };

--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -271,7 +271,7 @@ test("AMDMultipleModulesWithConflictBetweenNamedAndUnnamed", async (t) => {
 		await analyze("modules/amd_multiple_modules_with_conflict_between_named_and_unnamed.js");
 		t.fail("parsing a file with conflicting modules shouldn't succeed");
 	} catch (error) {
-		t.is(error.message, "conflicting main modules found (unnamed + named)",
+		t.is(error.message, "Conflicting main modules found (unnamed + named)",
 			"Exception message should contain a hint on conflicting modules");
 	}
 });
@@ -281,7 +281,7 @@ test("AMDMultipleModulesWithConflictBetweenUnnamedAndNamed", async (t) => {
 		await analyze("modules/amd_multiple_modules_with_conflict_between_unnamed_and_named.js");
 		t.fail("parsing a file with conflicting modules shouldn't succeed");
 	} catch (error) {
-		t.is(error.message, "conflicting main modules found (unnamed + named)",
+		t.is(error.message, "Conflicting main modules found (unnamed + named)",
 			"Exception message should contain a hint on conflicting modules");
 	}
 });
@@ -291,7 +291,7 @@ test("AMDMultipleModulesWithConflictBetweenTwoNamed", async (t) => {
 		await analyze("modules/amd_multiple_modules_with_conflict_between_two_named.js");
 		t.fail("parsing a file with conflicting modules shouldn't succeed");
 	} catch (error) {
-		t.is(error.message, "conflicting main modules found (unnamed + named)",
+		t.is(error.message, "Conflicting main modules found (unnamed + named)",
 			"Exception message should contain a hint on conflicting modules");
 	}
 });
@@ -1117,6 +1117,6 @@ test("@ui5-bundle comment: Multiple comments (Not in first line)", (t) => {
 //@ui5-bundle test/bundle2.js
 `;
 	t.throws(() => analyzeString(content, "modules/ui5-bundle-comments.js"), {
-		message: "conflicting main modules found (unnamed + named)"
+		message: "Conflicting main modules found (unnamed + named)"
 	});
 });

--- a/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
+++ b/test/lib/lbt/analyzer/XMLTemplateAnalyzer.js
@@ -62,7 +62,8 @@ test("integration: Analysis of an xml view with data binding in properties", asy
 test.serial("integration: Analysis of an xml view with core:require from databinding", async (t) => {
 	const errorLogStub = sinon.stub();
 	const myLoggerInstance = {
-		error: errorLogStub
+		error: errorLogStub,
+		verbose: sinon.stub()
 	};
 	const XMLTemplateAnalyzerWithStubbedLogger = await esmock("../../../../lib/lbt/analyzer/XMLTemplateAnalyzer.js", {
 		"@ui5/logger": {
@@ -112,12 +113,10 @@ test.serial("integration: Analysis of an xml view with core:require from databin
 		"A control outside of template:if should become a strict dependency");
 
 	t.is(errorLogStub.callCount, 1, "should be called 1 time");
-	t.deepEqual(errorLogStub.getCall(0).args, [
-		"Ignoring core:require: '%s' can't be parsed on Node %s:%s",
-		"{= '{Handler: \\'' + ${myActions>handlerModule} + '\\'}'}",
-		"sap.m",
-		"Button"
-	], "should be called with expected args");
+	t.is(errorLogStub.getCall(0).args[0],
+		"Ignoring core:require: '{= '{Handler: \\'' + ${myActions>handlerModule} + '\\'}'}' can't be " +
+		"parsed on Node sap.m:Button: Bad name",
+		"should be called with expected args");
 });
 
 test.serial("integration: Analysis of an xml view with core:require from databinding in template", async (t) => {
@@ -166,12 +165,10 @@ test.serial("integration: Analysis of an xml view with core:require from databin
 		"A control within template:if or template:repeat should become a conditional dependency");
 
 	t.is(verboseLogStub.callCount, 1, "should be called 1 time");
-	t.deepEqual(verboseLogStub.getCall(0).args, [
-		"Ignoring core:require: '%s' on Node %s:%s contains an expression binding and is within a 'template' Node",
-		"{= '{Handler: \\'' + ${myActions > handlerModule} + '\\'}'}",
-		"sap.m",
-		"Button"
-	], "should be called with expected args");
+	t.is(verboseLogStub.getCall(0).args[0],
+		"Ignoring core:require: '{= '{Handler: \\'' + ${myActions > handlerModule} + '\\'}'}' on Node " +
+		"sap.m:Button contains an expression binding and is within a 'template' Node",
+		"should be called with expected args");
 });
 
 test.serial("integration: Analysis of an xml view with core:require from expression binding in template", async (t) => {
@@ -216,12 +213,10 @@ test.serial("integration: Analysis of an xml view with core:require from express
 		"A control within template:if should become a conditional dependency");
 
 	t.is(verboseLogStub.callCount, 1, "should be called 1 time");
-	t.deepEqual(verboseLogStub.getCall(0).args, [
-		"Ignoring core:require: '%s' on Node %s:%s contains an expression binding and is within a 'template' Node",
-		"{= 'foo': true}",
-		"sap.m",
-		"Button"
-	], "should be called with expected args");
+	t.is(verboseLogStub.getCall(0).args[0],
+		"Ignoring core:require: '{= 'foo': true}' on Node sap.m:Button contains an expression binding " +
+		"and is within a 'template' Node",
+		"should be called with expected args");
 });
 
 test("integration: Analysis of an xml view with core:require", async (t) => {

--- a/test/lib/lbt/bundle/Builder.js
+++ b/test/lib/lbt/bundle/Builder.js
@@ -48,9 +48,8 @@ test.serial("writePreloadModule: with invalid json content", async (t) => {
 	const result = await builder.writePreloadModule("invalid.json", undefined, invalidJsonResource);
 
 	t.is(verboseLogStub.callCount, 2, "called 2 times");
-	t.is(verboseLogStub.firstCall.args[0], "Failed to parse JSON file %s. Ignoring error, skipping compression.",
+	t.is(verboseLogStub.firstCall.args[0], "Failed to parse JSON file invalid.json. Ignoring error, skipping compression.",
 		"first verbose log argument 0 is correct");
-	t.is(verboseLogStub.firstCall.args[1], "invalid.json", "first verbose log argument 1 is correct");
 	t.true(verboseLogStub.secondCall.args[0] instanceof SyntaxError, "second verbose log with SyntaxError");
 	t.regex(verboseLogStub.secondCall.args[0].message, /JSON/, "second verbose log about incorrect JSON");
 
@@ -796,7 +795,7 @@ ${SOURCE_MAPPING_URL}=library-preload.js.map
 
 	t.is(warnLogStub.callCount, 1);
 	t.deepEqual(warnLogStub.getCall(0).args, [
-		`bundleInfo section name 'my-custom-bundle' is missing a file extension. ` +
+		`BundleInfo section name 'my-custom-bundle' is missing a file extension. ` +
 		`The info might not work as expected. ` +
 		`The name must match the bundle filename (incl. extension such as '.js')`
 	]);

--- a/test/lib/lbt/graph/topologicalSort.js
+++ b/test/lib/lbt/graph/topologicalSort.js
@@ -32,7 +32,7 @@ test("cyclic dependencies", async (t) => {
 	const pool = createMockPool({"third": "mydep", "mydep": "third"});
 	const roots = ["myroot", "mydep", "third"];
 	const error = await t.throwsAsync(topologicalSort(pool, roots));
-	t.is(error.message, "failed to resolve cyclic dependencies: mydep,third");
+	t.is(error.message, "Failed to resolve cyclic dependencies: mydep, third");
 });
 
 test("no dependencies", async (t) => {

--- a/test/lib/lbt/resources/ResourceCollector.js
+++ b/test/lib/lbt/resources/ResourceCollector.js
@@ -64,7 +64,7 @@ test.serial("visitResource: path", async (t) => {
 	const resourceCollector = new ResourceCollector();
 	await resourceCollector.visitResource({getPath: () => "mypath", getSize: async () => 13});
 	t.is(t.context.logWarnSpy.callCount, 1);
-	t.is(t.context.logWarnSpy.getCall(0).args[0], "non-runtime resource mypath ignored");
+	t.is(t.context.logWarnSpy.getCall(0).args[0], "Non-runtime resource mypath ignored");
 });
 
 test.serial("visitResource: library.source.less", async (t) => {

--- a/test/lib/processors/manifestCreator.js
+++ b/test/lib/processors/manifestCreator.js
@@ -596,10 +596,8 @@ test.serial("manifest creation with themes", async (t) => {
 
 	t.is(errorLogStub.callCount, 0);
 	t.is(verboseLogStub.callCount, 7);
-	t.deepEqual(verboseLogStub.getCall(4).args, [
-		"  sap.ui/supportedThemes determined from resources: '%s'",
-		["base", "sap_foo"]
-	]);
+	t.is(verboseLogStub.getCall(4).args[0],
+		"  sap.ui/supportedThemes determined from resources: 'base, sap_foo'");
 });
 
 test.serial("manifest creation for sap/apf", async (t) => {
@@ -640,14 +638,12 @@ test.serial("manifest creation for sap/apf", async (t) => {
 	t.is(errorLogStub.callCount, 0);
 
 	t.is(verboseLogStub.callCount, 10);
-	t.is(verboseLogStub.getCall(0).args[0], "sap.app/i18n taken from .library appData: '%s'");
+	t.is(verboseLogStub.getCall(0).args[0], "sap.app/i18n taken from .library appData: 'i18n/i18n.properties'");
 	t.is(verboseLogStub.getCall(1).args[0],
-		"checking component at %s");
-	t.is(verboseLogStub.getCall(1).args[1], "/resources/sap/apf");
+		"Checking component at /resources/sap/apf");
 	t.is(verboseLogStub.getCall(2).args[0],
-		"Package %s contains both '*.library' and 'Component.js'. " +
+		"Package /resources/sap/apf contains both '*.library' and 'Component.js'. " +
 		"This is a known issue but can't be solved due to backward compatibility.");
-	t.is(verboseLogStub.getCall(2).args[1], "/resources/sap/apf");
 });
 
 test.serial("manifest creation for sap/ui/core", async (t) => {
@@ -711,8 +707,7 @@ test.serial("manifest creation for sap/ui/core", async (t) => {
 
 	t.is(verboseLogStub.callCount, 8);
 	t.is(verboseLogStub.getCall(1).args[0],
-		"  sap.app/id taken from .library: '%s'");
-	t.is(verboseLogStub.getCall(1).args[1], "sap.ui.core");
+		"  sap.app/id taken from .library: 'sap.ui.core'");
 });
 
 test.serial("manifest creation with .library / Component.js at same namespace", async (t) => {
@@ -773,17 +768,14 @@ test.serial("manifest creation with .library / Component.js at same namespace", 
 	t.is(await result.getString(), expectedManifestContent, "Correct result returned");
 
 	t.is(errorLogStub.callCount, 1);
-	t.deepEqual(errorLogStub.getCall(0).args, [
-		"Package %s contains both '*.library' and 'Component.js'. " +
+	t.is(errorLogStub.getCall(0).args[0],
+		"Package /resources/sap/lib1 contains both '*.library' and 'Component.js'. " +
 		"This is not supported by manifests, therefore the component won't be " +
-		"listed in the library's manifest.",
-		"/resources/sap/lib1"
-	]);
+		"listed in the library's manifest.");
 
 	t.is(verboseLogStub.callCount, 8);
 	t.is(verboseLogStub.getCall(1).args[0],
-		"  sap.app/id taken from .library: '%s'");
-	t.is(verboseLogStub.getCall(1).args[1], "sap.lib1");
+		"  sap.app/id taken from .library: 'sap.lib1'");
 });
 
 test.serial("manifest creation with embedded component", async (t) => {
@@ -862,12 +854,10 @@ test.serial("manifest creation with embedded component", async (t) => {
 	t.is(errorLogStub.callCount, 0);
 
 	t.true(verboseLogStub.callCount >= 2, "There should be at least 2 verbose log calls");
-	t.deepEqual(verboseLogStub.getCall(0).args, [
-		"checking component at %s", "/resources/sap/lib1/component1"
-	]);
-	t.deepEqual(verboseLogStub.getCall(1).args, [
-		"  sap.app/id taken from .library: '%s'", "sap.lib1"
-	]);
+	t.is(verboseLogStub.getCall(0).args[0],
+		"Checking component at /resources/sap/lib1/component1");
+	t.is(verboseLogStub.getCall(1).args[0],
+		"  sap.app/id taken from .library: 'sap.lib1'");
 });
 
 test.serial("manifest creation with embedded component (Missing 'embeddedBy')", async (t) => {
@@ -942,12 +932,10 @@ test.serial("manifest creation with embedded component (Missing 'embeddedBy')", 
 	t.is(errorLogStub.callCount, 0);
 
 	t.true(verboseLogStub.callCount >= 2, "There should be at least 2 verbose log calls");
-	t.deepEqual(verboseLogStub.getCall(0).args, [
-		"checking component at %s", "/resources/sap/lib1/component1"
-	]);
-	t.deepEqual(verboseLogStub.getCall(1).args, [
-		"  sap.app/id taken from .library: '%s'", "sap.lib1"
-	]);
+	t.is(verboseLogStub.getCall(0).args[0],
+		"Checking component at /resources/sap/lib1/component1");
+	t.is(verboseLogStub.getCall(1).args[0],
+		"  sap.app/id taken from .library: 'sap.lib1'");
 });
 
 test.serial("manifest creation with embedded component ('embeddedBy' doesn't point to library)", async (t) => {
@@ -1026,12 +1014,10 @@ test.serial("manifest creation with embedded component ('embeddedBy' doesn't poi
 	t.is(errorLogStub.callCount, 0);
 
 	t.true(verboseLogStub.callCount >= 2, "There should be at least 2 verbose log calls");
-	t.deepEqual(verboseLogStub.getCall(0).args, [
-		"checking component at %s", "/resources/sap/lib1/component1"
-	]);
-	t.deepEqual(verboseLogStub.getCall(1).args, [
-		"  sap.app/id taken from .library: '%s'", "sap.lib1"
-	]);
+	t.is(verboseLogStub.getCall(0).args[0],
+		"Checking component at /resources/sap/lib1/component1");
+	t.is(verboseLogStub.getCall(1).args[0],
+		"  sap.app/id taken from .library: 'sap.lib1'");
 });
 
 test.serial("manifest creation with embedded component ('embeddedBy' absolute path)", async (t) => {
@@ -1110,12 +1096,10 @@ test.serial("manifest creation with embedded component ('embeddedBy' absolute pa
 	t.is(errorLogStub.callCount, 0);
 
 	t.true(verboseLogStub.callCount >= 2, "There should be at least 2 verbose log calls");
-	t.deepEqual(verboseLogStub.getCall(0).args, [
-		"checking component at %s", "/resources/sap/lib1/component1"
-	]);
-	t.deepEqual(verboseLogStub.getCall(1).args, [
-		"  sap.app/id taken from .library: '%s'", "sap.lib1"
-	]);
+	t.is(verboseLogStub.getCall(0).args[0],
+		"Checking component at /resources/sap/lib1/component1");
+	t.is(verboseLogStub.getCall(1).args[0],
+		"  sap.app/id taken from .library: 'sap.lib1'");
 });
 
 test.serial("manifest creation with embedded component ('embeddedBy' empty string)", async (t) => {
@@ -1333,13 +1317,10 @@ test.serial("manifest creation with embedded component (no manifest.json)", asyn
 	t.is(errorLogStub.callCount, 0);
 
 	t.true(verboseLogStub.callCount >= 2, "There should be at least 2 verbose log calls");
-	t.deepEqual(verboseLogStub.getCall(0).args, [
-		"checking component at %s",
-		"/resources/sap/lib1/component1"
-	]);
-	t.deepEqual(verboseLogStub.getCall(1).args, [
-		"  component has no accompanying manifest.json, don't list it as 'embedded'"
-	]);
+	t.is(verboseLogStub.getCall(0).args[0],
+		"Checking component at /resources/sap/lib1/component1");
+	t.is(verboseLogStub.getCall(1).args[0],
+		"  Component has no accompanying manifest.json, don't list it as 'embedded'");
 });
 
 test.serial("manifest creation with embedded component (invalid manifest.json)", async (t) => {

--- a/test/lib/processors/resourceListCreator.js
+++ b/test/lib/processors/resourceListCreator.js
@@ -51,7 +51,7 @@ test.serial("Empty resources", async (t) => {
 	t.is(resourceListCreatorLog.error.callCount, 0);
 	t.is(resourceListCreatorLog.verbose.callCount, 1);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(0).args,
-		["\tfound 0 resources"]);
+		["\tFound 0 resources"]);
 });
 
 test.serial("Empty resources but options", async (t) => {
@@ -69,7 +69,7 @@ test.serial("Empty resources but options", async (t) => {
 	t.is(resourceListCreatorLog.error.callCount, 0);
 	t.is(resourceListCreatorLog.verbose.callCount, 1);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(0).args,
-		["\tfound 0 resources"]);
+		["\tFound 0 resources"]);
 });
 
 test.serial("Orphaned resources", async (t) => {
@@ -86,7 +86,7 @@ test.serial("Orphaned resources", async (t) => {
 	t.is(resourceListCreatorLog.error.callCount, 0);
 	t.is(resourceListCreatorLog.verbose.callCount, 1);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(0).args,
-		["\tfound 1 resources"]);
+		["\tFound 1 resources"]);
 });
 
 test.serial("Orphaned resources (failOnOrphans: true)", async (t) => {
@@ -112,7 +112,7 @@ test.serial("Orphaned resources (failOnOrphans: true)", async (t) => {
 		"resources.json generation failed because of unassigned resources: nomodule.foo");
 	t.is(resourceListCreatorLog.verbose.callCount, 1);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(0).args,
-		["\tfound 1 resources"]);
+		["\tFound 1 resources"]);
 });
 
 test.serial("Components and themes", async (t) => {
@@ -133,11 +133,11 @@ test.serial("Components and themes", async (t) => {
 	t.is(resourceListCreatorLog.error.callCount, 0);
 	t.is(resourceListCreatorLog.verbose.callCount, 3);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(0).args,
-		["\tfound 2 resources"]);
+		["\tFound 2 resources"]);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(1).args,
-		["\twriting 'mylib/resources.json'"]);
+		["\tWriting 'mylib/resources.json'"]);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(2).args,
-		["\twriting 'themes/a/resources.json'"]);
+		["\tWriting 'themes/a/resources.json'"]);
 
 
 	t.is(resources.length, 2);
@@ -224,9 +224,9 @@ test.serial("XML View with control resource as dependency", async (t) => {
 	t.is(resourceListCreatorLog.error.callCount, 0);
 	t.is(resourceListCreatorLog.verbose.callCount, 2);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(0).args,
-		["\tfound 3 resources"]);
+		["\tFound 3 resources"]);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(1).args,
-		["\twriting 'my/app/resources.json'"]);
+		["\tWriting 'my/app/resources.json'"]);
 
 	t.is(resourcesJson.length, 1, "One resources.json should be returned");
 	const myAppResourcesJson = resourcesJson[0];
@@ -322,15 +322,15 @@ sap.ui.require.preload({
 	t.is(resourceListCreatorLog.error.callCount, 0);
 	t.is(resourceListCreatorLog.verbose.callCount, 2);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(0).args,
-		["\tfound 4 resources"]);
+		["\tFound 4 resources"]);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(1).args,
-		["\twriting 'my/app/resources.json'"]);
+		["\tWriting 'my/app/resources.json'"]);
 
 	t.is(ResourceCollectorLog.error.callCount, 0);
 	t.is(ResourceCollectorLog.warn.callCount, 0);
 	t.is(ResourceCollectorLog.verbose.callCount, 1);
 	t.deepEqual(ResourceCollectorLog.verbose.getCall(0).args,
-		["  configured external resources filters (resources outside the namespace): (none)"]);
+		["  Configured external resources filters (resources outside the namespace): (none)"]);
 
 	t.is(resourcesJson.length, 1, "One resources.json should be returned");
 	const myAppResourcesJson = resourcesJson[0];
@@ -406,17 +406,17 @@ sap.ui.require.preload({
 	t.is(resourceListCreatorLog.error.callCount, 0);
 	t.is(resourceListCreatorLog.verbose.callCount, 2);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(0).args,
-		["\tfound 2 resources"]);
+		["\tFound 2 resources"]);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(1).args,
-		["\twriting 'my/app/resources.json'"]);
+		["\tWriting 'my/app/resources.json'"]);
 
 	t.is(ResourceCollectorLog.error.callCount, 0);
 	t.is(ResourceCollectorLog.warn.callCount, 0);
 	t.is(ResourceCollectorLog.verbose.callCount, 2);
 	t.deepEqual(ResourceCollectorLog.verbose.getCall(0).args,
-		["\tmissing submodule my/app/view/Main.view.xml included by my/app/bundle.js"]);
+		["\tMissing submodule my/app/view/Main.view.xml included by my/app/bundle.js"]);
 	t.deepEqual(ResourceCollectorLog.verbose.getCall(1).args,
-		["  configured external resources filters (resources outside the namespace): (none)"]);
+		["  Configured external resources filters (resources outside the namespace): (none)"]);
 
 	t.is(resourcesJson.length, 1, "One resources.json should be returned");
 	const myAppResourcesJson = resourcesJson[0];
@@ -498,15 +498,15 @@ sap.ui.require.preload({
 	t.is(resourceListCreatorLog.error.callCount, 0);
 	t.is(resourceListCreatorLog.verbose.callCount, 2);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(0).args,
-		["\tfound 4 resources"]);
+		["\tFound 4 resources"]);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(1).args,
-		["\twriting 'my/app/resources.json'"]);
+		["\tWriting 'my/app/resources.json'"]);
 
 	t.is(ResourceCollectorLog.error.callCount, 0);
 	t.is(ResourceCollectorLog.warn.callCount, 0);
 	t.is(ResourceCollectorLog.verbose.callCount, 1);
 	t.deepEqual(ResourceCollectorLog.verbose.getCall(0).args,
-		["  configured external resources filters (resources outside the namespace): (none)"]);
+		["  Configured external resources filters (resources outside the namespace): (none)"]);
 
 	// XMLTemplateAnalyzer should only be called once, which means that the view was only analyzed once
 	t.is(XMLTemplateAnalyzerAnalyzeViewSpy.callCount, 1);
@@ -603,15 +603,15 @@ sap.ui.require.preload({
 	t.is(resourceListCreatorLog.error.callCount, 0);
 	t.is(resourceListCreatorLog.verbose.callCount, 2);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(0).args,
-		["\tfound 4 resources"]);
+		["\tFound 4 resources"]);
 	t.deepEqual(resourceListCreatorLog.verbose.getCall(1).args,
-		["\twriting 'my/app/resources.json'"]);
+		["\tWriting 'my/app/resources.json'"]);
 
 	t.is(ResourceCollectorLog.error.callCount, 0);
 	t.is(ResourceCollectorLog.warn.callCount, 0);
 	t.is(ResourceCollectorLog.verbose.callCount, 1);
 	t.deepEqual(ResourceCollectorLog.verbose.getCall(0).args,
-		["  configured external resources filters (resources outside the namespace): (none)"]);
+		["  Configured external resources filters (resources outside the namespace): (none)"]);
 
 	t.is(resourcesJson.length, 1, "One resources.json should be returned");
 	const myAppResourcesJson = resourcesJson[0];

--- a/test/lib/tasks/generateVersionInfo.js
+++ b/test/lib/tasks/generateVersionInfo.js
@@ -955,7 +955,7 @@ test.serial("integration: Library without dependencies and embeddedBy undefined"
 
 	t.is(verboseLogStub.callCount, 1);
 	t.is(verboseLogStub.firstCall.args[0],
-		"  component doesn't declare 'sap.app/embeddedBy', don't list it as 'embedded'");
+		"  Component doesn't declare 'sap.app/embeddedBy', don't list it as 'embedded'");
 });
 
 test.serial("integration: Library without dependencies and embeddedBy not a string", async (t) => {
@@ -1002,8 +1002,8 @@ test.serial("integration: Library without dependencies and embeddedBy not a stri
 
 	t.is(errorLogStub.callCount, 1);
 	t.is(errorLogStub.firstCall.args[0],
-		"  component '%s': property 'sap.app/embeddedBy' is of type '%s' (expected 'string'), " +
-		"it won't be listed as 'embedded'");
+		"  Component '/resources/lib/a/sub/fold': property 'sap.app/embeddedBy' is of type 'object' " +
+		"(expected 'string'), it won't be listed as 'embedded'");
 });
 
 test.serial("integration: Library without dependencies and embeddedBy empty string", async (t) => {
@@ -1050,8 +1050,8 @@ test.serial("integration: Library without dependencies and embeddedBy empty stri
 
 	t.is(errorLogStub.callCount, 1);
 	t.is(errorLogStub.firstCall.args[0],
-		"  component '%s': property 'sap.app/embeddedBy' has an empty string value (which is invalid), " +
-		"it won't be listed as 'embedded'");
+		"  Component '/resources/lib/a/sub/fold': property 'sap.app/embeddedBy' has an empty string value " +
+		"(which is invalid), it won't be listed as 'embedded'");
 });
 
 test.serial("integration: Library without dependencies and embeddedBy path not correct", async (t) => {
@@ -1098,7 +1098,7 @@ test.serial("integration: Library without dependencies and embeddedBy path not c
 
 	t.is(verboseLogStub.callCount, 1);
 	t.is(verboseLogStub.firstCall.args[0],
-		"  component's 'sap.app/embeddedBy' points to '%s', don't list it as 'embedded'");
+		"  Component's 'sap.app/embeddedBy' points to '/resources/lib/a/sub/', don't list it as 'embedded'");
 });
 
 test.serial("integration: Library with manifest with invalid dependency", async (t) => {


### PR DESCRIPTION
Use template literals wherever possible. Start log messages with a
capital letter.

This is in prepration for @ui5/logger changes as per
https://github.com/SAP/ui5-logger/pull/353