### PR TITLE
[INTERNAL] stringReplacer: Replace using string instead of stream

### DIFF
--- a/lib/processors/stringReplacer.js
+++ b/lib/processors/stringReplacer.js
@@ -1,5 +1,3 @@
-import replaceStream from "replacestream";
-
 /**
  * @public
  * @module @ui5/builder/processors/stringReplacer
@@ -20,12 +18,12 @@ import replaceStream from "replacestream";
  * @returns {Promise<@ui5/fs/Resource[]>} Promise resolving with modified resources
  */
 export default function({resources, options: {pattern, replacement}}) {
-	return Promise.all(resources.map((resource) => {
-		let stream = resource.getStream();
-		stream.setEncoding("utf8");
-		stream = stream.pipe(replaceStream(pattern, replacement));
-
-		resource.setStream(stream);
+	return Promise.all(resources.map(async (resource) => {
+		const content = await resource.getString();
+		const newContent = content.replaceAll(pattern, replacement);
+		if (content !== newContent) {
+			resource.setString(newContent);
+		}
 		return resource;
 	}));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
 				"jsdoc": "^3.6.11",
 				"less-openui5": "^0.11.5",
 				"pretty-data": "^0.40.0",
-				"replacestream": "^4.0.3",
 				"rimraf": "^4.1.1",
 				"semver": "^7.3.8",
 				"terser": "^5.16.1",
@@ -2553,7 +2552,8 @@
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true
 		},
 		"node_modules/cosmiconfig": {
 			"version": "7.1.0",
@@ -6987,6 +6987,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7623,7 +7624,8 @@
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"node_modules/process-on-spawn": {
 			"version": "1.0.0",
@@ -8090,6 +8092,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
 			"integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
+			"dev": true,
 			"dependencies": {
 				"escape-string-regexp": "^1.0.3",
 				"object-assign": "^4.0.1",
@@ -8100,6 +8103,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -8107,12 +8111,14 @@
 		"node_modules/replacestream/node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true
 		},
 		"node_modules/replacestream/node_modules/readable-stream": {
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"dev": true,
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -8247,7 +8253,8 @@
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
@@ -8645,6 +8652,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -9216,7 +9224,8 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true
 		},
 		"node_modules/uuid": {
 			"version": "8.3.2",
@@ -11569,7 +11578,8 @@
 		"core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true
 		},
 		"cosmiconfig": {
 			"version": "7.1.0",
@@ -14908,7 +14918,8 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true
 		},
 		"once": {
 			"version": "1.4.0",
@@ -15333,7 +15344,8 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"process-on-spawn": {
 			"version": "1.0.0",
@@ -15659,6 +15671,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
 			"integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.3",
 				"object-assign": "^4.0.1",
@@ -15668,17 +15681,20 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+					"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+					"dev": true
 				},
 				"readable-stream": {
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -15770,7 +15786,8 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -16086,6 +16103,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -16510,7 +16528,8 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true
 		},
 		"uuid": {
 			"version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
 		"jsdoc": "^3.6.11",
 		"less-openui5": "^0.11.5",
 		"pretty-data": "^0.40.0",
-		"replacestream": "^4.0.3",
 		"rimraf": "^4.1.1",
 		"semver": "^7.3.8",
 		"terser": "^5.16.1",

--- a/test/lib/processors/stringReplacer.js
+++ b/test/lib/processors/stringReplacer.js
@@ -1,39 +1,23 @@
 import test from "ava";
-import {Readable} from "node:stream";
+import _sinon from "sinon";
 import stringReplacer from "../../../lib/processors/stringReplacer.js";
 
-const getStringFromStream = (stream) => {
-	return new Promise((resolve, reject) => {
-		const buffers = [];
-		stream.on("data", (data) => {
-			buffers.push(data);
-		});
-		stream.on("error", (err) => {
-			reject(err);
-		});
-		stream.on("end", () => {
-			const buffer = Buffer.concat(buffers);
-			resolve(buffer.toString());
-		});
-	});
-};
+test.beforeEach((t) => {
+	t.context.sinon = _sinon.createSandbox();
+});
 
-test.serial("Replaces string pattern from resource stream", async (t) => {
+test.afterEach.always((t) => {
+	t.context.sinon.restore();
+});
+
+test.serial("Replace using string pattern", async (t) => {
+	const {sinon} = t.context;
 	const input = `foo bar foo`;
 	const expected = `foo foo foo`;
 
-	let output;
-
 	const resource = {
-		getStream: () => {
-			const stream = new Readable();
-			stream.push(Buffer.from(input));
-			stream.push(null);
-			return stream;
-		},
-		setStream: (outputStream) => {
-			output = getStringFromStream(outputStream);
-		}
+		getString: sinon.stub().resolves(input),
+		setString: sinon.stub()
 	};
 
 	const processedResources = await stringReplacer({
@@ -44,43 +28,139 @@ test.serial("Replaces string pattern from resource stream", async (t) => {
 		}
 	});
 
-	t.deepEqual(processedResources, [resource], "Input resource is returned");
-	t.deepEqual(await output, expected, "Correct file content should be set");
+	t.is(processedResources.length, 1, "Returned one resource");
+	t.is(processedResources[0], resource, "Input resource is returned");
+	t.is(resource.setString.callCount, 1, "Resource#setString got called once");
+	t.is(resource.setString.firstCall.firstArg, expected, "Resource#setString got called with expected argument");
 });
 
-test.serial("Correctly processes utf8 characters within separate chunks", async (t) => {
-	const utf8string = "Κυ";
-	const expected = utf8string;
-
-	let output;
+test.serial("No replacement", async (t) => {
+	const {sinon} = t.context;
+	const input = `foo foo foo`;
 
 	const resource = {
-		getStream: () => {
-			const stream = new Readable();
-			const utf8stringAsBuffer = Buffer.from(utf8string, "utf8");
-			// Pushing each byte separately makes content unreadable
-			// if stream encoding is not set to utf8
-			// This might happen when reading large files with utf8 characters
-			stream.push(Buffer.from([utf8stringAsBuffer[0]]));
-			stream.push(Buffer.from([utf8stringAsBuffer[1]]));
-			stream.push(Buffer.from([utf8stringAsBuffer[2]]));
-			stream.push(Buffer.from([utf8stringAsBuffer[3]]));
-			stream.push(null);
-			return stream;
-		},
-		setStream: (outputStream) => {
-			output = getStringFromStream(outputStream);
-		}
+		getString: sinon.stub().resolves(input),
+		setString: sinon.stub()
 	};
 
 	const processedResources = await stringReplacer({
 		resources: [resource],
 		options: {
-			pattern: "n/a",
-			replacement: "n/a"
+			pattern: "bar",
+			replacement: "foo"
 		}
 	});
 
-	t.deepEqual(processedResources, [resource], "Input resource is returned");
-	t.deepEqual(await output, expected, "Correct file content should be set");
+	t.is(processedResources.length, 1, "Returned one resource");
+	t.is(processedResources[0], resource, "Input resource is returned");
+	t.is(resource.setString.callCount, 0, "Resource#setString did not get called");
+});
+
+test.serial("Replace using regular expression", async (t) => {
+	const {sinon} = t.context;
+	const input = `foo BAR foo`;
+	const expected = `foo foo foo`;
+
+	const resource = {
+		getString: sinon.stub().resolves(input),
+		setString: sinon.stub()
+	};
+
+	const processedResources = await stringReplacer({
+		resources: [resource],
+		options: {
+			pattern: /bar/ig,
+			replacement: "foo"
+		}
+	});
+
+	t.is(processedResources.length, 1, "Returned one resource");
+	t.is(processedResources[0], resource, "Input resource is returned");
+	t.is(resource.setString.callCount, 1, "Resource#setString got called once");
+	t.is(resource.setString.firstCall.firstArg, expected, "Resource#setString got called with expected argument");
+});
+
+test.serial("Regular expression requires global flag", async (t) => {
+	const {sinon} = t.context;
+	const input = `foo bar foo`;
+
+	const resource = {
+		getString: sinon.stub().resolves(input),
+		setString: sinon.stub()
+	};
+
+	await t.throwsAsync(stringReplacer({
+		resources: [resource],
+		options: {
+			pattern: /bar/i,
+			replacement: "foo"
+		}
+	}), {
+		message: "String.prototype.replaceAll called with a non-global RegExp argument"
+	}, "Threw with expected error message");
+});
+
+test.serial("Replaces string pattern with UTF8 characters", async (t) => {
+	const {sinon} = t.context;
+	const input = `早安`;
+	const expected = `午安`;
+
+	const resource = {
+		getString: sinon.stub().resolves(input),
+		setString: sinon.stub()
+	};
+
+	const processedResources = await stringReplacer({
+		resources: [resource],
+		options: {
+			pattern: /早/g,
+			replacement: "午"
+		}
+	});
+
+	t.is(processedResources.length, 1, "Returned one resource");
+	t.is(processedResources[0], resource, "Input resource is returned");
+	t.is(resource.setString.callCount, 1, "Resource#setString got called once");
+	t.is(resource.setString.firstCall.firstArg, expected, "Resource#setString got called with expected argument");
+});
+
+test.serial("Process multiple resources", async (t) => {
+	const {sinon} = t.context;
+
+	const resourceA = {
+		getString: sinon.stub().resolves("Resource A"),
+		setString: sinon.stub()
+	};
+	const resourceB = {
+		getString: sinon.stub().resolves("Resource B"),
+		setString: sinon.stub()
+	};
+	const resourceC = {
+		getString: sinon.stub().resolves("Resource 三"),
+		setString: sinon.stub()
+	};
+	const resourceD = {
+		getString: sinon.stub().resolves("Resource D"),
+		setString: sinon.stub()
+	};
+
+	const processedResources = await stringReplacer({
+		resources: [resourceA, resourceB, resourceC, resourceD],
+		options: {
+			pattern: /[B-D]/g,
+			replacement: "💎"
+		}
+	});
+
+	t.is(processedResources.length, 4, "Returned all four resources");
+	t.is(processedResources[0], resourceA, "Input resourceA is returned");
+	t.is(processedResources[1], resourceB, "Input resourceB is returned");
+	t.is(processedResources[2], resourceC, "Input resourceC is returned");
+	t.is(processedResources[3], resourceD, "Input resourceD is returned");
+	t.is(resourceA.setString.callCount, 0, "resourceA#setString did not get called");
+	t.is(resourceB.setString.callCount, 1, "resourceB#setString got called once");
+	t.is(resourceB.setString.firstCall.firstArg, "Resource 💎", "resourceB#setString got called with expected argument");
+	t.is(resourceC.setString.callCount, 0, "resourceC#setString did not get called");
+	t.is(resourceD.setString.callCount, 1, "resourceD#setString got called once");
+	t.is(resourceD.setString.firstCall.firstArg, "Resource 💎", "resourceD#setString got called with expected argument");
 });

--- a/test/lib/tasks/minify.js
+++ b/test/lib/tasks/minify.js
@@ -80,13 +80,21 @@ test();`;
 	t.deepEqual(await resSourceMap.getString(), expectedSourceMap, "Correct source map content");
 
 	t.is(taskUtil.setTag.callCount, 4, "taskUtil.setTag was called 4 times");
-	t.deepEqual(taskUtil.setTag.getCall(0).args, [res, "1️⃣"], "First taskUtil.setTag call with expected arguments");
-	t.deepEqual(taskUtil.setTag.getCall(1).args, [resDbg, "2️⃣"],
-		"Second taskUtil.setTag call with expected arguments");
-	t.deepEqual(taskUtil.setTag.getCall(2).args, [resSourceMap, "1️⃣"],
-		"Third taskUtil.setTag call with expected arguments");
-	t.deepEqual(taskUtil.setTag.getCall(3).args, [resSourceMap, "3️⃣"],
-		"Fourth taskUtil.setTag call with expected arguments");
+	t.is(taskUtil.setTag.getCall(0).args[0].getPath(), res.getPath(),
+		"First taskUtil.setTag call with expected first argument");
+	t.is(taskUtil.setTag.getCall(0).args[1], "1️⃣", "First taskUtil.setTag call with expected second argument");
+	t.is(taskUtil.setTag.getCall(1).args[0].getPath(), resDbg.getPath(),
+		"Second taskUtil.setTag call with expected first arguments");
+	t.is(taskUtil.setTag.getCall(1).args[1], "2️⃣",
+		"Second taskUtil.setTag call with expected second arguments");
+	t.is(taskUtil.setTag.getCall(2).args[0].getPath(), resSourceMap.getPath(),
+		"Third taskUtil.setTag call with expected first arguments");
+	t.is(taskUtil.setTag.getCall(2).args[1], "1️⃣",
+		"Third taskUtil.setTag call with expected second arguments");
+	t.is(taskUtil.setTag.getCall(3).args[0].getPath(), resSourceMap.getPath(),
+		"Fourth taskUtil.setTag call with expected first arguments");
+	t.is(taskUtil.setTag.getCall(3).args[1], "3️⃣",
+		"Fourth taskUtil.setTag call with expected second arguments");
 });
 
 test("integration: minify omitSourceMapResources=false", async (t) => {
@@ -145,11 +153,17 @@ ${SOURCE_MAPPING_URL}=test.js.map`;
 	t.deepEqual(await resSourceMap.getString(), expectedSourceMap, "Correct source map content");
 
 	t.is(taskUtil.setTag.callCount, 3, "taskUtil.setTag was called 3 times");
-	t.deepEqual(taskUtil.setTag.getCall(0).args, [res, "1️⃣"], "First taskUtil.setTag call with expected arguments");
-	t.deepEqual(taskUtil.setTag.getCall(1).args, [resDbg, "2️⃣"],
-		"Second taskUtil.setTag call with expected arguments");
-	t.deepEqual(taskUtil.setTag.getCall(2).args, [resSourceMap, "1️⃣"],
-		"Third taskUtil.setTag call with expected arguments");
+	t.is(taskUtil.setTag.getCall(0).args[0].getPath(), res.getPath(),
+		"First taskUtil.setTag call with expected first argument");
+	t.is(taskUtil.setTag.getCall(0).args[1], "1️⃣", "First taskUtil.setTag call with expected second argument");
+	t.is(taskUtil.setTag.getCall(1).args[0].getPath(), resDbg.getPath(),
+		"Second taskUtil.setTag call with expected first arguments");
+	t.is(taskUtil.setTag.getCall(1).args[1], "2️⃣",
+		"Second taskUtil.setTag call with expected second arguments");
+	t.is(taskUtil.setTag.getCall(2).args[0].getPath(), resSourceMap.getPath(),
+		"Third taskUtil.setTag call with expected first arguments");
+	t.is(taskUtil.setTag.getCall(2).args[1], "1️⃣",
+		"Third taskUtil.setTag call with expected second arguments");
 });
 
 test("integration: minify omitSourceMapResources=true (without taskUtil)", async (t) => {


### PR DESCRIPTION
This allows the processor to only modify a resource if necessary (as in,
a replacement has been applied). Currently, in a standard library build,
this processor is for example the only one to modify JSON files.
However, they often do not contain any of the searched placeholders.

https://github.com/SAP/ui5-fs/pull/472 will enable optimizations for
unmodified resources. So we strive for reducing unnecessary resource
modification across the whole tooling.