### PR TITLE
[INTERNAL] node 19 on windows: use 19.3.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ strategy:
       node_version: 19.x
     windows_node_current:
       imageName: 'windows-2022'
-      node_version: 19.5.0
+      node_version: 19.4.0
 
 pool:
   vmImage: $(imageName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ strategy:
       node_version: 19.x
     windows_node_current:
       imageName: 'windows-2022'
-      node_version: 19.x
+      node_version: 19.5.0
 
 pool:
   vmImage: $(imageName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ strategy:
       node_version: 19.x
     windows_node_current:
       imageName: 'windows-2022'
-      node_version: 19.4.0
+      node_version: 19.3.0
 
 pool:
   vmImage: $(imageName)


### PR DESCRIPTION
With node version 19.4.0 issues came up which might be fixed with a future node version.
Therefore downgrading to 19.3.0.
