### PR TITLE
[DEPENDENCY] Bump xml2js from 0.4.23 to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5901,9 +5901,9 @@
 			"dev": true
 		},
 		"xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
 			"requires": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
 		"rimraf": "^3.0.2",
 		"semver": "^7.3.8",
 		"terser": "^5.15.1",
-		"xml2js": "^0.4.23",
+		"xml2js": "^0.5.0",
 		"yazl": "^2.5.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
https://github.com/advisories/GHSA-776f-qx25-q3cc
