### PR TITLE
[INTERNAL] Support imported Core dependency when analyzing library.js

### DIFF
--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -25,8 +25,8 @@ async function analyze(resource) {
 		interfaces: []
 	};
 
-	function visit(node) {
-		if (isInitLibraryCall(node, resource)) {
+	function visit(node, sapUiDefineCall) {
+		if (isInitLibraryCall(node, sapUiDefineCall)) {
 			node.arguments[0].properties.forEach( (prop) => {
 				if (prop.type === Syntax.SpreadElement) {
 					// SpreadElements are currently not supported
@@ -64,11 +64,11 @@ async function analyze(resource) {
 		for ( const key of VisitorKeys[node.type] ) {
 			const child = node[key];
 			if ( Array.isArray(child) ) {
-				if ( child.some(visit) ) {
+				if ( child.some((c) => visit(c, sapUiDefineCall)) ) {
 					return true;
 				}
 			} else if ( child ) {
-				if ( visit(child) ) {
+				if ( visit(child, sapUiDefineCall) ) {
 					return true;
 				}
 			}
@@ -77,61 +77,78 @@ async function analyze(resource) {
 		return false;
 	}
 
+	function analyzeSapUiDefineCalls(node, resource) {
+		// Analyze sap.ui.define calls
+		let sapUiDefineCall;
+		if (
+			node.type === Syntax.CallExpression &&
+			node.callee.type === Syntax.MemberExpression
+		) {
+			sapUiDefineCall = new SapUiDefineCall(node, resource.getName());
+		}
+
+		if (sapUiDefineCall && sapUiDefineCall.dependencies) {
+			return sapUiDefineCall;
+		}
+
+		for (const key of VisitorKeys[node.type]) {
+			const child = node[key];
+			if (Array.isArray(child)) {
+				return child
+					.map((c) => analyzeSapUiDefineCalls(c, resource))
+					.filter((defineCall) => defineCall && defineCall.dependencies)[0];
+			} else if (child) {
+				return analyzeSapUiDefineCalls(child, resource);
+			}
+		}
+	}
+
+	/**
+	 * Determines whether the node is an initLibrary call.
+	 *
+	 * @param {Node} node
+	 * @param {SapUiDefineCall} sapUiDefineCall
+	 * @returns {boolean}
+	 */
+	function isInitLibraryCall(node, sapUiDefineCall) {
+		// sap.ui.getCore()
+		if (
+			node.type == Syntax.CallExpression &&
+			node.callee.type === Syntax.MemberExpression &&
+			isMethodCall(node.callee.object, CALL__SAP_UI_GETCORE) &&
+			isIdentifier(node.callee.property, "initLibrary") &&
+			node.arguments.length === 1 &&
+			node.arguments[0].type === Syntax.ObjectExpression
+		) {
+			return true;
+		}
+
+		// Find a CallExpression that is initLibrary
+		// i.e. node.callee.object === "Core" && node.callee.property === "initLibrary"
+		if (
+			node.type === Syntax.CallExpression &&
+			node.callee.type === Syntax.MemberExpression &&
+			sapUiDefineCall &&
+			AMD__LIB_INIT_RESOURCES.some((potentialDependency) =>
+				isIdentifier(node.callee.object,
+					sapUiDefineCall.findImportName(potentialDependency[0])) &&
+				isIdentifier(node.callee.property, potentialDependency[1])
+			) &&
+			node.arguments.length === 1 &&
+			node.arguments[0].type === Syntax.ObjectExpression
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
 	const code = await resource.getBuffer();
-	visit( parseJS(code) );
+	const rootNode = parseJS(code);
+	const sapUiDefineCalls = analyzeSapUiDefineCalls(rootNode, resource);
+	visit( rootNode, sapUiDefineCalls );
 
 	return libInfo;
-}
-
-const sapUiDefineCalls = {};
-/**
- * Determines whether the node is an initLibrary call.
- *
- * @param {Node} node
- * @param {@ui5/fs/Resource} resource
- * @returns {boolean}
- */
-function isInitLibraryCall(node, resource) {
-	// sap.ui.getCore()
-	if (
-		node.type == Syntax.CallExpression &&
-		node.callee.type === Syntax.MemberExpression &&
-		isMethodCall(node.callee.object, CALL__SAP_UI_GETCORE) &&
-		isIdentifier(node.callee.property, "initLibrary") &&
-		node.arguments.length === 1 &&
-		node.arguments[0].type === Syntax.ObjectExpression
-	) {
-		return true;
-	}
-
-	// Analyze sap.ui.define calls for every module
-	const resPath = resource.getPath();
-	if (
-		node.type === Syntax.CallExpression &&
-		node.callee.type === Syntax.MemberExpression &&
-		(!sapUiDefineCalls[resPath] || !sapUiDefineCalls[resPath].dependencies)
-	) {
-		sapUiDefineCalls[resPath] = new SapUiDefineCall(node, resource.getName());
-	}
-
-	// Find a CallExpression that is initLibrary
-	// i.e. node.callee.object === "Core" && node.callee.property === "initLibrary"
-	if (
-		node.type === Syntax.CallExpression &&
-		node.callee.type === Syntax.MemberExpression &&
-		sapUiDefineCalls[resPath] &&
-		AMD__LIB_INIT_RESOURCES.some((potentialDependency) =>
-			isIdentifier(node.callee.object,
-				sapUiDefineCalls[resPath].findImportName(potentialDependency[0])) &&
-			isIdentifier(node.callee.property, potentialDependency[1])
-		) &&
-		node.arguments.length === 1 &&
-		node.arguments[0].type === Syntax.ObjectExpression
-	) {
-		return true;
-	}
-
-	return false;
 }
 
 /**

--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -77,6 +77,13 @@ async function analyze(resource) {
 		return false;
 	}
 
+	/**
+	 * Finds and extracts dependencies from sap.ui.define call
+	 *
+	 * @param {Node} node
+	 * @param {@ui5/fs/Resource} resource
+	 * @returns {SapUiDefineCall}
+	 */
 	function analyzeSapUiDefineCalls(node, resource) {
 		// Analyze sap.ui.define calls
 		let sapUiDefineCall;

--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -1,15 +1,16 @@
 
 import {parseJS, Syntax, VisitorKeys} from "../utils/parseUtils.js";
 import {getPropertyKey, isMethodCall, isIdentifier, getStringArray} from "../utils/ASTUtils.js";
+import SapUiDefineCall from "../calls/SapUiDefine.js";
 import {getLogger} from "@ui5/logger";
 const log = getLogger("lbt:analyzer:LibraryJS");
 
 const CALL__SAP_UI_GETCORE = ["sap", "ui", "getCore"];
-const AMD__LIB_INIT_RESOURCES = {
-	// Depenedency definition: inti library method name
-	"sap/ui/core/Core": "initLibrary",
-	"sap/ui/core/Lib": "init",
-};
+const AMD__LIB_INIT_RESOURCES = [
+	// Depenedency definition, initi library method name
+	["sap/ui/core/Core.js", "initLibrary"],
+	["sap/ui/core/Lib.js", "init"]
+];
 
 /*
  * Static Code Analyzer that extracts library information from the sap.ui.getCore().initLibrary()
@@ -25,7 +26,7 @@ async function analyze(resource) {
 	};
 
 	function visit(node) {
-		if (isInitLibraryCall(node)) {
+		if (isInitLibraryCall(node, resource)) {
 			node.arguments[0].properties.forEach( (prop) => {
 				if (prop.type === Syntax.SpreadElement) {
 					// SpreadElements are currently not supported
@@ -82,14 +83,15 @@ async function analyze(resource) {
 	return libInfo;
 }
 
-const initLibraryDefintions = [];
+const sapUiDefineCalls = {};
 /**
- * Determines whether the node is a initLibrary call.
+ * Determines whether the node is an initLibrary call.
  *
  * @param {Node} node
+ * @param {@ui5/fs/Resource} resource
  * @returns {boolean}
  */
-function isInitLibraryCall(node) {
+function isInitLibraryCall(node, resource) {
 	// sap.ui.getCore()
 	if (
 		node.type == Syntax.CallExpression &&
@@ -102,30 +104,26 @@ function isInitLibraryCall(node) {
 		return true;
 	}
 
-	// Find whether there's potential initLibrary() dependency in AMD i.e. "sap/ui/core/Core"
-	if (node.type === Syntax.Program && !initLibraryDefintions.length) {
-		const amdDepDefinitions = node.body[0]?.expression?.arguments[0]?.elements;
-		const amdFnArguments = node.body[0]?.expression?.arguments[1]?.params || [];
-
-		for (let i = 0; i < amdFnArguments.length; i++) {
-			const fnArgName = amdFnArguments[i].name; // Name of the variable
-			const amdDef = amdDepDefinitions[i].value;
-			if (AMD__LIB_INIT_RESOURCES[amdDef]) {
-				// Add just the ones that are available
-				initLibraryDefintions.push([fnArgName, AMD__LIB_INIT_RESOURCES[amdDef]]);
-			}
-		}
-	}
-
-	// Find a CallExpression with the names that match the
-	// library initialization methods
+	// Analyze sap.ui.define calls for every module
+	const resPath = resource.getPath();
 	if (
 		node.type === Syntax.CallExpression &&
 		node.callee.type === Syntax.MemberExpression &&
-		// Filtered list of [["Library", "init"], ["Core", "initLibrary"]]
-		initLibraryDefintions.some((libArgs) =>
-			isMethodCall(node, libArgs) &&
-			isIdentifier(node.callee.property, libArgs[1])
+		(!sapUiDefineCalls[resPath] || !sapUiDefineCalls[resPath].dependencies)
+	) {
+		sapUiDefineCalls[resPath] = new SapUiDefineCall(node, resource.getName());
+	}
+
+	// Find a CallExpression that is initLibrary
+	// i.e. node.callee.object === "Core" && node.callee.property === "initLibrary"
+	if (
+		node.type === Syntax.CallExpression &&
+		node.callee.type === Syntax.MemberExpression &&
+		sapUiDefineCalls[resPath] &&
+		AMD__LIB_INIT_RESOURCES.some((potentialDependency) =>
+			isIdentifier(node.callee.object,
+				sapUiDefineCalls[resPath].findImportName(potentialDependency[0])) &&
+			isIdentifier(node.callee.property, potentialDependency[1])
 		) &&
 		node.arguments.length === 1 &&
 		node.arguments[0].type === Syntax.ObjectExpression

--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -7,7 +7,7 @@ const log = getLogger("lbt:analyzer:LibraryJS");
 
 const CALL__SAP_UI_GETCORE = ["sap", "ui", "getCore"];
 const AMD__LIB_INIT_RESOURCES = [
-	// Depenedency definition, initi library method name
+	// Depenedency definition, init library method name
 	["sap/ui/core/Core.js", "initLibrary"],
 	["sap/ui/core/Lib.js", "init"]
 ];

--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -6,6 +6,8 @@ import {getLogger} from "@ui5/logger";
 const log = getLogger("lbt:analyzer:LibraryJS");
 
 const CALL__SAP_UI_GETCORE = ["sap", "ui", "getCore"];
+const CALL_SAP_UI_DEFINE = ["sap", "ui", "define"];
+const CALL_AMD_DEFINE = ["define"];
 const AMD__LIB_INIT_RESOURCES = [
 	// Depenedency definition, init library method name
 	["sap/ui/core/Core.js", "initLibrary"],
@@ -94,19 +96,12 @@ async function analyze(resource) {
 	 */
 	function analyzeSapUiDefineCalls(node) {
 		// Analyze sap.ui.define calls
-		let defineCall;
-		if (
-			node.type === Syntax.CallExpression &&
-			node.callee.type === Syntax.MemberExpression
-		) {
-			defineCall = new SapUiDefineCall(node, resource.getName());
+		if ( [CALL_AMD_DEFINE, CALL_SAP_UI_DEFINE].some(
+			(defCall) => isMethodCall(node, defCall)) ) {
+			return new SapUiDefineCall(node, resource.getName());
 		}
 
-		if (defineCall && defineCall.dependencies) {
-			return defineCall;
-		} else {
-			return null;
-		}
+		return null;
 	}
 
 	/**
@@ -135,9 +130,10 @@ async function analyze(resource) {
 			node.callee.type === Syntax.MemberExpression &&
 			sapUiDefineCall &&
 			AMD__LIB_INIT_RESOURCES.some((potentialDependency) =>
-				isIdentifier(node.callee.object,
-					sapUiDefineCall.findImportName(potentialDependency[0])) &&
-				isIdentifier(node.callee.property, potentialDependency[1])
+				isMethodCall(node, [
+					sapUiDefineCall.findImportName(potentialDependency[0]),
+					potentialDependency[1],
+				])
 			) &&
 			node.arguments.length === 1 &&
 			node.arguments[0].type === Syntax.ObjectExpression

--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -9,7 +9,7 @@ const CALL__SAP_UI_GETCORE = ["sap", "ui", "getCore"];
 const CALL_SAP_UI_DEFINE = ["sap", "ui", "define"];
 const CALL_AMD_DEFINE = ["define"];
 const AMD__LIB_INIT_RESOURCES = [
-	// Depenedency definition, init library method name
+	// Dependency definition, init library method name
 	["sap/ui/core/Core.js", "initLibrary"],
 	["sap/ui/core/Lib.js", "init"]
 ];
@@ -33,7 +33,7 @@ async function analyze(resource) {
 	visit( rootNode );
 
 	function visit(node) {
-		// Define call would always be at the top of th tree, so it'd
+		// Define call would always be at the top of the tree, so it'd
 		// be the first significant thing that's been found.
 		sapUiDefineCall = sapUiDefineCall || analyzeSapUiDefineCalls(node);
 
@@ -131,6 +131,9 @@ async function analyze(resource) {
 			sapUiDefineCall &&
 			AMD__LIB_INIT_RESOURCES.some((potentialDependency) =>
 				isMethodCall(node, [
+					// The variable name could differ. The important thing is the
+					// declared depenendency. i.e. "sap/ui/core/Core".
+					// The var name is extracted here.
 					sapUiDefineCall.findImportName(potentialDependency[0]),
 					potentialDependency[1],
 				])

--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -27,10 +27,14 @@ async function analyze(resource) {
 
 	const code = await resource.getBuffer();
 	const rootNode = parseJS(code);
-	const sapUiDefineCall = analyzeSapUiDefineCalls(rootNode);
+	let sapUiDefineCall = null;
 	visit( rootNode );
 
 	function visit(node) {
+		// Define call would always be at the top of th tree, so it'd
+		// be the first significant thing that's been found.
+		sapUiDefineCall = sapUiDefineCall || analyzeSapUiDefineCalls(node);
+
 		if (isInitLibraryCall(node)) {
 			node.arguments[0].properties.forEach( (prop) => {
 				if (prop.type === Syntax.SpreadElement) {
@@ -100,17 +104,8 @@ async function analyze(resource) {
 
 		if (defineCall && defineCall.dependencies) {
 			return defineCall;
-		}
-
-		for (const key of VisitorKeys[node.type]) {
-			const child = node[key];
-			if (Array.isArray(child)) {
-				return child
-					.map(analyzeSapUiDefineCalls)
-					.filter((potentialCall) => potentialCall && potentialCall.dependencies)[0];
-			} else if (child) {
-				return analyzeSapUiDefineCalls(child);
-			}
+		} else {
+			return null;
 		}
 	}
 

--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -29,47 +29,49 @@ async function analyze(resource) {
 
 	const code = await resource.getBuffer();
 	const rootNode = parseJS(code);
-	let sapUiDefineCall = null;
+	let analyzedDefineCall = null;
 	visit( rootNode );
 
 	function visit(node) {
-		// Define call would always be at the top of the tree, so it'd
-		// be the first significant thing that's been found.
-		sapUiDefineCall = sapUiDefineCall || analyzeSapUiDefineCalls(node);
+		if ( node.type === Syntax.CallExpression ) {
+			// Define call would always be at the top of the tree, so it'd
+			// be the first significant thing that's been found.
+			analyzedDefineCall = analyzedDefineCall || analyzeSapUiDefineCalls(node);
 
-		if (isInitLibraryCall(node)) {
-			node.arguments[0].properties.forEach( (prop) => {
-				if (prop.type === Syntax.SpreadElement) {
-					// SpreadElements are currently not supported
-					return;
-				}
+			if (isInitLibraryCall(node)) {
+				node.arguments[0].properties.forEach( (prop) => {
+					if (prop.type === Syntax.SpreadElement) {
+						// SpreadElements are currently not supported
+						return;
+					}
 
-				const key = getPropertyKey(prop);
-				const value = prop.value;
+					const key = getPropertyKey(prop);
+					const value = prop.value;
 
-				if ( key === "noLibraryCSS" &&
-						(value.type === Syntax.Literal && typeof value.value === "boolean") ) {
-					libInfo.noLibraryCSS = value.value;
-				} else if ( key === "types" && value.type == Syntax.ArrayExpression ) {
-					libInfo.types = getStringArray(value, true);
-				} else if ( key === "interfaces" && value.type == Syntax.ArrayExpression ) {
-					libInfo.interfaces = getStringArray(value, true);
-				} else if ( key === "controls" && value.type == Syntax.ArrayExpression ) {
-					libInfo.controls = getStringArray(value, true);
-				} else if ( key === "elements" && value.type == Syntax.ArrayExpression ) {
-					libInfo.elements = getStringArray(value, true);
-				} else if ( ["designtime", "dependencies", "extensions", "name", "version"].includes(key) ) {
-					// do nothing, for all other supported properties
-				} else {
-					log.error(
-						"Unexpected property '" + key +
-						"' or wrong type for '" + key +
-						"' in sap.ui.getCore().initLibrary call in '" + resource.getPath() + "'"
-					);
-				}
-			});
+					if ( key === "noLibraryCSS" &&
+							(value.type === Syntax.Literal && typeof value.value === "boolean") ) {
+						libInfo.noLibraryCSS = value.value;
+					} else if ( key === "types" && value.type == Syntax.ArrayExpression ) {
+						libInfo.types = getStringArray(value, true);
+					} else if ( key === "interfaces" && value.type == Syntax.ArrayExpression ) {
+						libInfo.interfaces = getStringArray(value, true);
+					} else if ( key === "controls" && value.type == Syntax.ArrayExpression ) {
+						libInfo.controls = getStringArray(value, true);
+					} else if ( key === "elements" && value.type == Syntax.ArrayExpression ) {
+						libInfo.elements = getStringArray(value, true);
+					} else if ( ["designtime", "dependencies", "extensions", "name", "version"].includes(key) ) {
+						// do nothing, for all other supported properties
+					} else {
+						log.error(
+							"Unexpected property '" + key +
+							"' or wrong type for '" + key +
+							"' in sap.ui.getCore().initLibrary call in '" + resource.getPath() + "'"
+						);
+					}
+				});
 
-			return true; // abort, we're done
+				return true; // abort, we're done
+			}
 		}
 
 		for ( const key of VisitorKeys[node.type] ) {
@@ -98,7 +100,13 @@ async function analyze(resource) {
 		// Analyze sap.ui.define calls
 		if ( [CALL_AMD_DEFINE, CALL_SAP_UI_DEFINE].some(
 			(defCall) => isMethodCall(node, defCall)) ) {
-			return new SapUiDefineCall(node, resource.getName());
+			const defCall = new SapUiDefineCall(node, resource.getName());
+
+			return AMD__LIB_INIT_RESOURCES
+				// Resolve dependency variable names.
+				.map((dependency) => [defCall.findImportName(dependency[0]), dependency[1]])
+				// Remove potential dependencies that are not actually present.
+				.filter((dependency) => dependency[0]);
 		}
 
 		return null;
@@ -128,15 +136,9 @@ async function analyze(resource) {
 		if (
 			node.type === Syntax.CallExpression &&
 			node.callee.type === Syntax.MemberExpression &&
-			sapUiDefineCall &&
-			AMD__LIB_INIT_RESOURCES.some((potentialDependency) =>
-				isMethodCall(node, [
-					// The variable name could differ. The important thing is the
-					// declared depenendency. i.e. "sap/ui/core/Core".
-					// The var name is extracted here.
-					sapUiDefineCall.findImportName(potentialDependency[0]),
-					potentialDependency[1],
-				])
+			analyzedDefineCall &&
+			analyzedDefineCall.some((potentialDependency) =>
+				isMethodCall(node, potentialDependency)
 			) &&
 			node.arguments.length === 1 &&
 			node.arguments[0].type === Syntax.ObjectExpression

--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -5,6 +5,11 @@ import {getLogger} from "@ui5/logger";
 const log = getLogger("lbt:analyzer:LibraryJS");
 
 const CALL__SAP_UI_GETCORE = ["sap", "ui", "getCore"];
+const AMD__LIB_INIT_RESOURCES = {
+	// Depenedency definition: inti library method name
+	"sap/ui/core/Core": "initLibrary",
+	"sap/ui/core/Lib": "init",
+};
 
 /*
  * Static Code Analyzer that extracts library information from the sap.ui.getCore().initLibrary()
@@ -20,12 +25,7 @@ async function analyze(resource) {
 	};
 
 	function visit(node) {
-		if ( node.type == Syntax.CallExpression &&
-				node.callee.type === Syntax.MemberExpression &&
-				isMethodCall(node.callee.object, CALL__SAP_UI_GETCORE) &&
-				isIdentifier(node.callee.property, "initLibrary") &&
-				node.arguments.length === 1 &&
-				node.arguments[0].type === Syntax.ObjectExpression ) {
+		if (isInitLibraryCall(node)) {
 			node.arguments[0].properties.forEach( (prop) => {
 				if (prop.type === Syntax.SpreadElement) {
 					// SpreadElements are currently not supported
@@ -80,6 +80,60 @@ async function analyze(resource) {
 	visit( parseJS(code) );
 
 	return libInfo;
+}
+
+const initLibraryDefintions = [];
+/**
+ * Determines whether the node is a initLibrary call.
+ *
+ * @param {Node} node
+ * @returns {boolean}
+ */
+function isInitLibraryCall(node) {
+	// sap.ui.getCore()
+	if (
+		node.type == Syntax.CallExpression &&
+		node.callee.type === Syntax.MemberExpression &&
+		isMethodCall(node.callee.object, CALL__SAP_UI_GETCORE) &&
+		isIdentifier(node.callee.property, "initLibrary") &&
+		node.arguments.length === 1 &&
+		node.arguments[0].type === Syntax.ObjectExpression
+	) {
+		return true;
+	}
+
+	// Find whether there's potential initLibrary() dependency in AMD i.e. "sap/ui/core/Core"
+	if (node.type === Syntax.Program && !initLibraryDefintions.length) {
+		const amdDepDefinitions = node.body[0].expression.arguments[0].elements;
+		const amdFnArguments = node.body[0].expression.arguments[1].params;
+
+		for (let i = 0; i < amdFnArguments.length; i++) {
+			const fnArgName = amdFnArguments[i].name; // Name of the variable
+			const amdDef = amdDepDefinitions[i].value;
+			if (AMD__LIB_INIT_RESOURCES[amdDef]) {
+				// Add just the ones that are available
+				initLibraryDefintions.push([fnArgName, AMD__LIB_INIT_RESOURCES[amdDef]]);
+			}
+		}
+	}
+
+	// Find a CallExpression with the names that match the
+	// library initialization methods
+	if (
+		node.type === Syntax.CallExpression &&
+		node.callee.type === Syntax.MemberExpression &&
+		// Filtered list of [["Library", "init"], ["Core", "initLibrary"]]
+		initLibraryDefintions.some((libArgs) =>
+			isMethodCall(node, libArgs) &&
+			isIdentifier(node.callee.property, libArgs[1])
+		) &&
+		node.arguments.length === 1 &&
+		node.arguments[0].type === Syntax.ObjectExpression
+	) {
+		return true;
+	}
+
+	return false;
 }
 
 /**

--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -25,8 +25,13 @@ async function analyze(resource) {
 		interfaces: []
 	};
 
-	function visit(node, sapUiDefineCall) {
-		if (isInitLibraryCall(node, sapUiDefineCall)) {
+	const code = await resource.getBuffer();
+	const rootNode = parseJS(code);
+	const sapUiDefineCall = analyzeSapUiDefineCalls(rootNode);
+	visit( rootNode );
+
+	function visit(node) {
+		if (isInitLibraryCall(node)) {
 			node.arguments[0].properties.forEach( (prop) => {
 				if (prop.type === Syntax.SpreadElement) {
 					// SpreadElements are currently not supported
@@ -64,11 +69,11 @@ async function analyze(resource) {
 		for ( const key of VisitorKeys[node.type] ) {
 			const child = node[key];
 			if ( Array.isArray(child) ) {
-				if ( child.some((c) => visit(c, sapUiDefineCall)) ) {
+				if ( child.some(visit) ) {
 					return true;
 				}
 			} else if ( child ) {
-				if ( visit(child, sapUiDefineCall) ) {
+				if ( visit(child) ) {
 					return true;
 				}
 			}
@@ -81,31 +86,30 @@ async function analyze(resource) {
 	 * Finds and extracts dependencies from sap.ui.define call
 	 *
 	 * @param {Node} node
-	 * @param {@ui5/fs/Resource} resource
 	 * @returns {SapUiDefineCall}
 	 */
-	function analyzeSapUiDefineCalls(node, resource) {
+	function analyzeSapUiDefineCalls(node) {
 		// Analyze sap.ui.define calls
-		let sapUiDefineCall;
+		let defineCall;
 		if (
 			node.type === Syntax.CallExpression &&
 			node.callee.type === Syntax.MemberExpression
 		) {
-			sapUiDefineCall = new SapUiDefineCall(node, resource.getName());
+			defineCall = new SapUiDefineCall(node, resource.getName());
 		}
 
-		if (sapUiDefineCall && sapUiDefineCall.dependencies) {
-			return sapUiDefineCall;
+		if (defineCall && defineCall.dependencies) {
+			return defineCall;
 		}
 
 		for (const key of VisitorKeys[node.type]) {
 			const child = node[key];
 			if (Array.isArray(child)) {
 				return child
-					.map((c) => analyzeSapUiDefineCalls(c, resource))
-					.filter((defineCall) => defineCall && defineCall.dependencies)[0];
+					.map(analyzeSapUiDefineCalls)
+					.filter((potentialCall) => potentialCall && potentialCall.dependencies)[0];
 			} else if (child) {
-				return analyzeSapUiDefineCalls(child, resource);
+				return analyzeSapUiDefineCalls(child);
 			}
 		}
 	}
@@ -114,10 +118,9 @@ async function analyze(resource) {
 	 * Determines whether the node is an initLibrary call.
 	 *
 	 * @param {Node} node
-	 * @param {SapUiDefineCall} sapUiDefineCall
 	 * @returns {boolean}
 	 */
-	function isInitLibraryCall(node, sapUiDefineCall) {
+	function isInitLibraryCall(node) {
 		// sap.ui.getCore()
 		if (
 			node.type == Syntax.CallExpression &&
@@ -149,11 +152,6 @@ async function analyze(resource) {
 
 		return false;
 	}
-
-	const code = await resource.getBuffer();
-	const rootNode = parseJS(code);
-	const sapUiDefineCalls = analyzeSapUiDefineCalls(rootNode, resource);
-	visit( rootNode, sapUiDefineCalls );
 
 	return libInfo;
 }

--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -65,7 +65,7 @@ async function analyze(resource) {
 						log.error(
 							"Unexpected property '" + key +
 							"' or wrong type for '" + key +
-							"' in sap.ui.getCore().initLibrary call in '" + resource.getPath() + "'"
+							"' for a library initalization call in '" + resource.getPath() + "'"
 						);
 					}
 				});

--- a/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -104,8 +104,8 @@ function isInitLibraryCall(node) {
 
 	// Find whether there's potential initLibrary() dependency in AMD i.e. "sap/ui/core/Core"
 	if (node.type === Syntax.Program && !initLibraryDefintions.length) {
-		const amdDepDefinitions = node.body[0].expression.arguments[0].elements;
-		const amdFnArguments = node.body[0].expression.arguments[1].params;
+		const amdDepDefinitions = node.body[0]?.expression?.arguments[0]?.elements;
+		const amdFnArguments = node.body[0]?.expression?.arguments[1]?.params || [];
 
 		for (let i = 0; i < amdFnArguments.length; i++) {
 			const fnArgName = amdFnArguments[i].name; // Name of the variable

--- a/test/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/test/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -77,11 +77,11 @@ sap.ui.define([
 	t.is(errorLogStub.callCount, 2, "Error log is called twice");
 	t.is(errorLogStub.getCall(0).args[0],
 		"Unexpected property 'customProperty1' or wrong type for 'customProperty1'" +
-		" in sap.ui.getCore().initLibrary call in 'library/test/library.js'",
+		" for a library initalization call in 'library/test/library.js'",
 		"The error log message of the first call is correct");
 	t.is(errorLogStub.getCall(1).args[0],
 		"Unexpected property 'customProperty2' or wrong type for 'customProperty2'" +
-		" in sap.ui.getCore().initLibrary call in 'library/test/library.js'",
+		" for a library initalization call in 'library/test/library.js'",
 		"The error log message of the first call is correct");
 });
 

--- a/test/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/test/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -214,7 +214,7 @@ sap.ui.define([
 	t.is(result.elements[0], "library.test.MenuItem", "The libraryjs is correctly analyzed");
 });
 
-test.serial("analyze: library.js with unknonwn initLibrary call", async (t) => {
+test.serial("analyze: library.js with unknown initLibrary call", async (t) => {
 	const libraryJS = `
 sap.ui.define([
 	'sap/ui/core/Core',

--- a/test/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/test/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -154,3 +154,38 @@ sap.ui.define([
 	t.is(result.elements[0], "library.test.MenuItem", "The libraryjs is correctly analyzed");
 	t.true(result.noLibraryCSS, "The 'noLibraryCSS' property is correctly 'true'");
 });
+
+test.serial("analyze: library.js with AMD defined initLibrary", async (t) => {
+	const libraryJS = `
+sap.ui.define([
+	'sap/ui/core/Core',
+], function(Core) {
+	"use strict";
+	var thisLib = Core.initLibrary({
+		name : "library.test",
+		version: "1.0.0",
+		noLibraryCSS: true,
+		elements: [
+			"library.test.MenuItem"
+		],
+	});
+	return thisLib;
+});`;
+
+	const librayJSPath = "library/test/library.js";
+	const errorLogStub = sinon.stub();
+	const analyzeLibraryJSWithStubbedLogger = await esmock("../../../../lib/lbt/analyzer/analyzeLibraryJS", {
+		"@ui5/logger": {
+			getLogger: () => ({
+				error: errorLogStub
+			})
+		}
+	});
+
+	const mockResource = createMockResource(libraryJS, librayJSPath);
+
+	const result = await analyzeLibraryJSWithStubbedLogger(mockResource);
+
+	t.is(errorLogStub.callCount, 0, "Error log is not called");
+	t.is(result.elements[0], "library.test.MenuItem", "The libraryjs is correctly analyzed");
+});

--- a/test/lib/lbt/analyzer/analyzeLibraryJS.js
+++ b/test/lib/lbt/analyzer/analyzeLibraryJS.js
@@ -2,13 +2,16 @@ import test from "ava";
 import sinon from "sinon";
 import esmock from "esmock";
 
-function createMockResource(content, path) {
+function createMockResource(content, path, name = "library.js") {
 	return {
 		async getBuffer() {
 			return content;
 		},
 		getPath() {
 			return path;
+		},
+		getName() {
+			return name;
 		}
 	};
 }
@@ -172,6 +175,7 @@ sap.ui.define([
 	return thisLib;
 });`;
 
+	const librayName = "library.js";
 	const librayJSPath = "library/test/library.js";
 	const errorLogStub = sinon.stub();
 	const analyzeLibraryJSWithStubbedLogger = await esmock("../../../../lib/lbt/analyzer/analyzeLibraryJS", {
@@ -182,7 +186,7 @@ sap.ui.define([
 		}
 	});
 
-	const mockResource = createMockResource(libraryJS, librayJSPath);
+	const mockResource = createMockResource(libraryJS, librayJSPath, librayName);
 
 	const result = await analyzeLibraryJSWithStubbedLogger(mockResource);
 


### PR DESCRIPTION
JIRA: CPOUI5FOUNDATION-476

Analyzes library.js files for dependencies that might be able to initialize a UI5 library. Currently possible options now are:
- `sap.ui.getCore().initLibrary()`- already available
- 
  ```js 
  sap.ui.define(['sap/ui/core/Core',], function(Core) {
      var thisLib = Core.initLibrary({
      ...
  ```
- 
  ```js 
  sap.ui.define(['sap/ui/core/Lib',], function(Library) {
      var thisLib = Library.init({
      ...
  ```