### PR TITLE
[INTERNAL] Azure: Fix flaky tests on some Windows agents, set CI env variable 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,6 @@ steps:
     codeCoverageTool: 'cobertura'
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml'
 
-- script: npm run coverage
+- script: npm run coverage -- --no-worker-threads
   displayName: Run Test Natively in Case of Failures
   condition: failed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,9 @@ trigger:
 - v2
 - main
 
+variables:
+  CI: true
+
 strategy:
   matrix:
     linux_node_lts_16:

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"unit": "rimraf test/tmp && ava",
 		"unit-verbose": "rimraf test/tmp && cross-env UI5_LOG_LVL=verbose ava --verbose --serial",
 		"unit-watch": "rimraf test/tmp && ava --watch",
-		"unit-xunit": "rimraf test/tmp && ava --node-arguments=\"--experimental-loader=@istanbuljs/esm-loader-hook\" --tap --timeout=1m | tap-xunit --dontUseCommentsAsTestNames=true > test-results.xml",
+		"unit-xunit": "rimraf test/tmp && ava --no-worker-threads --node-arguments=\"--experimental-loader=@istanbuljs/esm-loader-hook\" --tap --timeout=1m | tap-xunit --dontUseCommentsAsTestNames=true > test-results.xml",
 		"unit-inspect": "cross-env UI5_LOG_LVL=verbose ava debug --break",
 		"coverage": "rimraf test/tmp && nyc ava --node-arguments=\"--experimental-loader=@istanbuljs/esm-loader-hook\"",
 		"coverage-xunit": "nyc --reporter=text --reporter=text-summary --reporter=cobertura npm run unit-xunit",


### PR DESCRIPTION
This is to workaround for the `FATAL ERROR: v8::FromJust Maybe value is Nothing.` errors we see for some of our Windows and macOS test executions on Azure.

The error is sporadic, but most consistently appears on Windows 2022 (Azure image '20230630.1.0' and Node v18.16.1.

https://github.com/avajs/ava/issues/2947 seems to suggest this is a Node.js issue as reported at https://github.com/nodejs/node/issues/43304

Disabling the use of our own worker threads in minifier.js resolve the issue. Disabling worker threads in AVA resolves it too.

Since we want to test our worker threads, we opted for the latter by setting the AVA option '--no-worker-threads' for all scripts executed in Azure.

All this indicates an issue with using worker threads (or the workerpool package) from within workers.

Also set the CI env variable for AVA to detect and make good use of.