### PR TITLE
[INTERNAL] Fix unit/coverage setup on Node 20 and adapt CI matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,13 +29,13 @@ strategy:
       node_version: 18.x
     linux_node_current:
       imageName: 'ubuntu-22.04'
-      node_version: 19.x
+      node_version: 20.x
     mac_node_current:
       imageName: 'macos-12'
-      node_version: 19.x
+      node_version: 20.x
     windows_node_current:
       imageName: 'windows-2022'
-      node_version: 19.3.0
+      node_version: 20.x
 
 pool:
   vmImage: $(imageName)
@@ -69,6 +69,6 @@ steps:
     codeCoverageTool: 'cobertura'
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml'
 
-- script: npm run coverage -- --no-worker-threads
+- script: npm run coverage
   displayName: Run Test Natively in Case of Failures
   condition: failed()

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"unit": "rimraf test/tmp && ava",
 		"unit-verbose": "rimraf test/tmp && cross-env UI5_LOG_LVL=verbose ava --verbose --serial",
 		"unit-watch": "rimraf test/tmp && ava --watch",
-		"unit-xunit": "rimraf test/tmp && ava --no-worker-threads --node-arguments=\"--experimental-loader=@istanbuljs/esm-loader-hook\" --tap --timeout=1m | tap-xunit --dontUseCommentsAsTestNames=true > test-results.xml",
+		"unit-xunit": "rimraf test/tmp && ava --node-arguments=\"--experimental-loader=@istanbuljs/esm-loader-hook\" --tap --timeout=1m | tap-xunit --dontUseCommentsAsTestNames=true > test-results.xml",
 		"unit-inspect": "cross-env UI5_LOG_LVL=verbose ava debug --break",
 		"coverage": "rimraf test/tmp && nyc ava --node-arguments=\"--experimental-loader=@istanbuljs/esm-loader-hook\"",
 		"coverage-xunit": "nyc --reporter=text --reporter=text-summary --reporter=cobertura npm run unit-xunit",
@@ -69,7 +69,8 @@
 		"nodeArguments": [
 			"--loader=esmock",
 			"--no-warnings"
-		]
+		],
+		"workerThreads": false
 	},
 	"nyc": {
 		"reporter": [


### PR DESCRIPTION
AVA's nodeArguments option doesn't seem to work with loaders on Node 20.
One solution is to disable worker threads to use child processes instead.

This solution has anyways already been applied via https://github.com/SAP/ui5-builder/pull/921
and is now enabled for all test executions.

JIRA: CPOUI5FOUNDATION-612
