### PR TITLE
[FIX] generateJsdoc: Also process resources created by preceeding tasks

### DIFF
--- a/lib/tasks/jsdoc/generateJsdoc.js
+++ b/lib/tasks/jsdoc/generateJsdoc.js
@@ -154,12 +154,7 @@ const utils = {
 			virBasePath: "/resources/"
 		});
 
-		let allResources;
-		if (workspace.byGlobSource) { // API only available on duplex collections
-			allResources = await workspace.byGlobSource(pattern);
-		} else {
-			allResources = await workspace.byGlob(pattern);
-		}
+		const allResources = await workspace.byGlob(pattern);
 
 		// write all resources to the tmp folder
 		await Promise.all(allResources.map((resource) => fsTarget.write(resource)));

--- a/test/lib/tasks/jsdoc/generateJsdoc.js
+++ b/test/lib/tasks/jsdoc/generateJsdoc.js
@@ -114,7 +114,7 @@ test.serial("createTmpDirs", async (t) => {
 		"Cleanup callback: rimraf called with correct path");
 });
 
-test.serial("writeResourcesToDir with byGlobSource", async (t) => {
+test.serial("writeResourcesToDir with byGlob even if byGlobSource is available", async (t) => {
 	const {generateJsdoc, createAdapterStub, writeStub} = t.context;
 	const generateJsdocUtils = generateJsdoc._utils;
 
@@ -122,6 +122,9 @@ test.serial("writeResourcesToDir with byGlobSource", async (t) => {
 		workspace: {
 			// stub byGlobSource
 			byGlobSource: (pattern) => {
+				throw new Error("Unexpected call to byGlobSource");
+			},
+			byGlob: (pattern) => {
 				t.is(pattern, "some pattern", "Glob with correct pattern");
 				return Promise.resolve(["resource A", "resource B"]);
 			}


### PR DESCRIPTION
End the use of byGlobSource and alwasy use byGlob. None of the standard
tasks executed before it add any resources. So no overhead is to be
expected from this.

On the other hand, the use of custom task extensions (for exmaple for
transpilation) requires the generateJsdoc to process resources the task
has created.

This was the last usage of the byGlobSource API of the DuplexCollection.
Therefore the API shall be deprecated in ui5-fs and removed in the
future.