### PR TITLE
[INTERNAL] Bundler: Ignore non-JS resources when creating module name mapping

### DIFF
--- a/lib/tasks/bundlers/utils/createModuleNameMapping.js
+++ b/lib/tasks/bundlers/utils/createModuleNameMapping.js
@@ -18,8 +18,8 @@ export default function({resources, taskUtil}) {
 	const moduleNameMapping = Object.create(null);
 	for (let i = resources.length - 1; i >= 0; i--) {
 		const resource = resources[i];
-		if (taskUtil.getTag(resource, taskUtil.STANDARD_TAGS.IsDebugVariant)) {
-			const resourcePath = resource.getPath();
+		const resourcePath = resource.getPath();
+		if (resourcePath.endsWith(".js") && taskUtil.getTag(resource, taskUtil.STANDARD_TAGS.IsDebugVariant)) {
 			const nonDbgPath = getNonDebugName(resourcePath);
 			if (!nonDbgPath) {
 				throw new Error(`Failed to resolve non-debug name for ${resourcePath}`);

--- a/test/lib/tasks/bundlers/generateBundle.js
+++ b/test/lib/tasks/bundlers/generateBundle.js
@@ -307,13 +307,10 @@ test.serial("generateBundle: bundleOptions: optimize=false, with taskUtil", asyn
 	t.deepEqual(filteredCombo.byGlob.getCall(0).args, ["/resources/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"filteredCombo.byGlob should have been called with expected pattern");
 
-	t.is(taskUtil.getTag.callCount, 2);
+	t.is(taskUtil.getTag.callCount, 1, "taskUtil#getTag has been called once");
 	t.deepEqual(taskUtil.getTag.getCall(0).args,
-		[resources[1], taskUtil.STANDARD_TAGS.IsDebugVariant],
-		"First resource should be checked whether it is a debug variant");
-	t.deepEqual(taskUtil.getTag.getCall(1).args,
 		[resources[0], taskUtil.STANDARD_TAGS.IsDebugVariant],
-		"Second resource should be checked whether it is a debug variant");
+		"First resource should be checked whether it is a debug variant");
 
 	t.is(taskUtil.clearTag.callCount, 1);
 	t.deepEqual(taskUtil.clearTag.getCall(0).args,

--- a/test/lib/tasks/bundlers/generateLibraryPreload.js
+++ b/test/lib/tasks/bundlers/generateLibraryPreload.js
@@ -456,7 +456,7 @@ test.serial("generateLibraryPreload for sap.ui.core (/w ui5loader.js)", async (t
 	});
 
 	t.is(workspace.byGlob.callCount, 3,
-		"workspace.byGlob should have been called three");
+		"workspace.byGlob should have been called three times");
 	t.deepEqual(workspace.byGlob.getCall(0).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
 		"workspace.byGlob should have been called with expected pattern");
 	t.deepEqual(workspace.byGlob.getCall(1).args, ["/**/*.{js,json,xml,html,properties,library,js.map}"],
@@ -464,7 +464,7 @@ test.serial("generateLibraryPreload for sap.ui.core (/w ui5loader.js)", async (t
 	t.deepEqual(workspace.byGlob.getCall(2).args, ["/resources/**/.library"],
 		"workspace.byGlob should have been called with expected pattern");
 
-	t.is(taskUtil.getTag.callCount, 3, "TaskUtil#getTag got called three times");
+	t.is(taskUtil.getTag.callCount, 2, "TaskUtil#getTag got called two times");
 	t.is(taskUtil.getTag.getCall(0).args[0], resources[2],
 		"TaskUtil#getTag got called with expected resource on first call");
 	t.is(taskUtil.getTag.getCall(0).args[1], "<IsDebugVariant>",
@@ -473,10 +473,6 @@ test.serial("generateLibraryPreload for sap.ui.core (/w ui5loader.js)", async (t
 		"TaskUtil#getTag got called with expected resource on second call");
 	t.is(taskUtil.getTag.getCall(1).args[1], "<IsDebugVariant>",
 		"TaskUtil#getTag got called with expected tag on second call");
-	t.is(taskUtil.getTag.getCall(2).args[0], resources[0],
-		"TaskUtil#getTag got called with expected resource on third call");
-	t.is(taskUtil.getTag.getCall(2).args[1], "<IsDebugVariant>",
-		"TaskUtil#getTag got called with expected tag on third call");
 
 	t.is(moduleBundlerStub.callCount, 7, "moduleBundler should have been called 7 times");
 	t.deepEqual(moduleBundlerStub.getCall(0).args, [{

--- a/test/lib/tasks/bundlers/utils/createModuleNameMapping.js
+++ b/test/lib/tasks/bundlers/utils/createModuleNameMapping.js
@@ -1,0 +1,51 @@
+import test from "ava";
+import sinonGlobal from "sinon";
+import createModuleNameMapping from "../../../../../lib/tasks/bundlers/utils/createModuleNameMapping.js";
+
+test.beforeEach((t) => {
+	const sinon = t.context.sinon = sinonGlobal.createSandbox();
+	t.context.taskUtil = {
+		getTag: sinon.stub(),
+		STANDARD_TAGS: {
+			IsDebugVariant: "🦄",
+		},
+	};
+});
+test.afterEach.always((t) => {
+	t.context.sinon.restore();
+});
+
+test("createModuleNameMapping", (t) => {
+	const {taskUtil} = t.context;
+	taskUtil.getTag.callsFake((resource) => {
+		if (resource.getPath() === "/resources/Module.js") {
+			return false;
+		}
+		// All but the first shall be assumed debug variants
+		return true;
+	});
+	const resources = [{
+		getPath: () => "/resources/Module.js"
+	}, {
+		getPath: () => "/resources/Module-dbg.js"
+	}, {
+		getPath: () => "/resources/Module-dbg.js.map"
+	}, {
+		getPath: () => "/resources/Module-dbg-dbg.js"
+	}, {
+		getPath: () => "/resources/Module-dbg-dbg.js.map"
+	}, {
+		getPath: () => "/resources/Module.xml"
+	}, {
+		getPath: () => "/resources/Module.css"
+	}];
+	const res = createModuleNameMapping({
+		resources,
+		taskUtil
+	});
+
+	t.deepEqual(res, {
+		"/resources/Module-dbg-dbg.js": "Module-dbg.js",
+		"/resources/Module-dbg.js": "Module.js"
+	}, "Expected module name mapping");
+});


### PR DESCRIPTION
This leads to issues where non-JS resources tagged as "IsDebugVariant" (like source map resources) where processed since ModuleName#getNonDebugName can only handle .js and .css extensions.