### PR TITLE
[FIX] Handle graceful termination of workerpool for parallel builds

### DIFF
--- a/lib/processors/minifier.js
+++ b/lib/processors/minifier.js
@@ -39,9 +39,12 @@ function getPool(taskUtil) {
 
 				// There are many stats that could be used, but these ones seem the most
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.
-				const {idleWorkers, totalWorkers} = pool.stats();
+				let {idleWorkers, totalWorkers} = pool.stats();
 				while (idleWorkers !== totalWorkers && !force) {
 					await setTimeoutPromise(100); // Wait a bit workers to finish and try again
+					const stats = pool.stats();
+					idleWorkers = stats.idleWorkers;
+					totalWorkers = stats.totalWorkers;
 				}
 
 				const poolToBeTerminated = pool;

--- a/lib/processors/minifier.js
+++ b/lib/processors/minifier.js
@@ -42,9 +42,7 @@ function getPool(taskUtil) {
 				let {idleWorkers, totalWorkers} = pool.stats();
 				while (idleWorkers !== totalWorkers && !force) {
 					await setTimeoutPromise(100); // Wait a bit workers to finish and try again
-					const stats = pool.stats();
-					idleWorkers = stats.idleWorkers;
-					totalWorkers = stats.totalWorkers;
+					({idleWorkers, totalWorkers} = pool.stats());
 				}
 
 				const poolToBeTerminated = pool;

--- a/lib/processors/minifier.js
+++ b/lib/processors/minifier.js
@@ -40,9 +40,8 @@ function getPool(taskUtil) {
 				// There are many stats that could be used, but these ones seem the most
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.
 				const {idleWorkers, totalWorkers} = pool.stats();
-				if (idleWorkers !== totalWorkers && !force) {
+				while (idleWorkers !== totalWorkers && !force) {
 					await setTimeoutPromise(100); // Wait a bit workers to finish and try again
-					return attemptPoolTermination();
 				}
 
 				const poolToBeTerminated = pool;

--- a/lib/processors/minifier.js
+++ b/lib/processors/minifier.js
@@ -28,14 +28,20 @@ function getPool(taskUtil) {
 			workerType: "auto",
 			maxWorkers
 		});
-		taskUtil.registerCleanupTask(() => {
+		taskUtil.registerCleanupTask((options) => {
 			const attemptPoolTermination = () => {
 				log.verbose(`Attempt to terminate the workerpool...`);
+
+				if (!pool) {
+					return;
+				}
+
+				const forceTerminate = !!options && !!options.exitCode;
 
 				// There are many stats that could be used, but these ones seem the most
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.
 				const {idleWorkers, totalWorkers} = pool.stats();
-				if (idleWorkers !== totalWorkers) {
+				if (idleWorkers !== totalWorkers && !forceTerminate) {
 					return new Promise((resolve) =>
 						setTimeout(() => resolve(attemptPoolTermination()), 100) // Retry after a while
 					);
@@ -43,7 +49,7 @@ function getPool(taskUtil) {
 
 				const poolToBeTerminated = pool;
 				pool = null;
-				return poolToBeTerminated.terminate();
+				return poolToBeTerminated.terminate(forceTerminate);
 			};
 
 			return attemptPoolTermination();

--- a/lib/processors/minifier.js
+++ b/lib/processors/minifier.js
@@ -36,17 +36,17 @@ function getPool(taskUtil) {
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.
 				const {idleWorkers, totalWorkers} = pool.stats();
 				if (idleWorkers !== totalWorkers) {
-					setTimeout(attemptPoolTermination, 100); // Retry after a while
-					return;
+					return new Promise((resolve) =>
+						setTimeout(() => resolve(attemptPoolTermination()), 100) // Retry after a while
+					);
 				}
 
 				const poolToBeTerminated = pool;
 				pool = null;
-				poolToBeTerminated.terminate();
-				log.verbose(`Pool terminated.`);
+				return poolToBeTerminated.terminate();
 			};
 
-			attemptPoolTermination();
+			return attemptPoolTermination();
 		});
 	}
 	return pool;

--- a/lib/processors/minifier.js
+++ b/lib/processors/minifier.js
@@ -28,7 +28,7 @@ function getPool(taskUtil) {
 			workerType: "auto",
 			maxWorkers
 		});
-		taskUtil.registerCleanupTask((forceTerminate) => {
+		taskUtil.registerCleanupTask((force) => {
 			const attemptPoolTermination = () => {
 				log.verbose(`Attempt to terminate the workerpool...`);
 
@@ -39,7 +39,7 @@ function getPool(taskUtil) {
 				// There are many stats that could be used, but these ones seem the most
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.
 				const {idleWorkers, totalWorkers} = pool.stats();
-				if (idleWorkers !== totalWorkers && !forceTerminate) {
+				if (idleWorkers !== totalWorkers && !force) {
 					return new Promise((resolve) =>
 						setTimeout(() => resolve(attemptPoolTermination()), 100) // Retry after a while
 					);
@@ -47,7 +47,7 @@ function getPool(taskUtil) {
 
 				const poolToBeTerminated = pool;
 				pool = null;
-				return poolToBeTerminated.terminate(forceTerminate);
+				return poolToBeTerminated.terminate(force);
 			};
 
 			return attemptPoolTermination();

--- a/lib/processors/minifier.js
+++ b/lib/processors/minifier.js
@@ -28,15 +28,13 @@ function getPool(taskUtil) {
 			workerType: "auto",
 			maxWorkers
 		});
-		taskUtil.registerCleanupTask((options) => {
+		taskUtil.registerCleanupTask((forceTerminate) => {
 			const attemptPoolTermination = () => {
 				log.verbose(`Attempt to terminate the workerpool...`);
 
 				if (!pool) {
 					return;
 				}
-
-				const forceTerminate = !!options && !!options.exitCode;
 
 				// There are many stats that could be used, but these ones seem the most
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.

--- a/lib/processors/minifier.js
+++ b/lib/processors/minifier.js
@@ -29,10 +29,24 @@ function getPool(taskUtil) {
 			maxWorkers
 		});
 		taskUtil.registerCleanupTask(() => {
-			log.verbose(`Terminating workerpool`);
-			const poolToBeTerminated = pool;
-			pool = null;
-			poolToBeTerminated.terminate();
+			const attemptPoolTermination = () => {
+				log.verbose(`Attempt to terminate the workerpool...`);
+
+				// There are many stats that could be used, but these ones seem the most
+				// convenient. When all the (available) workers are idle, then it's safe to terminate.
+				const {idleWorkers, totalWorkers} = pool.stats();
+				if (idleWorkers !== totalWorkers) {
+					setTimeout(attemptPoolTermination, 100); // Retry after a while
+					return;
+				}
+
+				const poolToBeTerminated = pool;
+				pool = null;
+				poolToBeTerminated.terminate();
+				log.verbose(`Pool terminated.`);
+			};
+
+			attemptPoolTermination();
 		});
 	}
 	return pool;

--- a/lib/processors/minifier.js
+++ b/lib/processors/minifier.js
@@ -6,6 +6,7 @@ import workerpool from "workerpool";
 import Resource from "@ui5/fs/Resource";
 import {getLogger} from "@ui5/logger";
 const log = getLogger("builder:processors:minifier");
+import {setTimeout as setTimeoutPromise} from "node:timers/promises";
 
 const debugFileRegex = /((?:\.view|\.fragment|\.controller|\.designtime|\.support)?\.js)$/;
 
@@ -29,7 +30,7 @@ function getPool(taskUtil) {
 			maxWorkers
 		});
 		taskUtil.registerCleanupTask((force) => {
-			const attemptPoolTermination = () => {
+			const attemptPoolTermination = async () => {
 				log.verbose(`Attempt to terminate the workerpool...`);
 
 				if (!pool) {
@@ -40,9 +41,8 @@ function getPool(taskUtil) {
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.
 				const {idleWorkers, totalWorkers} = pool.stats();
 				if (idleWorkers !== totalWorkers && !force) {
-					return new Promise((resolve) =>
-						setTimeout(() => resolve(attemptPoolTermination()), 100) // Retry after a while
-					);
+					await setTimeoutPromise(100); // Wait a bit workers to finish and try again
+					return attemptPoolTermination();
 				}
 
 				const poolToBeTerminated = pool;

--- a/lib/tasks/buildThemes.js
+++ b/lib/tasks/buildThemes.js
@@ -23,15 +23,13 @@ function getPool(taskUtil) {
 			workerType: "thread",
 			maxWorkers
 		});
-		taskUtil.registerCleanupTask((options) => {
+		taskUtil.registerCleanupTask((forceTerminate) => {
 			const attemptPoolTermination = () => {
 				log.verbose(`Attempt to terminate the workerpool...`);
 
 				if (!pool) {
 					return;
 				}
-
-				const forceTerminate = !!options && !!options.exitCode;
 
 				// There are many stats that could be used, but these ones seem the most
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.

--- a/lib/tasks/buildThemes.js
+++ b/lib/tasks/buildThemes.js
@@ -37,9 +37,7 @@ function getPool(taskUtil) {
 				let {idleWorkers, totalWorkers} = pool.stats();
 				while (idleWorkers !== totalWorkers && !force) {
 					await setTimeoutPromise(100); // Wait a bit workers to finish and try again
-					const stats = pool.stats();
-					idleWorkers = stats.idleWorkers;
-					totalWorkers = stats.totalWorkers;
+					({idleWorkers, totalWorkers} = pool.stats());
 				}
 
 				const poolToBeTerminated = pool;

--- a/lib/tasks/buildThemes.js
+++ b/lib/tasks/buildThemes.js
@@ -7,6 +7,7 @@ import {fileURLToPath} from "node:url";
 import os from "node:os";
 import workerpool from "workerpool";
 import {deserializeResources, serializeResources, FsMainThreadInterface} from "../processors/themeBuilderWorker.js";
+import {setTimeout as setTimeoutPromise} from "node:timers/promises";
 
 let pool;
 
@@ -24,7 +25,7 @@ function getPool(taskUtil) {
 			maxWorkers
 		});
 		taskUtil.registerCleanupTask((force) => {
-			const attemptPoolTermination = () => {
+			const attemptPoolTermination = async () => {
 				log.verbose(`Attempt to terminate the workerpool...`);
 
 				if (!pool) {
@@ -34,10 +35,8 @@ function getPool(taskUtil) {
 				// There are many stats that could be used, but these ones seem the most
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.
 				const {idleWorkers, totalWorkers} = pool.stats();
-				if (idleWorkers !== totalWorkers && !force) {
-					return new Promise((resolve) =>
-						setTimeout(() => resolve(attemptPoolTermination()), 100) // Retry after a while
-					);
+				while (idleWorkers !== totalWorkers && !force) {
+					await setTimeoutPromise(100); // Wait a bit workers to finish and try again
 				}
 
 				const poolToBeTerminated = pool;

--- a/lib/tasks/buildThemes.js
+++ b/lib/tasks/buildThemes.js
@@ -34,9 +34,12 @@ function getPool(taskUtil) {
 
 				// There are many stats that could be used, but these ones seem the most
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.
-				const {idleWorkers, totalWorkers} = pool.stats();
+				let {idleWorkers, totalWorkers} = pool.stats();
 				while (idleWorkers !== totalWorkers && !force) {
 					await setTimeoutPromise(100); // Wait a bit workers to finish and try again
+					const stats = pool.stats();
+					idleWorkers = stats.idleWorkers;
+					totalWorkers = stats.totalWorkers;
 				}
 
 				const poolToBeTerminated = pool;

--- a/lib/tasks/buildThemes.js
+++ b/lib/tasks/buildThemes.js
@@ -23,7 +23,7 @@ function getPool(taskUtil) {
 			workerType: "thread",
 			maxWorkers
 		});
-		taskUtil.registerCleanupTask((forceTerminate) => {
+		taskUtil.registerCleanupTask((force) => {
 			const attemptPoolTermination = () => {
 				log.verbose(`Attempt to terminate the workerpool...`);
 
@@ -34,7 +34,7 @@ function getPool(taskUtil) {
 				// There are many stats that could be used, but these ones seem the most
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.
 				const {idleWorkers, totalWorkers} = pool.stats();
-				if (idleWorkers !== totalWorkers && !forceTerminate) {
+				if (idleWorkers !== totalWorkers && !force) {
 					return new Promise((resolve) =>
 						setTimeout(() => resolve(attemptPoolTermination()), 100) // Retry after a while
 					);
@@ -42,7 +42,7 @@ function getPool(taskUtil) {
 
 				const poolToBeTerminated = pool;
 				pool = null;
-				return poolToBeTerminated.terminate(forceTerminate);
+				return poolToBeTerminated.terminate(force);
 			};
 
 			return attemptPoolTermination();

--- a/lib/tasks/buildThemes.js
+++ b/lib/tasks/buildThemes.js
@@ -24,10 +24,24 @@ function getPool(taskUtil) {
 			maxWorkers
 		});
 		taskUtil.registerCleanupTask(() => {
-			log.verbose(`Terminating workerpool`);
-			const poolToBeTerminated = pool;
-			pool = null;
-			poolToBeTerminated.terminate();
+			const attemptPoolTermination = () => {
+				log.verbose(`Attempt to terminate the workerpool...`);
+
+				// There are many stats that could be used, but these ones seem the most
+				// convenient. When all the (available) workers are idle, then it's safe to terminate.
+				const {idleWorkers, totalWorkers} = pool.stats();
+				if (idleWorkers !== totalWorkers) {
+					setTimeout(attemptPoolTermination, 100); // Retry after a while
+					return;
+				}
+
+				const poolToBeTerminated = pool;
+				pool = null;
+				poolToBeTerminated.terminate();
+				log.verbose(`Pool terminated.`);
+			};
+
+			attemptPoolTermination();
 		});
 	}
 	return pool;

--- a/lib/tasks/buildThemes.js
+++ b/lib/tasks/buildThemes.js
@@ -23,14 +23,20 @@ function getPool(taskUtil) {
 			workerType: "thread",
 			maxWorkers
 		});
-		taskUtil.registerCleanupTask(() => {
+		taskUtil.registerCleanupTask((options) => {
 			const attemptPoolTermination = () => {
 				log.verbose(`Attempt to terminate the workerpool...`);
+
+				if (!pool) {
+					return;
+				}
+
+				const forceTerminate = !!options && !!options.exitCode;
 
 				// There are many stats that could be used, but these ones seem the most
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.
 				const {idleWorkers, totalWorkers} = pool.stats();
-				if (idleWorkers !== totalWorkers) {
+				if (idleWorkers !== totalWorkers && !forceTerminate) {
 					return new Promise((resolve) =>
 						setTimeout(() => resolve(attemptPoolTermination()), 100) // Retry after a while
 					);
@@ -38,7 +44,7 @@ function getPool(taskUtil) {
 
 				const poolToBeTerminated = pool;
 				pool = null;
-				return poolToBeTerminated.terminate();
+				return poolToBeTerminated.terminate(forceTerminate);
 			};
 
 			return attemptPoolTermination();

--- a/lib/tasks/buildThemes.js
+++ b/lib/tasks/buildThemes.js
@@ -31,17 +31,17 @@ function getPool(taskUtil) {
 				// convenient. When all the (available) workers are idle, then it's safe to terminate.
 				const {idleWorkers, totalWorkers} = pool.stats();
 				if (idleWorkers !== totalWorkers) {
-					setTimeout(attemptPoolTermination, 100); // Retry after a while
-					return;
+					return new Promise((resolve) =>
+						setTimeout(() => resolve(attemptPoolTermination()), 100) // Retry after a while
+					);
 				}
 
 				const poolToBeTerminated = pool;
 				pool = null;
-				poolToBeTerminated.terminate();
-				log.verbose(`Pool terminated.`);
+				return poolToBeTerminated.terminate();
 			};
 
-			attemptPoolTermination();
+			return attemptPoolTermination();
 		});
 	}
 	return pool;


### PR DESCRIPTION
fixes: https://github.com/SAP/ui5-tooling/issues/894
JIRA: CPOUI5FOUNDATION-751
depends on: https://github.com/SAP/ui5-project/pull/677

Workerpool needs to wait for all the active tasks to complete before terminating.