### PR TITLE
[INTERNAL] Align jsdoc publish with UI5

### DIFF
--- a/lib/processors/jsdoc/lib/ui5/template/publish.cjs
+++ b/lib/processors/jsdoc/lib/ui5/template/publish.cjs
@@ -2122,7 +2122,13 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 			// secTags(symbol); // TODO repeat from class?
 			closeTag("constructor");
 
+		} else {
+
+			// even though the constructor is omitted here, the "hide" information is needed because in TypeScript it even exists when omitted
+			attrib("hideconstructor", true, /* default */ false, /* raw */ true); // as boolean
+
 		}
+
 	} else if ( kind === 'namespace' ) {
 		if ( symbol.__ui5.stereotype || symbol.__ui5.metadata ) {
 			tag("ui5-metadata");


### PR DESCRIPTION
Align `lib/processors/jsdoc/lib/ui5/template/publish.cjs` with [OpenUI5](https://github.com/SAP/openui5/commit/5f1963602e75996b18c6f160262dc864a7d8ae0e)