### PR TITLE
[BREAKING] Require Node.js 20.11.x/>=21.2.0 and npm >=10

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Use Node.js LTS 16.18.0
+    - name: Use Node.js LTS 20.11.0
       uses: actions/setup-node@v4.0.2
       with:
-        node-version: 16.18.0
+        node-version: 20.11.0
 
     - name: Install dependencies
       run: npm ci

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,30 +11,30 @@ variables:
 
 strategy:
   matrix:
-    linux_node_lts_16:
+    linux_node_lts_20_min_version:
       imageName: 'ubuntu-22.04'
-      node_version: 16.x
-    linux_node_lts_18_min_version:
+      node_version: 20.11.0
+    linux_node_21_min_version:
       imageName: 'ubuntu-22.04'
-      node_version: 18.12.0
-    linux_node_lts_18:
+      node_version: 21.2.0
+    linux_node_lts_20:
       imageName: 'ubuntu-22.04'
-      node_version: 18.x
-    mac_node_lts_18:
+      node_version: 20.x
+    mac_node_lts_20:
       imageName: 'macos-12'
-      node_version: 18.x
-    windows_node_lts_18:
+      node_version: 20.x
+    windows_node_lts_20:
       imageName: 'windows-2022'
-      node_version: 18.x
+      node_version: 20.x
     linux_node_current:
       imageName: 'ubuntu-22.04'
-      node_version: 20.x
+      node_version: 21.x
     mac_node_current:
       imageName: 'macos-12'
-      node_version: 20.x
+      node_version: 21.x
     windows_node_current:
       imageName: 'windows-2022'
-      node_version: 20.x
+      node_version: 21.x
 
 pool:
   vmImage: $(imageName)

--- a/lib/processors/jsdoc/jsdocGenerator.js
+++ b/lib/processors/jsdoc/jsdocGenerator.js
@@ -4,11 +4,7 @@ import path from "node:path";
 import {promisify} from "node:util";
 const writeFile = promisify(fs.writeFile);
 import {createAdapter} from "@ui5/fs/resourceFactory";
-import {createRequire} from "node:module";
 import {fileURLToPath} from "node:url";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const require = createRequire(import.meta.url);
 
 /**
  * @public
@@ -93,7 +89,7 @@ async function generateJsdocConfig({targetPath, tmpPath, namespace, projectName,
 	const backslashRegex = /\\/g;
 
 	// Resolve path to this script to get the path to the JSDoc extensions folder
-	const jsdocPath = path.normalize(__dirname);
+	const jsdocPath = path.normalize(import.meta.dirname);
 	const pluginPath = path.join(jsdocPath, "lib", "ui5", "plugin.cjs").replace(backslashRegex, "\\\\");
 	// Using export via package.json to allow loading the CJS template.
 	// jsdoc appends /publish to the provided path but doesn't allow to
@@ -164,7 +160,7 @@ async function writeJsdocConfig(targetDirPath, config) {
  */
 async function buildJsdoc({sourcePath, configPath}) {
 	const args = [
-		require.resolve("jsdoc/jsdoc"),
+		fileURLToPath(import.meta.resolve("jsdoc/jsdoc.js")),
 		"-c",
 		configPath,
 		"--verbose",

--- a/lib/tasks/taskRepository.js
+++ b/lib/tasks/taskRepository.js
@@ -98,7 +98,7 @@ export function getRemovedTaskNames() {
 	return ["createDebugFiles", "uglify", "generateManifestBundle"];
 }
 
-// Using CommonsJS require as importing json files causes an ExperimentalWarning
+// Using CommonsJS require since JSON module imports are still experimental
 const require = createRequire(import.meta.url);
 function getVersion(pkg) {
 	return require(`${pkg}/package.json`).version;

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,8 @@
 				"tap-xunit": "^2.4.1"
 			},
 			"engines": {
-				"node": "^16.18.0 || >=18.12.0",
-				"npm": ">= 8"
+				"node": "^20.11.0 || >=21.2.0",
+				"npm": ">= 10"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
 		"./internal/jsdoc/template/publish": "./lib/processors/jsdoc/lib/ui5/template/publish.cjs"
 	},
 	"engines": {
-		"node": "^16.18.0 || >=18.12.0",
-		"npm": ">= 8"
+		"node": "^20.11.0 || >=21.2.0",
+		"npm": ">= 10"
 	},
 	"scripts": {
 		"test": "npm run lint && npm run jsdoc-generate && npm run coverage && npm run depcheck",

--- a/test/lib/builder/builder.js
+++ b/test/lib/builder/builder.js
@@ -1,6 +1,5 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import {createRequire} from "node:module";
 import chai from "chai";
 import chaiFs from "chai-fs";
@@ -14,10 +13,10 @@ import {graphFromObject, graphFromPackageDependencies} from "@ui5/project/graph"
 import * as taskRepository from "../../../lib/tasks/taskRepository.js";
 import {setLogLevel} from "@ui5/logger";
 
-// Using CommonsJS require as importing json files causes an ExperimentalWarning
+// Using CommonsJS require since JSON module imports are still experimental
 const require = createRequire(import.meta.url);
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationAPath = path.join(__dirname, "..", "..", "fixtures", "application.a");
 const applicationGPath = path.join(__dirname, "..", "..", "fixtures", "application.g");

--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -6,10 +6,6 @@ import {ecmaVersion, parseJS, VisitorKeys} from "../../../../lib/lbt/utils/parse
 import ModuleInfo from "../../../../lib/lbt/resources/ModuleInfo.js";
 import JSModuleAnalyzer, {EnrichedVisitorKeys} from "../../../../lib/lbt/analyzer/JSModuleAnalyzer.js";
 
-import {fileURLToPath} from "node:url";
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
 const EXPECTED_MODULE_NAME = "sap/ui/testmodule.js";
 
 const EXPECTED_DECLARE_DEPENDENCIES = [
@@ -40,7 +36,7 @@ function analyze(file, name) {
 		name = file;
 	}
 	return new Promise( (resolve, reject) => {
-		file = path.join(__dirname, "..", "..", "..", "fixtures", "lbt", file);
+		file = path.join(import.meta.dirname, "..", "..", "..", "fixtures", "lbt", file);
 		fs.readFile(file, (err, buffer) => {
 			if ( err ) {
 				reject(err);

--- a/test/lib/package-exports.js
+++ b/test/lib/package-exports.js
@@ -1,7 +1,7 @@
 import test from "ava";
 import {createRequire} from "node:module";
 
-// Using CommonsJS require as importing json files causes an ExperimentalWarning
+// Using CommonsJS require since JSON module imports are still experimental
 const require = createRequire(import.meta.url);
 
 // package.json should be exported to allow reading version (e.g. from @ui5/cli)

--- a/test/lib/processors/jsdoc/jsdocGenerator.js
+++ b/test/lib/processors/jsdoc/jsdocGenerator.js
@@ -2,14 +2,8 @@ import path from "node:path";
 import test from "ava";
 import sinon from "sinon";
 import esmock from "esmock";
-import jsdocGenerator from "../../../../lib/processors/jsdoc/jsdocGenerator.js";
-import {createRequire} from "node:module";
-
-const require = createRequire(import.meta.url);
-
 import {fileURLToPath} from "node:url";
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import jsdocGenerator from "../../../../lib/processors/jsdoc/jsdocGenerator.js";
 
 test.serial("generateJsdocConfig", async (t) => {
 	const res = await jsdocGenerator._generateJsdocConfig({
@@ -22,7 +16,7 @@ test.serial("generateJsdocConfig", async (t) => {
 		variants: ["apijson"]
 	});
 
-	const jsdocGeneratorPath = path.resolve(__dirname, "..", "..", "..", "..", "lib", "processors",
+	const jsdocGeneratorPath = path.resolve(import.meta.dirname, "..", "..", "..", "..", "lib", "processors",
 		"jsdoc");
 
 	const backslashRegex = /\\/g;
@@ -104,7 +98,7 @@ test.serial("buildJsdoc", async (t) => {
 	const firstCallArgs = cpStub.getCall(0).args;
 	t.is(firstCallArgs[0], "node", "Spawn got called with correct process argument");
 	t.deepEqual(firstCallArgs[1], [
-		require.resolve("jsdoc/jsdoc.js"),
+		fileURLToPath(import.meta.resolve("jsdoc/jsdoc.js")),
 		"-c",
 		"/some/config/path/jsdoc-config.json",
 		"--verbose",

--- a/test/lib/tasks/bundlers/generateLibraryPreload.integration.js
+++ b/test/lib/tasks/bundlers/generateLibraryPreload.integration.js
@@ -1,5 +1,4 @@
 import test from "ava";
-import {fileURLToPath} from "node:url";
 import path from "node:path";
 import chai from "chai";
 import chaiFs from "chai-fs";
@@ -11,7 +10,7 @@ import {graphFromObject} from "@ui5/project/graph";
 import generateLibraryPreload from "../../../../lib/tasks/bundlers/generateLibraryPreload.js";
 import * as taskRepository from "../../../../lib/tasks/taskRepository.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const libraryDPath = path.join(__dirname, "..", "..", "..", "fixtures", "library.d");
 const libraryDMinifiedPath = path.join(__dirname, "..", "..", "..", "fixtures", "library.d-minified");
 const sapUiCorePath = path.join(__dirname, "..", "..", "..", "fixtures", "sap.ui.core");

--- a/test/lib/tasks/bundlers/generateStandaloneAppBundle.integration.js
+++ b/test/lib/tasks/bundlers/generateStandaloneAppBundle.integration.js
@@ -1,5 +1,4 @@
 import test from "ava";
-import {fileURLToPath} from "node:url";
 import path from "node:path";
 import chai from "chai";
 import chaiFs from "chai-fs";
@@ -10,7 +9,7 @@ import {graphFromObject} from "@ui5/project/graph";
 import * as taskRepository from "../../../../lib/tasks/taskRepository.js";
 import recursive from "recursive-readdir";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const applicationBPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.b");
 const sapUiCorePath = path.join(__dirname, "..", "..", "..", "fixtures", "sap.ui.core");
 

--- a/test/lib/tasks/generateCachebusterInfo.js
+++ b/test/lib/tasks/generateCachebusterInfo.js
@@ -1,7 +1,6 @@
 import test from "ava";
 import fs from "node:fs";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import chai from "chai";
 import chaiFs from "chai-fs";
 chai.use(chaiFs);
@@ -10,7 +9,7 @@ const assert = chai.assert;
 import {graphFromObject} from "@ui5/project/graph";
 import * as taskRepository from "../../../lib/tasks/taskRepository.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const applicationGPath = path.join(__dirname, "..", "..", "fixtures", "application.g");
 

--- a/test/lib/tasks/generateVersionInfo.js
+++ b/test/lib/tasks/generateVersionInfo.js
@@ -1,11 +1,10 @@
 import test from "ava";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import * as resourceFactory from "@ui5/fs/resourceFactory";
 import sinon from "sinon";
 import esmock from "esmock";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 const projectCache = {};
 


### PR DESCRIPTION
BREAKING CHANGE:
Support for older Node.js and npm releases has been dropped.
Only Node.js 20.11.x and >=21.2.0 as well as npm v10 or higher are supported.