### PR TITLE
[INTERNAL] tests: remove packages 'chai', 'chai-fs' and 'recursive-dir'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,6 @@
 				"@jridgewell/trace-mapping": "^0.3.23",
 				"@ui5/project": "^3.9.0",
 				"ava": "^5.3.1",
-				"chai": "^4.4.1",
-				"chai-fs": "^2.0.0",
 				"chokidar-cli": "^3.0.0",
 				"cross-env": "^7.0.3",
 				"depcheck": "^1.4.7",
@@ -45,7 +43,6 @@
 				"line-column": "^1.0.2",
 				"nyc": "^15.1.0",
 				"open-cli": "^8.0.0",
-				"recursive-readdir": "^2.2.3",
 				"sinon": "^17.0.1",
 				"tap-xunit": "^2.4.1"
 			},
@@ -1611,19 +1608,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/array-events": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/array-events/-/array-events-0.2.0.tgz",
-			"integrity": "sha512-Js6+JM/MxB72WeODWcUOOD/BWRqx6QTff8FWvweERQ0MdzViScUJV4XwRFnXvyvbfhuwWNrwhid7IJe2ux3r4Q==",
-			"dev": true,
-			"dependencies": {
-				"async-arrays": "*",
-				"extended-emitter": "*"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -1661,27 +1645,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/async-arrays": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/async-arrays/-/async-arrays-2.0.0.tgz",
-			"integrity": "sha512-lMm6njQEX7gHbdX/b+PGBDXD/Vwg40BKSatlOaWNxrW/O5wYzARmoh+50h58s3hsyzGPU5+xYndwtc+m91yLiw==",
-			"dev": true,
-			"dependencies": {
-				"sift": "*"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/ava": {
@@ -1804,18 +1767,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/bit-mask": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bit-mask/-/bit-mask-1.0.2.tgz",
-			"integrity": "sha512-UGtq08LSiazxL4zVmBzrhdCWnT4RWx3JhhD/3crhfv8xxjnVHxf/WoVjEstjSUaZeZRP7kZrWNqup1VvUClCaQ==",
-			"dev": true,
-			"dependencies": {
-				"array-events": "^0.2.0"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/bluebird": {
@@ -2037,12 +1988,6 @@
 				"typedarray-to-buffer": "^3.1.5"
 			}
 		},
-		"node_modules/call-me-maybe": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-			"integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
-			"dev": true
-		},
 		"node_modules/callsite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
@@ -2116,40 +2061,6 @@
 				"node": ">=12.19"
 			}
 		},
-		"node_modules/chai": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-			"integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
-			"dev": true,
-			"dependencies": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.3",
-				"deep-eql": "^4.1.3",
-				"get-func-name": "^2.0.2",
-				"loupe": "^2.3.6",
-				"pathval": "^1.1.1",
-				"type-detect": "^4.0.8"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/chai-fs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chai-fs/-/chai-fs-2.0.0.tgz",
-			"integrity": "sha512-PGfINFH/7XrQBnbp5/MnbFtzBL1//erKs+uoUdyo7KnW0mUX13L6bTO3Jm8OIexSVSh0Y+aaFhhbxyDtb679DA==",
-			"dev": true,
-			"dependencies": {
-				"bit-mask": "^1.0.1",
-				"readdir-enhanced": "^1.4.0"
-			},
-			"engines": {
-				"node": ">=4"
-			},
-			"peerDependencies": {
-				"chai": ">= 1.6.1 < 5"
-			}
-		},
 		"node_modules/chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2183,18 +2094,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/check-error": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-			"dev": true,
-			"dependencies": {
-				"get-func-name": "^2.0.2"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/cheerio": {
@@ -2900,18 +2799,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/deep-eql": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-			"dev": true,
-			"dependencies": {
-				"type-detect": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3348,12 +3235,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
 			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true
-		},
-		"node_modules/es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
 			"dev": true
 		},
 		"node_modules/escalade": {
@@ -4003,18 +3884,6 @@
 			"integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
 			"dev": true
 		},
-		"node_modules/extended-emitter": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/extended-emitter/-/extended-emitter-1.6.0.tgz",
-			"integrity": "sha512-TNF4xMKL9aKYTR2cTNkKYMUnKzzjfV5Nl6TX45smJ/796CmaFt+KCyidgGdod0Kgj5VSL+ctNIGVf+i1l3e+UA==",
-			"dev": true,
-			"dependencies": {
-				"sift": "*"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4345,15 +4214,6 @@
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
-		"node_modules/get-func-name": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/get-package-type": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -4406,12 +4266,6 @@
 			"engines": {
 				"node": ">= 6"
 			}
-		},
-		"node_modules/glob-to-regexp": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-			"integrity": "sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==",
-			"dev": true
 		},
 		"node_modules/global-modules": {
 			"version": "1.0.0",
@@ -5578,15 +5432,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
 			"integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
 			"dev": true
-		},
-		"node_modules/loupe": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-			"dev": true,
-			"dependencies": {
-				"get-func-name": "^2.0.1"
-			}
 		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
@@ -7045,15 +6890,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/pathval": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/peek-readable": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
@@ -7671,17 +7507,6 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
-		"node_modules/readdir-enhanced": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/readdir-enhanced/-/readdir-enhanced-1.5.2.tgz",
-			"integrity": "sha512-oncAoS9LLjy/+DeZfSAdZBI/iFJGcPCOp44RPFI6FIMHuxt5CC5P0cUZ9mET+EZB9ONhcEvAids/lVRkj0sTHw==",
-			"dev": true,
-			"dependencies": {
-				"call-me-maybe": "^1.0.1",
-				"es6-promise": "^4.1.0",
-				"glob-to-regexp": "^0.3.0"
-			}
-		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7692,40 +7517,6 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
-			}
-		},
-		"node_modules/recursive-readdir": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
-			"integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
-			"dev": true,
-			"dependencies": {
-				"minimatch": "^3.0.5"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/recursive-readdir/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/recursive-readdir/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/release-zalgo": {
@@ -8008,12 +7799,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/sift": {
-			"version": "17.0.1",
-			"resolved": "https://registry.npmjs.org/sift/-/sift-17.0.1.tgz",
-			"integrity": "sha512-10rmPF5nuz5UdKuhhxgfS7Vz1aIRGmb+kn5Zy6bntCgNwkbZc0a7Z2dUw2Y9wSoRrBzf7Oim81SUsYdOkVnI8Q==",
-			"dev": true
 		},
 		"node_modules/signal-exit": {
 			"version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -140,8 +140,6 @@
 		"@jridgewell/trace-mapping": "^0.3.23",
 		"@ui5/project": "^3.9.0",
 		"ava": "^5.3.1",
-		"chai": "^4.4.1",
-		"chai-fs": "^2.0.0",
 		"chokidar-cli": "^3.0.0",
 		"cross-env": "^7.0.3",
 		"depcheck": "^1.4.7",
@@ -154,7 +152,6 @@
 		"line-column": "^1.0.2",
 		"nyc": "^15.1.0",
 		"open-cli": "^8.0.0",
-		"recursive-readdir": "^2.2.3",
 		"sinon": "^17.0.1",
 		"tap-xunit": "^2.4.1"
 	}

--- a/test/lib/builder/builder.js
+++ b/test/lib/builder/builder.js
@@ -1,13 +1,10 @@
 import test from "ava";
 import path from "node:path";
 import {createRequire} from "node:module";
-import chai from "chai";
-import chaiFs from "chai-fs";
-chai.use(chaiFs);
 import fs from "graceful-fs";
 import {promisify} from "node:util";
 const readFile = promisify(fs.readFile);
-const assert = chai.assert;
+import {directoryDeepEqual, findFiles} from "../../utils/fshelper.js";
 import sinon from "sinon";
 import {graphFromObject, graphFromPackageDependencies} from "@ui5/project/graph";
 import * as taskRepository from "../../../lib/tasks/taskRepository.js";
@@ -38,22 +35,7 @@ const libraryCore = path.join(__dirname, "..", "..", "fixtures", "sap.ui.core-ev
 const libraryCoreBuildtime = path.join(__dirname, "..", "..", "fixtures", "sap.ui.core-buildtime");
 const themeJPath = path.join(__dirname, "..", "..", "fixtures", "theme.j");
 const themeLibraryEPath = path.join(__dirname, "..", "..", "fixtures", "theme.library.e");
-
-import recursive from "recursive-readdir";
-
 const newLineRegexp = /\r?\n|\r/g;
-
-const findFiles = (folder) => {
-	return new Promise((resolve, reject) => {
-		recursive(folder, (err, files) => {
-			if (err) {
-				reject(err);
-			} else {
-				resolve(files);
-			}
-		});
-	});
-};
 
 function clone(obj) {
 	return JSON.parse(JSON.stringify(obj));
@@ -71,27 +53,6 @@ function cloneProjectTree(tree) {
 
 	increaseDepth(tree);
 	return tree;
-}
-
-function arrayToMap(array) {
-	const map = {};
-	array.forEach((v) => {
-		if (map[v]) {
-			throw new Error(`Unable to convert array to map because of duplicate entry '${v}'`);
-		}
-		map[v] = true;
-	});
-	return map;
-}
-
-function directoryDeepEqual(t, destPath, expectedPath) {
-	try {
-		assert.directoryDeepEqual(destPath, expectedPath);
-	} catch (err) {
-		if (err instanceof chai.AssertionError) {
-			t.deepEqual(arrayToMap(err.actual), arrayToMap(err.expected), err.message);
-		}
-	}
 }
 
 async function checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath) {
@@ -142,7 +103,7 @@ test.serial("Build application.a", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -167,7 +128,7 @@ test.serial("Build application.a with dependencies", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -193,7 +154,7 @@ test.serial("Build application.a with dependencies exclude", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -215,7 +176,7 @@ test.serial("Build application.a self-contained", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -241,7 +202,7 @@ test.serial("Build application.a with dependencies self-contained", async (t) =>
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -274,7 +235,7 @@ test.serial("Build application.a and clean target path", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -295,7 +256,7 @@ test.serial("Build application.g", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -316,7 +277,7 @@ test.serial("Build application.g with component preload paths", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -337,7 +298,7 @@ test.serial("Build application.g with excludes", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -359,7 +320,7 @@ test.serial("Build application.h", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -381,7 +342,7 @@ test.serial("Build application.h (no minify)", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -402,7 +363,7 @@ test.serial("Build application.i", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -423,7 +384,7 @@ test.serial("Build application.j", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -450,7 +411,7 @@ test.serial("Build application.j with resources.json and version info", async (t
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -472,7 +433,7 @@ test.serial("Build application.k (componentPreload excludes)", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -494,7 +455,7 @@ test.serial("Build application.k (package sub-components / componentPreload excl
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -515,7 +476,7 @@ test.serial("Build application.l: minification excludes, w/ namespace", async (t
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -536,7 +497,7 @@ test.serial("Build application.ø", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -557,7 +518,7 @@ test.serial("Build library.d with copyright from .library file", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -578,7 +539,7 @@ test.serial("Build library.e with copyright from metadata configuration of tree"
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -605,7 +566,7 @@ test.serial("Build library.e with build manifest", async (t) => {
 	let expectedFiles = await findFiles(expectedPath);
 
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Filter out build-manifest.json for manual comparison
 	expectedFiles = expectedFiles.filter((filePath) => {
 		return !filePath.endsWith("build-manifest.json");
@@ -678,7 +639,7 @@ test.serial("Build library.h with custom bundles and component-preloads", async 
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -699,7 +660,7 @@ test.serial("Build library.h with custom bundles and component-preloads (no mini
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -732,7 +693,7 @@ test.serial("Build library.h w/ custom bundles, component-preloads, resources.js
 	});
 
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 
@@ -873,7 +834,7 @@ test.serial("Build library.i with manifest info taken from .library and library.
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -899,7 +860,7 @@ test.serial("Build library.j with JSDoc build only", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -920,7 +881,7 @@ test.serial("Build library.i, bundling library.h", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -969,7 +930,7 @@ test.serial("Build library.i, bundling library.h with build manifest", async (t)
 	});
 
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 
@@ -1028,7 +989,7 @@ test.serial("Build library.l", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -1048,7 +1009,7 @@ test.serial("Build theme.j even without an library", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -1071,7 +1032,7 @@ test.serial("Build theme.j even without an library with resources.json", async (
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -1098,7 +1059,7 @@ test.serial("Build theme.j with build manifest", async (t) => {
 	let expectedFiles = await findFiles(expectedPath);
 
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Filter out build-manifest.json for manual comparison
 	expectedFiles = expectedFiles.filter((filePath) => {
 		return !filePath.endsWith("build-manifest.json");
@@ -1151,7 +1112,7 @@ test.serial("Build library.ø", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -1182,7 +1143,7 @@ test.serial("Build library.coreBuildtime: replaceBuildtime", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -1203,7 +1164,7 @@ test.serial("Build library with theme configured for CSS variables", async (t) =
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -1225,7 +1186,7 @@ test.serial("Build library with theme configured for CSS variables and theme des
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -1246,7 +1207,7 @@ test.serial("Build theme-library with CSS variables", async (t) => {
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();
@@ -1268,7 +1229,7 @@ test.serial("Build theme-library with CSS variables and theme designer resources
 
 	const expectedFiles = await findFiles(expectedPath);
 	// Check for all directories and files
-	directoryDeepEqual(t, destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 	// Check for all file contents
 	await checkFileContentsIgnoreLineFeeds(t, expectedFiles, expectedPath, destPath);
 	t.pass();

--- a/test/lib/tasks/bundlers/generateLibraryPreload.integration.js
+++ b/test/lib/tasks/bundlers/generateLibraryPreload.integration.js
@@ -1,12 +1,9 @@
 import test from "ava";
 import path from "node:path";
-import chai from "chai";
-import chaiFs from "chai-fs";
-chai.use(chaiFs);
-const assert = chai.assert;
 import {createAdapter, createResource} from "@ui5/fs/resourceFactory";
 import DuplexCollection from "@ui5/fs/DuplexCollection";
 import {graphFromObject} from "@ui5/project/graph";
+import {directoryDeepEqual, fileEqual, findFiles} from "../../../utils/fshelper.js";
 import generateLibraryPreload from "../../../../lib/tasks/bundlers/generateLibraryPreload.js";
 import * as taskRepository from "../../../../lib/tasks/taskRepository.js";
 
@@ -14,20 +11,6 @@ const __dirname = import.meta.dirname;
 const libraryDPath = path.join(__dirname, "..", "..", "..", "fixtures", "library.d");
 const libraryDMinifiedPath = path.join(__dirname, "..", "..", "..", "fixtures", "library.d-minified");
 const sapUiCorePath = path.join(__dirname, "..", "..", "..", "fixtures", "sap.ui.core");
-
-import recursive from "recursive-readdir";
-
-const findFiles = (folder) => {
-	return new Promise((resolve, reject) => {
-		recursive(folder, (err, files) => {
-			if (err) {
-				reject(err);
-			} else {
-				resolve(files);
-			}
-		});
-	});
-};
 
 test.serial("integration: build library.d with library preload", async (t) => {
 	const destPath = "./test/tmp/build/library.d/preload";
@@ -48,15 +31,15 @@ test.serial("integration: build library.d with library preload", async (t) => {
 	const expectedFiles = await findFiles(expectedPath);
 
 	// Check for all directories and files
-	assert.directoryDeepEqual(destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 
 	// Check for all file contents
 	t.is(expectedFiles.length, 7, "7 files are expected");
-	expectedFiles.forEach((expectedFile) => {
+	await Promise.all(expectedFiles.map(async (expectedFile) => {
 		const relativeFile = path.relative(expectedPath, expectedFile);
 		const destFile = path.join(destPath, relativeFile);
-		assert.fileEqual(destFile, expectedFile);
-	});
+		await fileEqual(t, destFile, expectedFile);
+	}));
 });
 
 const libraryDTree = {
@@ -101,15 +84,15 @@ test.serial("integration: build library.d-minified with library preload", async 
 	const expectedFiles = await findFiles(expectedPath);
 
 	// Check for all directories and files
-	assert.directoryDeepEqual(destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 
 	// Check for all file contents
 	t.is(expectedFiles.length, 9, "9 files are expected");
-	expectedFiles.forEach((expectedFile) => {
+	await Promise.all(expectedFiles.map(async (expectedFile) => {
 		const relativeFile = path.relative(expectedPath, expectedFile);
 		const destFile = path.join(destPath, relativeFile);
-		assert.fileEqual(destFile, expectedFile);
-	});
+		await fileEqual(t, destFile, expectedFile);
+	}));
 });
 
 const libraryDMinifiedTree = {
@@ -154,14 +137,14 @@ test.serial("integration: build sap.ui.core with library preload", async (t) => 
 	const expectedFiles = await findFiles(expectedPath);
 
 	// Check for all directories and files
-	assert.directoryDeepEqual(destPath, expectedPath);
+	await directoryDeepEqual(t, destPath, expectedPath);
 
 	// Check for all file contents
-	expectedFiles.forEach((expectedFile) => {
+	await Promise.all(expectedFiles.map(async (expectedFile) => {
 		const relativeFile = path.relative(expectedPath, expectedFile);
 		const destFile = path.join(destPath, relativeFile);
-		assert.fileEqual(destFile, expectedFile);
-	});
+		await fileEqual(t, destFile, expectedFile);
+	}));
 });
 
 const sapUiCoreTree = {

--- a/test/lib/tasks/bundlers/generateStandaloneAppBundle.integration.js
+++ b/test/lib/tasks/bundlers/generateStandaloneAppBundle.integration.js
@@ -1,29 +1,13 @@
 import test from "ava";
 import path from "node:path";
-import chai from "chai";
-import chaiFs from "chai-fs";
-chai.use(chaiFs);
-const assert = chai.assert;
 import sinon from "sinon";
+import {directoryDeepEqual, fileEqual, findFiles} from "../../../utils/fshelper.js";
 import {graphFromObject} from "@ui5/project/graph";
 import * as taskRepository from "../../../../lib/tasks/taskRepository.js";
-import recursive from "recursive-readdir";
 
 const __dirname = import.meta.dirname;
 const applicationBPath = path.join(__dirname, "..", "..", "..", "fixtures", "application.b");
 const sapUiCorePath = path.join(__dirname, "..", "..", "..", "fixtures", "sap.ui.core");
-
-const findFiles = (folder) => {
-	return new Promise((resolve, reject) => {
-		recursive(folder, (err, files) => {
-			if (err) {
-				reject(err);
-			} else {
-				resolve(files);
-			}
-		});
-	});
-};
 
 test.afterEach.always((t) => {
 	sinon.restore();
@@ -48,13 +32,13 @@ test("integration: build application.b standalone", async (t) => {
 	const expectedFiles = await findFiles(expectedPath);
 
 	// Check for all directories and files
-	assert.directoryDeepEqual(destPath, expectedPath, "Result directory structure correct");
+	directoryDeepEqual(destPath, expectedPath, "Result directory structure correct");
 
 	// Check for all file contents
 	expectedFiles.forEach((expectedFile) => {
 		const relativeFile = path.relative(expectedPath, expectedFile);
 		const destFile = path.join(destPath, relativeFile);
-		assert.fileEqual(destFile, expectedFile, "Correct file content");
+		fileEqual(destFile, expectedFile, "Correct file content");
 	});
 	t.pass("No assertion exception");
 });

--- a/test/lib/tasks/bundlers/generateStandaloneAppBundle.js
+++ b/test/lib/tasks/bundlers/generateStandaloneAppBundle.js
@@ -1,7 +1,4 @@
 import test from "ava";
-import chai from "chai";
-import chaiFs from "chai-fs";
-chai.use(chaiFs);
 import sinon from "sinon";
 import esmock from "esmock";
 

--- a/test/utils/fshelper.js
+++ b/test/utils/fshelper.js
@@ -1,0 +1,24 @@
+import {readdir, readFile} from "node:fs/promises";
+import path from "node:path";
+
+export async function findFiles(dirPath) {
+	const files = await readdir(dirPath, {withFileTypes: true, recursive: true});
+	return files.filter((file) => file.isFile()).map((file) => path.join(file.path, file.name));
+}
+
+export async function readFileContent(filePath) {
+	return await readFile(filePath, {encoding: "utf8"});
+}
+
+export async function directoryDeepEqual(t, destPath, expectedPath) {
+	const dest = await readdir(destPath, {recursive: true});
+	const expected = await readdir(expectedPath, {recursive: true});
+	t.deepEqual(dest, expected);
+}
+
+export async function fileEqual(t, destPath, expectedPath) {
+	const destContent = await readFileContent(destPath);
+	const expectedContent = await readFileContent(expectedPath);
+	t.is(destContent, expectedContent);
+}
+


### PR DESCRIPTION
Get rid of `chai`, `chai-fs` and `recursive-dir`. 

`chai-fs` is not compatible with `chai@v5`. Therefore upgrade to latest `chai` is not possible.
`recursive-dir` is no longer required because node supports option `recursive: true` for native `readdir`