### PR TITLE
[BREAKING] Task API arguments rename

### DIFF
--- a/lib/tasks/bundlers/generateFlexChangesBundle.js
+++ b/lib/tasks/bundlers/generateFlexChangesBundle.js
@@ -29,8 +29,7 @@ import semver from "semver";
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written
  */
 export default async function({workspace, taskUtil, options = {}}) {
-	// Backward compatibility: "namespace" option got renamed to "projectNamespace"
-	const namespace = options.projectNamespace || options.namespace;
+	const namespace = options.projectNamespace;
 
 	// Use the given namespace if available, otherwise use no namespace
 	// (e.g. in case no manifest.json is present)

--- a/lib/tasks/bundlers/generateStandaloneAppBundle.js
+++ b/lib/tasks/bundlers/generateStandaloneAppBundle.js
@@ -83,8 +83,7 @@ function getBundleDefinition(config) {
  */
 export default async function({workspace, dependencies, taskUtil, options}) {
 	const {projectName} = options;
-	// Backward compatibility: "namespace" option got renamed to "projectNamespace"
-	const namespace = options.projectNamespace || options.namespace;
+	const namespace = options.projectNamespace;
 
 	if (!namespace) {
 		log.warn(`Namespace of project ${projectName} is not known. Self contained bundling is currently ` +

--- a/lib/tasks/generateCachebusterInfo.js
+++ b/lib/tasks/generateCachebusterInfo.js
@@ -51,8 +51,7 @@ function getSigner(type) {
  */
 export default function({workspace, options}) {
 	const {signatureType} = options;
-	// Backward compatibility: "namespace" option got renamed to "projectNamespace"
-	const namespace = options.projectNamespace || options.namespace;
+	const namespace = options.projectNamespace;
 
 	const basePath = `/resources/${namespace}/`;
 	return workspace.byGlob(`/resources/${namespace}/**/*`)

--- a/lib/tasks/generateThemeDesignerResources.js
+++ b/lib/tasks/generateThemeDesignerResources.js
@@ -216,8 +216,7 @@ async function generateCssVariablesLess({workspace, combo, namespace}) {
  */
 export default async function({workspace, dependencies, options}) {
 	const {projectName, version} = options;
-	// Backward compatibility: "namespace" option got renamed to "projectNamespace"
-	const namespace = options.projectNamespace || options.namespace;
+	const namespace = options.projectNamespace;
 
 	// Skip sap.ui.documentation since it is not intended to be available in SAP Theme Designer to create custom themes
 	if (namespace === "sap/ui/documentation") {

--- a/lib/tasks/transformBootstrapHtml.js
+++ b/lib/tasks/transformBootstrapHtml.js
@@ -16,8 +16,7 @@ import bootstrapHtmlTransformer from "../processors/bootstrapHtmlTransformer.js"
  */
 export default async function({workspace, options}) {
 	const {projectName} = options;
-	// Backward compatibility: "namespace" option got renamed to "projectNamespace"
-	const namespace = options.projectNamespace || options.namespace;
+	const namespace = options.projectNamespace;
 
 	let indexPath;
 	if (namespace) {

--- a/lib/tasks/transformBootstrapHtml.js
+++ b/lib/tasks/transformBootstrapHtml.js
@@ -11,7 +11,7 @@ import bootstrapHtmlTransformer from "../processors/bootstrapHtmlTransformer.js"
  * @param {@ui5/fs/DuplexCollection} parameters.workspace DuplexCollection to read and write files
  * @param {object} parameters.options Options
  * @param {string} parameters.options.projectName Project name
- * @param {string} [parameters.options.namespace] Project namespace
+ * @param {string} [parameters.options.projectNamespace] Project namespace
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written
  */
 export default async function({workspace, options}) {

--- a/test/lib/tasks/bundlers/generateStandaloneAppBundle.js
+++ b/test/lib/tasks/bundlers/generateStandaloneAppBundle.js
@@ -56,7 +56,7 @@ test.serial("execute module bundler and write results", async (t) => {
 		dependencies: dummyReaderWriter,
 		options: {
 			projectName: "some.project.name",
-			namespace: "some/project/namespace"
+			projectNamespace: "some/project/namespace"
 		}
 	};
 	await generateStandaloneAppBundle(params);
@@ -150,7 +150,7 @@ test.serial("execute module bundler and write results in evo mode", async (t) =>
 		dependencies: dummyReaderWriter,
 		options: {
 			projectName: "some.project.name",
-			namespace: "some/project/namespace"
+			projectNamespace: "some/project/namespace"
 		}
 	};
 	await generateStandaloneAppBundle(params);
@@ -207,7 +207,7 @@ test.serial("execute module bundler with taskUtil", async (t) => {
 		taskUtil,
 		options: {
 			projectName: "some.project.name",
-			namespace: "some/project/namespace"
+			projectNamespace: "some/project/namespace"
 		}
 	};
 	await generateStandaloneAppBundle(params);
@@ -355,7 +355,7 @@ test.serial("Error: Failed to resolve non-debug name", async (t) => {
 		taskUtil,
 		options: {
 			projectName: "some.project.name",
-			namespace: "some/project/namespace"
+			projectNamespace: "some/project/namespace"
 		}
 	};
 

--- a/test/lib/tasks/generateThemeDesignerResources.js
+++ b/test/lib/tasks/generateThemeDesignerResources.js
@@ -80,7 +80,7 @@ test.serial("generateThemeDesignerResources: Library", async (t) => {
 		options: {
 			projectName: "sap.ui.demo.lib",
 			version: "1.2.3",
-			namespace: "sap/ui/demo/lib"
+			projectNamespace: "sap/ui/demo/lib"
 		}
 	});
 
@@ -203,7 +203,7 @@ test.serial("generateThemeDesignerResources: Library sap.ui.core", async (t) => 
 		options: {
 			projectName: "sap.ui.core",
 			version: "1.2.3",
-			namespace: "sap/ui/core"
+			projectNamespace: "sap/ui/core"
 		}
 	});
 
@@ -268,7 +268,7 @@ test.serial("generateThemeDesignerResources: Library sap.ui.documentation is ski
 		options: {
 			projectName: "sap.ui.documentation",
 			version: "1.2.3",
-			namespace: "sap/ui/documentation"
+			projectNamespace: "sap/ui/documentation"
 		}
 	});
 
@@ -296,7 +296,7 @@ test.serial("generateThemeDesignerResources: Library without themes", async (t) 
 		options: {
 			projectName: "sap.ui.demo.lib",
 			version: "1.2.3",
-			namespace: "sap/ui/demo/lib"
+			projectNamespace: "sap/ui/demo/lib"
 		}
 	});
 
@@ -521,7 +521,7 @@ test.serial("generateThemeDesignerResources: Theme-Library with CSS Variables wi
 		options: {
 			projectName: "sap.ui.demo.lib",
 			version: "1.2.3",
-			namespace: "sap/ui/demo/lib"
+			projectNamespace: "sap/ui/demo/lib"
 		}
 	});
 
@@ -757,7 +757,7 @@ test.serial("generateThemeDesignerResources: .theming file missing in sap.ui.cor
 		options: {
 			projectName: "sap.ui.core",
 			version: "1.2.3",
-			namespace: "sap/ui/core"
+			projectNamespace: "sap/ui/core"
 		}
 	}), {
 		message: ".theming file for theme base missing in sap.ui.core library source"

--- a/test/lib/tasks/transformBootstrapHtml.js
+++ b/test/lib/tasks/transformBootstrapHtml.js
@@ -48,7 +48,7 @@ test.serial("Transforms index.html resource", async (t) => {
 		workspace,
 		options: {
 			projectName: "sap.ui.demo.app",
-			namespace: "sap/ui/demo/app"
+			projectNamespace: "sap/ui/demo/app"
 		}
 	});
 
@@ -126,7 +126,7 @@ test.serial("No index.html resource exists", async (t) => {
 		workspace,
 		options: {
 			projectName: "sap.ui.demo.app",
-			namespace: "sap/ui/demo/app"
+			projectNamespace: "sap/ui/demo/app"
 		}
 	});
 


### PR DESCRIPTION
BREAKING CHANGE:
Task API `namespace` option got renamed to `projectNamespace`

JIRA: CPOUI5FOUNDATION-802
Relates to: https://github.com/SAP/ui5-tooling/issues/701