### PR TITLE
[INTERNAL] JSDoc: Update test fixtures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 			"devDependencies": {
 				"@istanbuljs/esm-loader-hook": "^0.2.0",
 				"@jridgewell/trace-mapping": "^0.3.25",
-				"@ui5/project": "^3.9.0",
+				"@ui5/project": "^3.9.1",
 				"ava": "^5.3.1",
 				"chai": "^4.4.1",
 				"chai-fs": "^2.0.0",
@@ -1245,9 +1245,9 @@
 			"dev": true
 		},
 		"node_modules/@ui5/builder": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@ui5/builder/-/builder-3.3.0.tgz",
-			"integrity": "sha512-gQ28Bj4WqF3b+8Mp4luxe2pGb+Adq2qpy1H9JZ8DTpIGcCEcJgJVCTRv6KdWZja6y5ZD89NWQAv0k0N50MV6Sw==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@ui5/builder/-/builder-3.3.1.tgz",
+			"integrity": "sha512-YHhCN8pF7eRHKWq4l8j3MYSabpGPe4ByoPLhW8NCz37HjlKPKa50ySUpTSHN9CGopMRzWxVMw6Zjul4SAwULWg==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15",
@@ -1262,8 +1262,8 @@
 				"less-openui5": "^0.11.6",
 				"pretty-data": "^0.40.0",
 				"rimraf": "^5.0.5",
-				"semver": "^7.5.4",
-				"terser": "^5.27.0",
+				"semver": "^7.6.0",
+				"terser": "^5.29.2",
 				"workerpool": "^6.5.1",
 				"xml2js": "^0.6.2"
 			},
@@ -1318,13 +1318,13 @@
 			}
 		},
 		"node_modules/@ui5/project": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/@ui5/project/-/project-3.9.0.tgz",
-			"integrity": "sha512-pm7FzV8oCaZtLBuoH9bVVpAtRz0pwpAJhJKg731lUHGsMkGG5zaWkmUjajBlQR/+dZtWmTlkwxjpJttjUVi43A==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@ui5/project/-/project-3.9.1.tgz",
+			"integrity": "sha512-0DEHAw38gXzp0RK5+aVeHSfQB2UFK0Iz+bCOpecgSnhYk2htFstMhdTxMqataFxdf3ri1L4NH5iSiZVViUERkA==",
 			"dev": true,
 			"dependencies": {
-				"@npmcli/config": "^8.0.3",
-				"@ui5/builder": "^3.2.0",
+				"@npmcli/config": "^8.2.0",
+				"@ui5/builder": "^3.3.1",
 				"@ui5/fs": "^3.0.5",
 				"@ui5/logger": "^3.0.0",
 				"ajv": "^6.12.6",
@@ -1337,13 +1337,13 @@
 				"lockfile": "^1.0.4",
 				"make-fetch-happen": "^13.0.0",
 				"node-stream-zip": "^1.15.0",
-				"pacote": "^17.0.5",
+				"pacote": "^17.0.6",
 				"pretty-hrtime": "^1.0.3",
 				"read-pkg": "^8.1.0",
 				"read-pkg-up": "^10.1.0",
 				"resolve": "^1.22.8",
 				"rimraf": "^5.0.5",
-				"semver": "^7.5.4",
+				"semver": "^7.6.0",
 				"xml2js": "^0.6.2",
 				"yesno": "^0.4.0"
 			},

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 	"devDependencies": {
 		"@istanbuljs/esm-loader-hook": "^0.2.0",
 		"@jridgewell/trace-mapping": "^0.3.25",
-		"@ui5/project": "^3.9.0",
+		"@ui5/project": "^3.9.1",
 		"ava": "^5.3.1",
 		"chai": "^4.4.1",
 		"chai-fs": "^2.0.0",

--- a/test/expected/build/library.j/dest/test-resources/library/j/designtime/api.json
+++ b/test/expected/build/library.j/dest/test-resources/library/j/designtime/api.json
@@ -12,7 +12,7 @@
 			"export": "AnotherValidEnum",
 			"static": true,
 			"visibility": "public",
-			"description": "AnotherValidEnum",
+			"description": "AnotherValidEnum\n\nThis enum is part of the 'library/j/core/library' module export and must be accessed by the property 'AnotherValidEnum'.",
 			"ui5-metamodel": true,
 			"ui5-metadata": {
 				"stereotype": "enum"
@@ -58,7 +58,7 @@
 			"export": "MyValidEnum",
 			"static": true,
 			"visibility": "public",
-			"description": "MyValidEnum",
+			"description": "MyValidEnum\n\nThis enum is part of the 'library/j/library' module export and must be accessed by the property 'MyValidEnum'.",
 			"ui5-metamodel": true,
 			"ui5-metadata": {
 				"stereotype": "enum"
@@ -208,7 +208,7 @@
 			"export": "ThisIsEnumToo",
 			"static": true,
 			"visibility": "public",
-			"description": "ThisIsEnumToo",
+			"description": "ThisIsEnumToo\n\nThis enum is part of the 'library/j/library' module export and must be accessed by the property 'ThisIsEnumToo'.",
 			"ui5-metadata": {
 				"stereotype": "enum"
 			},


### PR DESCRIPTION
Test were actually not affected by https://github.com/SAP/ui5-builder/commit/834232db1a81f80e26dc2e4fc663ff83fb933922 due to the circular dependency between ui5-builder and ui5-project. The JSDoc process spawned ui5-builder seems to have resolved it's plugin to the ui5-builder dependency of ui5-project, which was the latest released ui5-builder version.