### PR TITLE
[FEATURE] generateFlexChangesBundle: Handle minUI5Version as array

### DIFF
--- a/lib/tasks/bundlers/generateFlexChangesBundle.js
+++ b/lib/tasks/bundlers/generateFlexChangesBundle.js
@@ -73,18 +73,23 @@ export default async function({workspace, taskUtil, options = {}}) {
 
 		manifestContent["sap.ui5"] = manifestContent["sap.ui5"] || {};
 		manifestContent["sap.ui5"].dependencies = manifestContent["sap.ui5"].dependencies || {};
-		return manifestContent["sap.ui5"].dependencies.minUI5Version =
-			manifestContent["sap.ui5"].dependencies.minUI5Version || "";
+		if (!Array.isArray(manifestContent["sap.ui5"].dependencies.minUI5Version)) {
+			manifestContent["sap.ui5"].dependencies.minUI5Version =
+				[manifestContent["sap.ui5"].dependencies.minUI5Version] || [""];
+		}
+		return manifestContent["sap.ui5"].dependencies.minUI5Version;
 	}
 
 	log.verbose("Collecting flexibility changes");
 	const allResources = await workspace.byGlob(
 		`${pathPrefix}/changes/*.{change,variant,ctrl_variant,ctrl_variant_change,ctrl_variant_management_change}`);
 	if (allResources.length > 0) {
-		const version = semver.coerce(await readManifestMinUI5Version());
+		const versionArray = await readManifestMinUI5Version();
+		const versions = versionArray.map((version) => semver.coerce(version));
+		const versionsAllSuitableForFlexBundle = versions.every((version) => semver.compare(version, "1.73.0") >= 0);
 		let hasFlexBundleVersion = false;
 		let flexBundle = {};
-		if (semver.compare(version, "1.73.0") >= 0) {
+		if (versionsAllSuitableForFlexBundle) {
 			hasFlexBundleVersion = true;
 			const flexBundleResource = await workspace.byPath(`${pathPrefix}/changes/flexibility-bundle.json`);
 			if (flexBundleResource) {

--- a/test/lib/tasks/bundlers/generateFlexChangesBundle.js
+++ b/test/lib/tasks/bundlers/generateFlexChangesBundle.js
@@ -3,7 +3,7 @@ import sinon from "sinon";
 import generateFlexChangesBundle from "../../../../lib/tasks/bundlers/generateFlexChangesBundle.js";
 
 
-function createDummyResource(content) {
+function createPlaceholderResource(content) {
 	return {
 		name: "file",
 		getBuffer: async () => JSON.stringify(content),
@@ -12,14 +12,14 @@ function createDummyResource(content) {
 	};
 }
 
-function createDummyWorkspace(changes, manifest, flexBundle) {
+function createPlaceholderWorkspace(changes, manifest, flexBundle) {
 	return {
-		byGlob: async (path) => changes.map(createDummyResource),
+		byGlob: async (path) => changes.map(createPlaceholderResource),
 		byPath: async (path) => {
 			if ( path.includes("manifest.json") ) {
-				return createDummyResource(manifest);
+				return createPlaceholderResource(manifest);
 			} else if ( path.includes("flexibility-bundle.json")) {
-				return createDummyResource(flexBundle);
+				return createPlaceholderResource(flexBundle);
 			}
 		},
 		write: () => {
@@ -28,123 +28,207 @@ function createDummyWorkspace(changes, manifest, flexBundle) {
 	};
 }
 
-test.serial("execute flexChangeBundler", async (t) => {
-	const changeList = [
-		{
-			"fileName": "id_1504764957625_7_rename1",
-			"fileType": "change",
-			"changeType": "rename",
-			"reference": "rta.performance.Component",
-			"packageName": "$TMP",
-			"content": {
-				"originalControlType": "sap.m.Label"
-			},
-			"selector": {
-				"id": "initialLabel",
-				"idIsLocal": false
-			},
-			"layer": "CUSTOMER",
-			"texts": {
-				"newText": {
-					"value": "rename_0",
-					"type": "XFLD"
+["1.120.0", ["1.120.0", "2.0.0"]].forEach((minVersion) => {
+	test.serial(`execute flexChangeBundler with the minVersion: ${minVersion}`, async (t) => {
+		const changeList = [
+			{
+				"fileName": "id_1504764957625_7_rename1",
+				"fileType": "change",
+				"changeType": "rename",
+				"reference": "rta.performance.Component",
+				"packageName": "$TMP",
+				"content": {
+					"originalControlType": "sap.m.Label"
+				},
+				"selector": {
+					"id": "initialLabel",
+					"idIsLocal": false
+				},
+				"layer": "CUSTOMER",
+				"texts": {
+					"newText": {
+						"value": "rename_0",
+						"type": "XFLD"
+					}
+				},
+				"namespace": "apps/MyComponent/changes/",
+				"creation": "2017-10-06T11:54:55.238Z",
+				"originalLanguage": "EN",
+				"conditions": {},
+				"context": "",
+				"support": {
+					"generator": "Change.createInitialFileContent",
+					"service": "",
+					"user": "",
+					"sapui5Version": "1.51.0-SNAPSHOT"
+				},
+				"dependentSelector": {},
+				"validAppVersions": {
+					"creation": "1.0.0",
+					"from": "1.0.0",
+					"to": "1.0.0"
 				}
-			},
-			"namespace": "apps/MyComponent/changes/",
-			"creation": "2017-10-06T11:54:55.238Z",
-			"originalLanguage": "EN",
-			"conditions": {},
-			"context": "",
-			"support": {
-				"generator": "Change.createInitialFileContent",
-				"service": "",
-				"user": "",
-				"sapui5Version": "1.51.0-SNAPSHOT"
-			},
-			"dependentSelector": {},
-			"validAppVersions": {
-				"creation": "1.0.0",
-				"from": "1.0.0",
-				"to": "1.0.0"
 			}
-		}
-	];
-	const existingChangeList = [
-		{
-			"fileName": "id_1504764957630_7_rename2",
-			"fileType": "change",
-			"changeType": "rename",
-			"reference": "rta.performance.Component",
-			"packageName": "$TMP",
-			"content": {
-				"originalControlType": "sap.m.Label"
-			},
-			"selector": {
-				"id": "initialLabel",
-				"idIsLocal": false
-			},
-			"layer": "USER",
-			"texts": {
-				"newText": {
-					"value": "rename_5",
-					"type": "XFLD"
+		];
+		const existingChangeList = [
+			{
+				"fileName": "id_1504764957630_7_rename2",
+				"fileType": "change",
+				"changeType": "rename",
+				"reference": "rta.performance.Component",
+				"packageName": "$TMP",
+				"content": {
+					"originalControlType": "sap.m.Label"
+				},
+				"selector": {
+					"id": "initialLabel",
+					"idIsLocal": false
+				},
+				"layer": "USER",
+				"texts": {
+					"newText": {
+						"value": "rename_5",
+						"type": "XFLD"
+					}
+				},
+				"namespace": "apps/MyComponent/changes/",
+				"creation": "2017-09-01T11:54:55.238Z",
+				"originalLanguage": "EN",
+				"conditions": {},
+				"context": "",
+				"support": {
+					"generator": "Change.createInitialFileContent",
+					"service": "",
+					"user": "",
+					"sapui5Version": "1.51.0-SNAPSHOT"
+				},
+				"dependentSelector": {},
+				"validAppVersions": {
+					"creation": "1.0.0",
+					"from": "1.0.0",
+					"to": "1.0.0"
 				}
-			},
-			"namespace": "apps/MyComponent/changes/",
-			"creation": "2017-09-01T11:54:55.238Z",
-			"originalLanguage": "EN",
-			"conditions": {},
-			"context": "",
-			"support": {
-				"generator": "Change.createInitialFileContent",
-				"service": "",
-				"user": "",
-				"sapui5Version": "1.51.0-SNAPSHOT"
-			},
-			"dependentSelector": {},
-			"validAppVersions": {
-				"creation": "1.0.0",
-				"from": "1.0.0",
-				"to": "1.0.0"
 			}
-		}
-	];
-	const manifest = {
-		"sap.ui5": {
-			dependencies: {
-				minUI5Version: "1.120.0"
+		];
+		const manifest = {
+			"sap.ui5": {
+				dependencies: {
+					minUI5Version: minVersion
+				}
 			}
-		}
-	};
+		};
 
-	const flexBundle = {
-		"changes": existingChangeList,
-		"compVariants": [],
-		"variantChanges": [],
-		"variantDependentControlChanges": [],
-		"variantManagementChanges": [],
-		"variants": []
-	};
+		const flexBundle = {
+			"changes": existingChangeList,
+			"compVariants": [],
+			"variantChanges": [],
+			"variantDependentControlChanges": [],
+			"variantManagementChanges": [],
+			"variants": []
+		};
 
-	const flexBundleMerge = {
-		"changes": existingChangeList.concat(changeList),
-		"compVariants": [],
-		"variantChanges": [],
-		"variantDependentControlChanges": [],
-		"variantManagementChanges": [],
-		"variants": []
-	};
+		const flexBundleMerge = {
+			"changes": existingChangeList.concat(changeList),
+			"compVariants": [],
+			"variantChanges": [],
+			"variantDependentControlChanges": [],
+			"variantManagementChanges": [],
+			"variants": []
+		};
 
-	const dummyWorkspace = createDummyWorkspace(changeList, manifest, flexBundle);
-	const stub = sinon.stub(dummyWorkspace, "write").returnsArg(0);
-	await generateFlexChangesBundle({
-		workspace: dummyWorkspace,
-		taskUtil: false,
-		options: {
-			namespace: "/mypath"
-		}
+		const placeholderWorkspace = createPlaceholderWorkspace(changeList, manifest, flexBundle);
+		const stub = sinon.stub(placeholderWorkspace, "write").returnsArg(0);
+		await generateFlexChangesBundle({
+			workspace: placeholderWorkspace,
+			taskUtil: false,
+			options: {
+				namespace: "/mypath"
+			}
+		});
+
+		const content = JSON.parse(await stub.getCall(0).args[0].getString());
+		t.deepEqual(content, flexBundleMerge, "Result must contain the same content");
+
+		const path = await stub.getCall(0).args[0].getPath();
+		t.is(path, "/resources/mypath/changes/flexibility-bundle.json");
 	});
+});
 
-	const content = JSON.parse(await stub.getCall(0).args[0].getString());
-	t.deepEqual(content, flexBundleMerge, "Result must contain the same content");
+["1.70.0", ["1.70.0", "2.0.0"]].forEach((minVersion) => {
+	test.serial(`execute flexChangeBundler with the minVersion < 1.73: ${minVersion}`, async (t) => {
+		const manifest = {
+			"sap.ui5": {
+				dependencies: {
+					minUI5Version: minVersion
+				}
+			}
+		};
+
+		const changeList = [
+			{
+				"fileName": "id_1504764957625_7_rename1",
+				"fileType": "change",
+				"changeType": "rename",
+				"reference": "rta.performance.Component",
+				"packageName": "$TMP",
+				"content": {
+					"originalControlType": "sap.m.Label"
+				},
+				"selector": {
+					"id": "initialLabel",
+					"idIsLocal": false
+				},
+				"layer": "CUSTOMER",
+				"texts": {
+					"newText": {
+						"value": "rename_0",
+						"type": "XFLD"
+					}
+				},
+				"namespace": "apps/MyComponent/changes/",
+				"creation": "2017-10-06T11:54:55.238Z",
+				"originalLanguage": "EN",
+				"conditions": {},
+				"context": "",
+				"support": {
+					"generator": "Change.createInitialFileContent",
+					"service": "",
+					"user": "",
+					"sapui5Version": "1.51.0-SNAPSHOT"
+				},
+				"dependentSelector": {},
+				"validAppVersions": {
+					"creation": "1.0.0",
+					"from": "1.0.0",
+					"to": "1.0.0"
+				}
+			}
+		];
+
+		const flexBundle = {
+			"changes": [],
+			"compVariants": [],
+			"variantChanges": [],
+			"variantDependentControlChanges": [],
+			"variantManagementChanges": [],
+			"variants": []
+		};
+
+		const placeholderWorkspace = createPlaceholderWorkspace(changeList, manifest, flexBundle);
+		const stub = sinon.stub(placeholderWorkspace, "write").returnsArg(0);
+
+		await generateFlexChangesBundle({
+			workspace: placeholderWorkspace,
+			taskUtil: false,
+			options: {
+				namespace: "/mypath"
+			}
+		});
+
+		const content = JSON.parse(await stub.getCall(0).args[0].getString());
+		t.deepEqual(content, changeList, "Result must contain the same content");
+
+		const path = await stub.getCall(0).args[0].getPath();
+		t.is(path, "/resources/mypath/changes/changes-bundle.json");
+	});
 });


### PR DESCRIPTION
generateFlexChangesBundle understands minUI5Version as string and array

With the upcoming UI5 2.x the manifest may contain a minUI5Version with multiple entries as described in the AppDescriptor schema (internal PR 499). This change enables the generateFlexChangesBundle to understand the new syntax

in addition, the tests for the generateFlexChangesBundle were enhanced to check better their complete functionality - boy scouted!

JIRA: CLOUDIOI-1170

## Pull Request Checklist
- [✅] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/main/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/main/CONTRIBUTING.md#how-to-contribute) section 
- [✅] [No merge commits](https://github.com/SAP/ui5-tooling/blob/main/docs/Guidelines.md#no-merge-commits)
- [✅] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/main/docs/Guidelines.md#commit-message-style)