### PR TITLE
[INTERNAL] generateVersionInfo: Only process dependencies of type 'library'

### DIFF
--- a/lib/tasks/generateVersionInfo.js
+++ b/lib/tasks/generateVersionInfo.js
@@ -23,7 +23,9 @@ const MANIFEST_JSON = "manifest.json";
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written
  */
 export default async ({workspace, dependencies, options: {rootProject, pattern}}) => {
-	const resources = await dependencies.byGlob(pattern);
+	let resources = await dependencies.byGlob(pattern);
+
+	resources = resources.filter((res) => res.getProject()?.getType() === "library");
 
 	const libraryInfosPromises = resources.map((dotLibResource) => {
 		const namespace = dotLibResource.getProject().getNamespace();


### PR DESCRIPTION
Ignore any other project types, even if the project contains a .library file.

Currently, projects of type 'module' will return null as their
namespace, which is then incorrectly used as a string in the constructed
glob pattern.

Projects of type 'library' always provide a valid namespace.

Relates to https://github.com/SAP/ui5-server/pull/656