### PR TITLE
[INTERNAL] Replace deprecated new Buffer() calls

### DIFF
--- a/test/lib/processors/minifier.js
+++ b/test/lib/processors/minifier.js
@@ -1508,7 +1508,7 @@ test("getSourceMapFromUrl: Unexpected data: format", async (t) => {
 
 test("getSourceMapFromUrl: File reference", async (t) => {
 	const {getSourceMapFromUrl} = __localFunctions__;
-	const readFileStub = sinon.stub().resolves(new Buffer("Source Map Content"));
+	const readFileStub = sinon.stub().resolves(Buffer.from("Source Map Content"));
 	const sourceMappingUrl = `./other/file.map`;
 
 	const res = await getSourceMapFromUrl({
@@ -1540,7 +1540,7 @@ test("getSourceMapFromUrl: File reference not found", async (t) => {
 
 test("getSourceMapFromUrl: HTTPS URL reference", async (t) => {
 	const {getSourceMapFromUrl} = __localFunctions__;
-	const readFileStub = sinon.stub().resolves(new Buffer("Source Map Content"));
+	const readFileStub = sinon.stub().resolves(Buffer.from("Source Map Content"));
 	const sourceMappingUrl = `https://ui5.sap.com/resources/my/test/module.js.map`;
 
 	const res = await getSourceMapFromUrl({
@@ -1555,7 +1555,7 @@ test("getSourceMapFromUrl: HTTPS URL reference", async (t) => {
 
 test("getSourceMapFromUrl: Absolute path reference", async (t) => {
 	const {getSourceMapFromUrl} = __localFunctions__;
-	const readFileStub = sinon.stub().resolves(new Buffer("Source Map Content"));
+	const readFileStub = sinon.stub().resolves(Buffer.from("Source Map Content"));
 	const sourceMappingUrl = `/some/file.map`;
 
 	const res = await getSourceMapFromUrl({

--- a/test/lib/tasks/buildThemes.js
+++ b/test/lib/tasks/buildThemes.js
@@ -493,7 +493,7 @@ test.serial("buildThemes (useWorkers = true)", async (t) => {
 	};
 	const lessResource = {
 		getPath: () => "/resources/test/library.source.less",
-		getBuffer: () => new Buffer("/** test comment */")
+		getBuffer: () => Buffer.from("/** test comment */")
 	};
 
 	const workspace = {


### PR DESCRIPTION
Replacing deprecated 'new Buffer(string)' with 'Buffer.from(string)'.

Resolves a TypeError being thrown in our tests when executed with
Node 20.15.0 or 22.3.0.

Root cause: https://github.com/nodejs/node/issues/53075

(cherry picked from commit 934956a1097c8d6bd70510541e06bc919ea52a19)