### PR TITLE
[INTERNAL] lib/processors/jsdoc: support optional methods also in classes

### DIFF
--- a/lib/processors/jsdoc/lib/ui5/template/publish.cjs
+++ b/lib/processors/jsdoc/lib/ui5/template/publish.cjs
@@ -2308,7 +2308,7 @@ function createAPIJSON4Symbol(symbol, omitDefaults) {
 		if ( symbol.__ui5.stereotype !== 'xmlmacro' && ownMethods.length > 0 ) {
 			collection("methods");
 			ownMethods.forEach(function(member) {
-				writeMethod(member, undefined, symbol.kind === 'interface');
+				writeMethod(member, undefined, symbol.kind === 'interface' || symbol.kind === 'class');
 				if ( member.__ui5.members ) {
 					// HACK: export nested static functions as siblings of the current function
 					// A correct representation has to be discussed with the SDK / WebIDE


### PR DESCRIPTION
So far, the documentation build only allowed optional methods in interfaces. But UI5 in several places specifies methods on a base class level without implementing them. Subclasses can then implement such a method to get a certain behavior (example: Control#getAccessibilityInfo).

TypeScript (meanwhile?) allows to describe this as optional methods in the base class.

To allow to use this and thereby to better describe those methods in the TypeScript types, the JSDoc template lifts its limitation and writes out the 'optional' marker also for methods in classes.

Note: this is now even possible for static class methods, although this is not used yet in the framework.

Cherry-picked from SAP/openui5@a7ccde144.
