### PR TITLE
[INTERNAL] generateThemeDesignerResources: Allow core .theming in sources

### DIFF
--- a/lib/tasks/generateThemeDesignerResources.js
+++ b/lib/tasks/generateThemeDesignerResources.js
@@ -2,6 +2,7 @@ import posixPath from "node:path/posix";
 import {getLogger} from "@ui5/logger";
 const log = getLogger("builder:tasks:generateThemeDesignerResources");
 import libraryLessGenerator from "../processors/libraryLessGenerator.js";
+import {updateLibraryDotTheming} from "./utils/dotTheming.js";
 import ReaderCollectionPrioritized from "@ui5/fs/ReaderCollectionPrioritized";
 import Resource from "@ui5/fs/Resource";
 import fsInterface from "@ui5/fs/fsInterface";
@@ -44,6 +45,10 @@ function generateLibraryDotTheming({namespace, version, hasThemes}) {
 		sVersion: version
 	};
 
+	// Note that with sap.ui.core version 1.127.0 the .theming file has been put into
+	// the library sources so that "aFiles" can be maintained from there.
+	// The below configuration is still needed for older versions of sap.ui.core which do not
+	// contain the file.
 	if (namespace === "sap/ui/core") {
 		dotTheming.aFiles = [
 			"library",
@@ -240,12 +245,33 @@ export default async function({workspace, dependencies, options}) {
 	// Only for type "library". Type "theme-library" does not provide a namespace
 	// Also needs to be created in case a library does not have any themes (see bIgnore flag)
 	if (namespace) {
-		log.verbose(`Generating .theming for namespace ${namespace}`);
-		const libraryDotThemingResource = generateLibraryDotTheming({
-			namespace,
-			version,
-			hasThemes
-		});
+		let libraryDotThemingResource;
+
+		// Do not generate a .theming file for the sap.ui.core library
+		if (namespace === "sap/ui/core") {
+			// Check if the .theming file already exists
+			libraryDotThemingResource = await workspace.byPath(`/resources/${namespace}/.theming`);
+			if (libraryDotThemingResource) {
+				// Update the existing .theming resource
+				log.verbose(`Updating .theming for namespace ${namespace}`);
+				await updateLibraryDotTheming({
+					resource: libraryDotThemingResource,
+					namespace,
+					version,
+					hasThemes
+				});
+			}
+		}
+
+		if (!libraryDotThemingResource) {
+			log.verbose(`Generating .theming for namespace ${namespace}`);
+			libraryDotThemingResource = generateLibraryDotTheming({
+				namespace,
+				version,
+				hasThemes
+			});
+		}
+
 		await workspace.write(libraryDotThemingResource);
 	}
 

--- a/lib/tasks/utils/dotTheming.js
+++ b/lib/tasks/utils/dotTheming.js
@@ -1,0 +1,33 @@
+export async function updateLibraryDotTheming({resource, namespace, version, hasThemes}) {
+	const dotTheming = JSON.parse(await resource.getString());
+
+	if (!dotTheming.sEntity) {
+		throw new Error(`Missing 'sEntity' property in ${resource.getPath()}`);
+	}
+
+	if (dotTheming.sEntity !== "Library") {
+		throw new Error(
+			`Incorrect 'sEntity' value '${dotTheming.sEntity}' in ${resource.getPath()}: ` +
+			`Expected 'Library'`
+		);
+	}
+
+	if (!dotTheming.sId) {
+		throw new Error(`Missing 'sId' property in ${resource.getPath()}`);
+	}
+
+	if (dotTheming.sId !== namespace) {
+		throw new Error(`Incorrect 'sId' value '${dotTheming.sId}' in ${resource.getPath()}: Expected '${namespace}'`);
+	}
+
+	dotTheming.sVersion = version;
+
+	if (!hasThemes) {
+		// Set ignore flag when there are no themes at all
+		// This is important in case a library used to contain themes that have been removed
+		// in a later version of the library.
+		dotTheming.bIgnore = true;
+	}
+
+	resource.setString(JSON.stringify(dotTheming, null, 2));
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"./processors/jsdoc/lib/*": null,
 		"./tasks/*": "./lib/tasks/*.js",
 		"./tasks/taskRepository": null,
+		"./tasks/utils/*": null,
 		"./tasks/bundlers/utils/*": null,
 		"./package.json": "./package.json",
 		"./internal/taskRepository": "./lib/tasks/taskRepository.js",

--- a/test/lib/package-exports.js
+++ b/test/lib/package-exports.js
@@ -9,10 +9,10 @@ test("export of package.json", (t) => {
 	t.truthy(require("@ui5/builder/package.json").version);
 });
 
-// Check number of definied exports
+// Check number of defined exports
 test("check number of exports", (t) => {
 	const packageJson = require("@ui5/builder/package.json");
-	t.is(Object.keys(packageJson.exports).length, 8);
+	t.is(Object.keys(packageJson.exports).length, 9);
 });
 
 // Public API contract (exported modules)
@@ -80,6 +80,12 @@ test("no export of processors/jsdoc/lib/ui5/plugin", async (t) => {
 	await t.throwsAsync(import("@ui5/builder/processors/jsdoc/lib/ui5/plugin.cjs"), {
 		code: "ERR_PACKAGE_PATH_NOT_EXPORTED",
 		any: true
+	});
+});
+
+test("no export of tasks/utils/dotTheming", async (t) => {
+	await t.throwsAsync(import("@ui5/builder/tasks/utils/dotTheming"), {
+		code: "ERR_PACKAGE_PATH_NOT_EXPORTED"
 	});
 });
 

--- a/test/lib/package-exports.js
+++ b/test/lib/package-exports.js
@@ -85,7 +85,8 @@ test("no export of processors/jsdoc/lib/ui5/plugin", async (t) => {
 
 test("no export of tasks/utils/dotTheming", async (t) => {
 	await t.throwsAsync(import("@ui5/builder/tasks/utils/dotTheming"), {
-		code: "ERR_PACKAGE_PATH_NOT_EXPORTED"
+		code: "ERR_PACKAGE_PATH_NOT_EXPORTED",
+		any: true
 	});
 });
 

--- a/test/lib/tasks/generateThemeDesignerResources.js
+++ b/test/lib/tasks/generateThemeDesignerResources.js
@@ -303,7 +303,7 @@ test.serial("generateThemeDesignerResources: Library sap.ui.core with existing l
 		options: {
 			projectName: "sap.ui.core",
 			version: "1.2.3",
-			namespace: "sap/ui/core"
+			projectNamespace: "sap/ui/core"
 		}
 	});
 
@@ -394,7 +394,7 @@ test.serial("generateThemeDesignerResources: Library sap.ui.core without themes,
 		options: {
 			projectName: "sap.ui.core",
 			version: "1.2.3",
-			namespace: "sap/ui/core"
+			projectNamespace: "sap/ui/core"
 		}
 	});
 
@@ -463,7 +463,7 @@ test.serial("generateThemeDesignerResources: Library sap.ui.core with existing i
 		options: {
 			projectName: "sap.ui.core",
 			version: "1.2.3",
-			namespace: "sap/ui/core"
+			projectNamespace: "sap/ui/core"
 		}
 	}), {
 		message: "Incorrect 'sId' value 'sap/m' in /resources/sap/ui/core/.theming: Expected 'sap/ui/core'"

--- a/test/lib/tasks/generateThemeDesignerResources.js
+++ b/test/lib/tasks/generateThemeDesignerResources.js
@@ -254,6 +254,234 @@ test.serial("generateThemeDesignerResources: Library sap.ui.core", async (t) => 
 		"workspace.write should be called with libraryLessResource");
 });
 
+test.serial("generateThemeDesignerResources: Library sap.ui.core with existing library .theming", async (t) => {
+	const {sinon, generateThemeDesignerResources, libraryLessGeneratorStub, fsInterfaceStub, ResourceStub} = t.context;
+
+	const librarySourceLessResource = {
+		getPath: sinon.stub().returns("/resources/sap/ui/core/themes/base/library.source.less")
+	};
+
+	const coreLibraryDotThemingResource = {
+		getString: async () => JSON.stringify({
+			sEntity: "Library",
+			sId: "sap/ui/core",
+			aFiles: [
+				"existing", "entries"
+			]
+		}, null, 2),
+		setString: sinon.stub()
+	};
+
+	const workspace = {
+		byGlob: sinon.stub().callsFake(async (globPattern) => {
+			if (globPattern === "/resources/sap/ui/core/themes/*/library.source.less") {
+				return [librarySourceLessResource];
+			} else {
+				return [];
+			}
+		}),
+		byPath: sinon.stub().callsFake(async (virPath) => {
+			if (virPath === "/resources/sap/ui/core/themes/base/.theming") {
+				return {};
+			} else if (virPath === "/resources/sap/ui/core/.theming") {
+				return coreLibraryDotThemingResource;
+			} else {
+				return null;
+			}
+		}),
+		write: sinon.stub()
+	};
+	const dependencies = {};
+
+	const libraryLessResource = {};
+
+	libraryLessGeneratorStub.resolves([libraryLessResource]);
+
+	await generateThemeDesignerResources({
+		workspace,
+		dependencies,
+		options: {
+			projectName: "sap.ui.core",
+			version: "1.2.3",
+			namespace: "sap/ui/core"
+		}
+	});
+
+	t.is(t.context.ReaderCollectionPrioritizedStub.callCount, 1, "ReaderCollectionPrioritized should be created once");
+	t.deepEqual(t.context.ReaderCollectionPrioritizedStub.getCall(0).args, [{
+		name: `generateThemeDesignerResources - prioritize workspace over dependencies: sap.ui.core`,
+		readers: [workspace, dependencies]
+	}]);
+	const combo = t.context.ReaderCollectionPrioritizedStub.getCall(0).returnValue;
+
+	t.is(fsInterfaceStub.callCount, 1, "fsInterface should be created once");
+	t.deepEqual(fsInterfaceStub.getCall(0).args, [combo], "fsInterface should be created for 'combo'");
+	const fs = fsInterfaceStub.getCall(0).returnValue;
+
+	t.is(libraryLessGeneratorStub.callCount, 1);
+
+	t.deepEqual(libraryLessGeneratorStub.getCall(0).args[0], {
+		resources: [librarySourceLessResource],
+		fs,
+	}, "libraryLessGenerator processor should be called with expected arguments");
+
+	t.is(ResourceStub.callCount, 0, "No new resource should be created");
+
+	t.is(coreLibraryDotThemingResource.setString.callCount, 1);
+	t.deepEqual(coreLibraryDotThemingResource.setString.getCall(0).args, [
+		JSON.stringify({
+			sEntity: "Library",
+			sId: "sap/ui/core",
+			aFiles: [
+				"existing", "entries"
+			],
+			sVersion: "1.2.3",
+		}, null, 2)
+	]);
+
+	t.is(workspace.write.callCount, 2);
+	t.is(workspace.write.getCall(0).args.length, 1,
+		"workspace.write for coreLibraryDotThemingResource should be called with 1 argument");
+	t.is(workspace.write.getCall(0).args[0], coreLibraryDotThemingResource,
+		"workspace.write should be called with libraryDotTheming");
+	t.is(workspace.write.getCall(1).args.length, 1,
+		"workspace.write for libraryLessResource should be called with 1 argument");
+	t.is(workspace.write.getCall(1).args[0], libraryLessResource,
+		"workspace.write should be called with libraryLessResource");
+});
+
+test.serial("generateThemeDesignerResources: Library sap.ui.core without themes, " +
+"with existing library .theming with version", async (t) => {
+	// NOTE: This tests the case when sap.ui.core has no themes, which is not a likely scenario.
+	// But as the underlying functionality might be used in other scenarios in future, it is tested here.
+
+	const {sinon, generateThemeDesignerResources, libraryLessGeneratorStub, fsInterfaceStub, ResourceStub} = t.context;
+
+	const coreLibraryDotThemingResource = {
+		getString: async () => JSON.stringify({
+			sEntity: "Library",
+			sId: "sap/ui/core",
+			sVersion: "0.0.0", // existing version should be ignored
+			aFiles: [
+				"existing", "entries"
+			]
+		}, null, 2),
+		setString: sinon.stub()
+	};
+
+	const workspace = {
+		byGlob: sinon.stub().callsFake(async (globPattern) => {
+			return [];
+		}),
+		byPath: sinon.stub().callsFake(async (virPath) => {
+			if (virPath === "/resources/sap/ui/core/.theming") {
+				return coreLibraryDotThemingResource;
+			} else {
+				return null;
+			}
+		}),
+		write: sinon.stub()
+	};
+	const dependencies = {};
+
+	const libraryLessResource = {};
+
+	libraryLessGeneratorStub.resolves([libraryLessResource]);
+
+	await generateThemeDesignerResources({
+		workspace,
+		dependencies,
+		options: {
+			projectName: "sap.ui.core",
+			version: "1.2.3",
+			namespace: "sap/ui/core"
+		}
+	});
+
+	t.is(t.context.ReaderCollectionPrioritizedStub.callCount, 0, "ReaderCollectionPrioritized should not be created");
+
+	t.is(fsInterfaceStub.callCount, 0, "fsInterface should not be created");
+
+	t.is(libraryLessGeneratorStub.callCount, 0);
+
+	t.is(ResourceStub.callCount, 0, "No new resource should be created");
+
+	t.is(coreLibraryDotThemingResource.setString.callCount, 1);
+	t.deepEqual(coreLibraryDotThemingResource.setString.getCall(0).args, [
+		JSON.stringify({
+			sEntity: "Library",
+			sId: "sap/ui/core",
+			sVersion: "1.2.3",
+			aFiles: [
+				"existing", "entries"
+			],
+			bIgnore: true
+		}, null, 2)
+	]);
+
+	t.is(workspace.write.callCount, 1);
+	t.is(workspace.write.getCall(0).args.length, 1,
+		"workspace.write for coreLibraryDotThemingResource should be called with 1 argument");
+	t.is(workspace.write.getCall(0).args[0], coreLibraryDotThemingResource,
+		"workspace.write should be called with libraryDotTheming");
+});
+
+test.serial("generateThemeDesignerResources: Library sap.ui.core with existing invalid library .theming", async (t) => {
+	const {sinon, generateThemeDesignerResources, libraryLessGeneratorStub, fsInterfaceStub, ResourceStub} = t.context;
+
+	const coreLibraryDotThemingResource = {
+		getPath: () => "/resources/sap/ui/core/.theming",
+		getString: async () => JSON.stringify({
+			sEntity: "Library",
+			sId: "sap/m"
+		}, null, 2),
+		setString: sinon.stub()
+	};
+
+	const workspace = {
+		byGlob: sinon.stub().callsFake(async (globPattern) => {
+			return [];
+		}),
+		byPath: sinon.stub().callsFake(async (virPath) => {
+			if (virPath === "/resources/sap/ui/core/.theming") {
+				return coreLibraryDotThemingResource;
+			} else {
+				return null;
+			}
+		}),
+		write: sinon.stub()
+	};
+	const dependencies = {};
+
+	const libraryLessResource = {};
+
+	libraryLessGeneratorStub.resolves([libraryLessResource]);
+
+	await t.throwsAsync(generateThemeDesignerResources({
+		workspace,
+		dependencies,
+		options: {
+			projectName: "sap.ui.core",
+			version: "1.2.3",
+			namespace: "sap/ui/core"
+		}
+	}), {
+		message: "Incorrect 'sId' value 'sap/m' in /resources/sap/ui/core/.theming: Expected 'sap/ui/core'"
+	});
+
+	t.is(t.context.ReaderCollectionPrioritizedStub.callCount, 0, "ReaderCollectionPrioritized should not be created");
+
+	t.is(fsInterfaceStub.callCount, 0, "fsInterface should not be created");
+
+	t.is(libraryLessGeneratorStub.callCount, 0);
+
+	t.is(ResourceStub.callCount, 0, "No new resource should be created");
+
+	t.is(coreLibraryDotThemingResource.setString.callCount, 0);
+
+	t.is(workspace.write.callCount, 0);
+});
+
 test.serial("generateThemeDesignerResources: Library sap.ui.documentation is skipped", async (t) => {
 	const {sinon, generateThemeDesignerResources, libraryLessGeneratorStub, fsInterfaceStub, ResourceStub} = t.context;
 

--- a/test/lib/tasks/utils/dotTheming.js
+++ b/test/lib/tasks/utils/dotTheming.js
@@ -1,0 +1,186 @@
+import test from "ava";
+import sinonGlobal from "sinon";
+import esmock from "esmock";
+
+test.beforeEach(async (t) => {
+	t.context.sinon = sinonGlobal.createSandbox();
+	t.context.dotTheming = await esmock("../../../../lib/tasks/utils/dotTheming", {});
+
+	t.context.createDotThemingResource = (path, dotTheming) => {
+		return {
+			getPath: () => path,
+			getString: async () => JSON.stringify(dotTheming, null, 2),
+			setString: t.context.sinon.stub()
+		};
+	};
+});
+
+test.afterEach.always((t) => {
+	t.context.sinon.restore();
+});
+
+test("updateLibraryDotTheming: Default case", async (t) => {
+	const {createDotThemingResource} = t.context;
+	const {updateLibraryDotTheming} = t.context.dotTheming;
+
+	const resource = createDotThemingResource("/resources/sap/ui/core/.theming", {
+		sEntity: "Library",
+		sId: "sap/ui/core",
+		aFiles: [
+			"existing", "entries"
+		]
+	});
+
+	await updateLibraryDotTheming({
+		resource,
+		namespace: "sap/ui/core",
+		version: "1.2.3",
+		hasThemes: true
+	});
+
+	t.is(resource.setString.callCount, 1);
+	t.deepEqual(resource.setString.getCall(0).args, [
+		JSON.stringify({
+			sEntity: "Library",
+			sId: "sap/ui/core",
+			aFiles: [
+				"existing", "entries"
+			],
+			sVersion: "1.2.3",
+		}, null, 2)
+	]);
+});
+
+test("updateLibraryDotTheming: No themes", async (t) => {
+	const {createDotThemingResource} = t.context;
+	const {updateLibraryDotTheming} = t.context.dotTheming;
+
+	const resource = createDotThemingResource("/resources/sap/ui/core/.theming", {
+		sEntity: "Library",
+		sId: "sap/ui/core",
+		aFiles: [
+			"existing", "entries"
+		]
+	});
+
+	await updateLibraryDotTheming({
+		resource,
+		namespace: "sap/ui/core",
+		version: "1.2.3",
+		hasThemes: false
+	});
+
+	t.is(resource.setString.callCount, 1);
+	t.deepEqual(resource.setString.getCall(0).args, [
+		JSON.stringify({
+			sEntity: "Library",
+			sId: "sap/ui/core",
+			aFiles: [
+				"existing", "entries"
+			],
+			sVersion: "1.2.3",
+			bIgnore: true
+		}, null, 2)
+	]);
+});
+
+test("updateLibraryDotTheming: Existing sVersion", async (t) => {
+	const {createDotThemingResource} = t.context;
+	const {updateLibraryDotTheming} = t.context.dotTheming;
+
+	const resource = createDotThemingResource("/resources/sap/ui/core/.theming", {
+		sEntity: "Library",
+		sId: "sap/ui/core",
+		sVersion: "1.2.3"
+	});
+
+	await updateLibraryDotTheming({
+		resource,
+		namespace: "sap/ui/core",
+		version: "1.2.4",
+		hasThemes: true
+	});
+
+	t.is(resource.setString.callCount, 1);
+	t.deepEqual(resource.setString.getCall(0).args, [
+		JSON.stringify({
+			sEntity: "Library",
+			sId: "sap/ui/core",
+			sVersion: "1.2.4",
+		}, null, 2)
+	]);
+});
+
+test("updateLibraryDotTheming: Missing sEntity", async (t) => {
+	const {createDotThemingResource} = t.context;
+	const {updateLibraryDotTheming} = t.context.dotTheming;
+
+	const resource = createDotThemingResource("/resources/sap/ui/core/.theming", {
+		sId: "sap/ui/core",
+	});
+
+	await t.throwsAsync(updateLibraryDotTheming({
+		resource,
+		namespace: "sap/ui/core",
+		version: "1.2.3",
+		hasThemes: true
+	}), {
+		message: "Missing 'sEntity' property in /resources/sap/ui/core/.theming"
+	});
+});
+
+test("updateLibraryDotTheming: Incorrect sEntity", async (t) => {
+	const {createDotThemingResource} = t.context;
+	const {updateLibraryDotTheming} = t.context.dotTheming;
+
+	const resource = createDotThemingResource("/resources/sap/ui/core/.theming", {
+		sEntity: "Wrong",
+		sId: "sap/ui/core",
+	});
+
+	await t.throwsAsync(updateLibraryDotTheming({
+		resource,
+		namespace: "sap/ui/core",
+		version: "1.2.3",
+		hasThemes: true
+	}), {
+		message: "Incorrect 'sEntity' value 'Wrong' in /resources/sap/ui/core/.theming: Expected 'Library'"
+	});
+});
+
+test("updateLibraryDotTheming: Missing sId", async (t) => {
+	const {createDotThemingResource} = t.context;
+	const {updateLibraryDotTheming} = t.context.dotTheming;
+
+	const resource = createDotThemingResource("/resources/sap/ui/core/.theming", {
+		sEntity: "Library",
+	});
+
+	await t.throwsAsync(updateLibraryDotTheming({
+		resource,
+		namespace: "sap/ui/core",
+		version: "1.2.3",
+		hasThemes: true
+	}), {
+		message: "Missing 'sId' property in /resources/sap/ui/core/.theming"
+	});
+});
+
+test("updateLibraryDotTheming: Incorrect sId", async (t) => {
+	const {createDotThemingResource} = t.context;
+	const {updateLibraryDotTheming} = t.context.dotTheming;
+
+	const resource = createDotThemingResource("/resources/sap/ui/core/.theming", {
+		sEntity: "Library",
+		sId: "Wrong",
+	});
+
+	await t.throwsAsync(updateLibraryDotTheming({
+		resource,
+		namespace: "sap/ui/core",
+		version: "1.2.3",
+		hasThemes: true
+	}), {
+		message: "Incorrect 'sId' value 'Wrong' in /resources/sap/ui/core/.theming: Expected 'sap/ui/core'"
+	});
+});


### PR DESCRIPTION
This change respects an sap.ui.core library .theming file from the sources instead of simply overwriting the file.
It allows the configuration to be put into the library and adjusted there instead of having to adjust it in the build task.

The existing logic is kept to support older UI5 versions where the file is not available in the sources.

JIRA: CPOUI5FOUNDATION-862
(cherry picked from commit dda30114461314e81da43bd739e709186744f592)
