### PR TITLE
[INTERNAL] azure: Migrate to task 'PublishCodeCoverageResults' version 2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,11 +61,10 @@ steps:
     testResultsFormat: 'JUnit'
     testResultsFiles: '$(System.DefaultWorkingDirectory)/test-results.xml'
 
-- task: PublishCodeCoverageResults@1
+- task: PublishCodeCoverageResults@2
   displayName: Publish Test Coverage Results
   condition: succeededOrFailed()
   inputs:
-    codeCoverageTool: 'cobertura'
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml'
 
 - script: npm run coverage


### PR DESCRIPTION
For further info, see https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v2?view=azure-pipelines
