### PR TITLE
[FIX] manifestEnhancer: Only use valid files for supportedLocales

### DIFF
--- a/lib/processors/manifestEnhancer.js
+++ b/lib/processors/manifestEnhancer.js
@@ -231,7 +231,7 @@ class ManifestEnhancer {
 				if (bcp47Locale) {
 					supportedLocales.push(bcp47Locale);
 				} else {
-					log.warn(`Skipping invalid file '${fileName}' for bundle '${i18nBundleUrl}'`);
+					log.warn(`Ignoring unexpected locale in filename '${fileName}' for bundle '${i18nBundleUrl}'`);
 				}
 			}
 		});

--- a/lib/processors/manifestEnhancer.js
+++ b/lib/processors/manifestEnhancer.js
@@ -11,11 +11,14 @@ const APP_DESCRIPTOR_V22 = new Version("1.21.0");
  * Matches a legacy Java locale string, which is the format used by the UI5 Runtime (ResourceBundle)
  * to load i18n properties files.
  * Special case: "sr_Latn" is also supported, although the BCP47 script part is not supported by the Java locale format.
+ *
+ * Variants are limited to the format from BCP47, but with underscores instead of hyphens.
  */
-//                          [     language     ]    [    region    ]    [  variants  ]
-const rLegacyJavaLocale = /^([a-z]{2,3}|sr_Latn)(?:_([A-Z]{2}|\d{3})(?:_([a-zA-Z0-9]+))?)?$/;
+//                          [     language     ]    [    region    ][                variants               ]
+const rLegacyJavaLocale = /^([a-z]{2,3}|sr_Latn)(?:_([A-Z]{2}|\d{3})((?:_[0-9a-zA-Z]{5,8}|_[0-9][0-9a-zA-Z]{3})*)?)?$/;
 
-const sapSupportabilityLocales = ["saptrc", "sappsd", "saprigi"];
+// See https://github.com/SAP/openui5/blob/a8f36e430f1fac172eb705811da4a2af25483408/src/sap.ui.core/src/sap/base/i18n/ResourceBundle.js#L76
+const sapSupportabilityVariants = ["saptrc", "sappsd", "saprigi"];
 
 function getBCP47LocaleFromPropertiesFilename(locale) {
 	const match = rLegacyJavaLocale.exec(locale);
@@ -25,15 +28,20 @@ function getBCP47LocaleFromPropertiesFilename(locale) {
 	let [, language, region, variants] = match;
 	let script;
 
+	variants = variants?.slice(1); // Remove leading underscore
+
 	// Special handling of sr_Latn (see regex above)
-	// Note: This needs to be in sync with the runtime logic in sap/base/i18n/ResourceBundle
+	// Note: This needs to be in sync with the runtime logic:
+	// https://github.com/SAP/openui5/blob/a8f36e430f1fac172eb705811da4a2af25483408/src/sap.ui.core/src/sap/base/i18n/ResourceBundle.js#L202
 	if (language === "sr_Latn") {
 		language = "sr";
 		script = "Latn";
 	}
 
-	if (language === "en" && region === "US" && sapSupportabilityLocales.includes(variants)) {
-		// Convert to private use section (aligned with ResourceBundle behavior)
+	if (language === "en" && region === "US" && sapSupportabilityVariants.includes(variants)) {
+		// Convert to private use section
+		// Note: This needs to be in sync with the runtime logic:
+		// https://github.com/SAP/openui5/blob/a8f36e430f1fac172eb705811da4a2af25483408/src/sap.ui.core/src/sap/base/i18n/ResourceBundle.js#L190
 		variants = `x-${variants}`;
 	}
 
@@ -45,7 +53,8 @@ function getBCP47LocaleFromPropertiesFilename(locale) {
 		bcp47Locale += `-${region}`;
 	}
 	if (variants) {
-		bcp47Locale += `-${variants}`;
+		// Convert to BCP47 variant format
+		bcp47Locale += `-${variants.replace(/_/g, "-")}`;
 	}
 	return bcp47Locale;
 }

--- a/lib/processors/manifestEnhancer.js
+++ b/lib/processors/manifestEnhancer.js
@@ -7,42 +7,47 @@ const log = getLogger("builder:processors:manifestEnhancer");
 
 const APP_DESCRIPTOR_V22 = new Version("1.21.0");
 
-// NOTE: The following regular expression is taken from sap/base/i18n/ResourceBundle and should be kept in sync with it:
-// https://github.com/SAP/openui5/blob/22183ac8f3e31e819dd1084f7dbe71ff75b16bb9/src/sap.ui.core/src/sap/base/i18n/ResourceBundle.js
-/**
- * A regular expression that describes language tags according to BCP-47.
- *
- * @see BCP47 "Tags for Identifying Languages" (http://www.ietf.org/rfc/bcp/bcp47.txt)
- *
- * The matching groups are
- *  0=all
- *  1=language (shortest ISO639 code + ext. language sub tags | 4digits (reserved) | registered language sub tags)
- *  2=script (4 letters)
- *  3=region (2letter language or 3 digits)
- *  4=variants (separated by '-', Note: capturing group contains leading '-' to shorten the regex!)
- *  5=extensions (including leading singleton, multiple extensions separated by '-')
- *  6=private use section (including leading 'x', multiple sections separated by '-')
+/*
+ * Matches a legacy Java locale string, which is the format used by the UI5 Runtime (ResourceBundle)
+ * to load i18n properties files.
+ * Special case: "sr_Latn" is also supported, although the BCP47 script part is not supported by the Java locale format.
  */
-// eslint-disable-next-line max-len
-//                [-------------------- language ----------------------][--- script ---][------- region --------][------------- variants --------------][----------- extensions ------------][------ private use -------]
-const rLocale = /^((?:[A-Z]{2,3}(?:-[A-Z]{3}){0,3})|[A-Z]{4}|[A-Z]{5,8})(?:-([A-Z]{4}))?(?:-([A-Z]{2}|[0-9]{3}))?((?:-[0-9A-Z]{5,8}|-[0-9][0-9A-Z]{3})*)((?:-[0-9A-WYZ](?:-[0-9A-Z]{2,8})+)*)(?:-(X(?:-[0-9A-Z]{1,8})+))?$/i;
+//                          [     language     ]    [    region    ]    [  variants  ]
+const rLegacyJavaLocale = /^([a-z]{2,3}|sr_Latn)(?:_([A-Z]{2}|\d{3})(?:_([a-zA-Z0-9]+))?)?$/;
 
-function isValidPropertiesFilenameLocale(locale) {
-	// The ResourceBundle at runtime only requests locales with an underscore as separator.
-	// Files that are using a dash as separator will not be loaded and should therefore not be added
-	// to the supportedLocales.
-	if (locale.includes("-")) {
-		return false;
+const sapSupportabilityLocales = ["saptrc", "sappsd", "saprigi"];
+
+function getBCP47LocaleFromPropertiesFilename(locale) {
+	const match = rLegacyJavaLocale.exec(locale);
+	if (!match) {
+		return null;
 	}
-	// However, the regular expression only allows dashes so the input needs to be converted.
-	const m = rLocale.exec(locale.replace(/_/g, "-"));
-	if (!m) {
-		return false;
+	let [, language, region, variants] = match;
+	let script;
+
+	// Special handling of sr_Latn (see regex above)
+	// Note: This needs to be in sync with the runtime logic in sap/base/i18n/ResourceBundle
+	if (language === "sr_Latn") {
+		language = "sr";
+		script = "Latn";
 	}
-	// Extensions and private use sections are not part of the filename requested by the ResourceBundle
-	// (see normalize function in sap/base/i18n/ResourceBundle).
-	// Properties files must therefore not contain these parts.
-	return !m[5] && !m[6];
+
+	if (language === "en" && region === "US" && sapSupportabilityLocales.includes(variants)) {
+		// Convert to private use section (aligned with ResourceBundle behavior)
+		variants = `x-${variants}`;
+	}
+
+	let bcp47Locale = language;
+	if (script) {
+		bcp47Locale += `-${script}`;
+	}
+	if (region) {
+		bcp47Locale += `-${region}`;
+	}
+	if (variants) {
+		bcp47Locale += `-${variants}`;
+	}
+	return bcp47Locale;
 }
 
 function isAbsoluteUrl(url) {
@@ -212,9 +217,10 @@ class ManifestEnhancer {
 			if (fileNameWithoutExtension === i18nBundleName) {
 				supportedLocales.push("");
 			} else if (fileNameWithoutExtension.startsWith(i18nBundlePrefix)) {
-				const locale = fileNameWithoutExtension.replace(i18nBundlePrefix, "");
-				if (isValidPropertiesFilenameLocale(locale)) {
-					supportedLocales.push(locale);
+				const fileNameLocale = fileNameWithoutExtension.replace(i18nBundlePrefix, "");
+				const bcp47Locale = getBCP47LocaleFromPropertiesFilename(fileNameLocale);
+				if (bcp47Locale) {
+					supportedLocales.push(bcp47Locale);
 				} else {
 					log.warn(`Skipping invalid file '${fileName}' for bundle '${i18nBundleUrl}'`);
 				}

--- a/lib/processors/manifestEnhancer.js
+++ b/lib/processors/manifestEnhancer.js
@@ -17,7 +17,7 @@ const APP_DESCRIPTOR_V22 = new Version("1.21.0");
 //                          [     language     ]    [    region    ][                variants               ]
 const rLegacyJavaLocale = /^([a-z]{2,3}|sr_Latn)(?:_([A-Z]{2}|\d{3})((?:_[0-9a-zA-Z]{5,8}|_[0-9][0-9a-zA-Z]{3})*)?)?$/;
 
-// See https://github.com/SAP/openui5/blob/a8f36e430f1fac172eb705811da4a2af25483408/src/sap.ui.core/src/sap/base/i18n/ResourceBundle.js#L76
+// See https://github.com/SAP/openui5/blob/d7ecf2792788719d35b4eee3085a327d545bab24/src/sap.ui.core/src/sap/base/i18n/LanguageFallback.js#L10
 const sapSupportabilityVariants = ["saptrc", "sappsd", "saprigi"];
 
 function getBCP47LocaleFromPropertiesFilename(locale) {
@@ -32,7 +32,7 @@ function getBCP47LocaleFromPropertiesFilename(locale) {
 
 	// Special handling of sr_Latn (see regex above)
 	// Note: This needs to be in sync with the runtime logic:
-	// https://github.com/SAP/openui5/blob/a8f36e430f1fac172eb705811da4a2af25483408/src/sap.ui.core/src/sap/base/i18n/ResourceBundle.js#L202
+	// https://github.com/SAP/openui5/blob/d7ecf2792788719d35b4eee3085a327d545bab24/src/sap.ui.core/src/sap/base/i18n/LanguageFallback.js#L87
 	if (language === "sr_Latn") {
 		language = "sr";
 		script = "Latn";
@@ -41,7 +41,7 @@ function getBCP47LocaleFromPropertiesFilename(locale) {
 	if (language === "en" && region === "US" && sapSupportabilityVariants.includes(variants)) {
 		// Convert to private use section
 		// Note: This needs to be in sync with the runtime logic:
-		// https://github.com/SAP/openui5/blob/a8f36e430f1fac172eb705811da4a2af25483408/src/sap.ui.core/src/sap/base/i18n/ResourceBundle.js#L190
+		// https://github.com/SAP/openui5/blob/d7ecf2792788719d35b4eee3085a327d545bab24/src/sap.ui.core/src/sap/base/i18n/LanguageFallback.js#L75
 		variants = `x-${variants}`;
 	}
 

--- a/lib/processors/manifestEnhancer.js
+++ b/lib/processors/manifestEnhancer.js
@@ -170,6 +170,8 @@ class ManifestEnhancer {
 
 		this.isModified = false;
 		this.runInvoked = false;
+
+		this.supportedLocalesCache = new Map();
 	}
 
 	markModified() {
@@ -189,7 +191,14 @@ class ManifestEnhancer {
 		}
 	}
 
-	async findSupportedLocales(i18nBundleUrl) {
+	findSupportedLocales(i18nBundleUrl) {
+		if (!this.supportedLocalesCache.has(i18nBundleUrl)) {
+			this.supportedLocalesCache.set(i18nBundleUrl, this._findSupportedLocales(i18nBundleUrl));
+		}
+		return this.supportedLocalesCache.get(i18nBundleUrl);
+	}
+
+	async _findSupportedLocales(i18nBundleUrl) {
 		const i18nBundleName = path.basename(i18nBundleUrl, ".properties");
 		const i18nBundlePrefix = `${i18nBundleName}_`;
 		const i18nBundleDir = path.dirname(i18nBundleUrl);
@@ -207,7 +216,7 @@ class ManifestEnhancer {
 				if (isValidPropertiesFilenameLocale(locale)) {
 					supportedLocales.push(locale);
 				} else {
-					log.verbose(`Skipping invalid locale '${locale}' for bundle '${i18nBundleUrl}'`);
+					log.warn(`Skipping invalid file '${fileName}' for bundle '${i18nBundleUrl}'`);
 				}
 			}
 		});

--- a/lib/processors/manifestEnhancer.js
+++ b/lib/processors/manifestEnhancer.js
@@ -7,6 +7,44 @@ const log = getLogger("builder:processors:manifestEnhancer");
 
 const APP_DESCRIPTOR_V22 = new Version("1.21.0");
 
+// NOTE: The following regular expression is taken from sap/base/i18n/ResourceBundle and should be kept in sync with it:
+// https://github.com/SAP/openui5/blob/22183ac8f3e31e819dd1084f7dbe71ff75b16bb9/src/sap.ui.core/src/sap/base/i18n/ResourceBundle.js
+/**
+ * A regular expression that describes language tags according to BCP-47.
+ *
+ * @see BCP47 "Tags for Identifying Languages" (http://www.ietf.org/rfc/bcp/bcp47.txt)
+ *
+ * The matching groups are
+ *  0=all
+ *  1=language (shortest ISO639 code + ext. language sub tags | 4digits (reserved) | registered language sub tags)
+ *  2=script (4 letters)
+ *  3=region (2letter language or 3 digits)
+ *  4=variants (separated by '-', Note: capturing group contains leading '-' to shorten the regex!)
+ *  5=extensions (including leading singleton, multiple extensions separated by '-')
+ *  6=private use section (including leading 'x', multiple sections separated by '-')
+ */
+// eslint-disable-next-line max-len
+//                [-------------------- language ----------------------][--- script ---][------- region --------][------------- variants --------------][----------- extensions ------------][------ private use -------]
+const rLocale = /^((?:[A-Z]{2,3}(?:-[A-Z]{3}){0,3})|[A-Z]{4}|[A-Z]{5,8})(?:-([A-Z]{4}))?(?:-([A-Z]{2}|[0-9]{3}))?((?:-[0-9A-Z]{5,8}|-[0-9][0-9A-Z]{3})*)((?:-[0-9A-WYZ](?:-[0-9A-Z]{2,8})+)*)(?:-(X(?:-[0-9A-Z]{1,8})+))?$/i;
+
+function isValidPropertiesFilenameLocale(locale) {
+	// The ResourceBundle at runtime only requests locales with an underscore as separator.
+	// Files that are using a dash as separator will not be loaded and should therefore not be added
+	// to the supportedLocales.
+	if (locale.includes("-")) {
+		return false;
+	}
+	// However, the regular expression only allows dashes so the input needs to be converted.
+	const m = rLocale.exec(locale.replace(/_/g, "-"));
+	if (!m) {
+		return false;
+	}
+	// Extensions and private use sections are not part of the filename requested by the ResourceBundle
+	// (see normalize function in sap/base/i18n/ResourceBundle).
+	// Properties files must therefore not contain these parts.
+	return !m[5] && !m[6];
+}
+
 function isAbsoluteUrl(url) {
 	if (url.startsWith("/")) {
 		return true;
@@ -166,7 +204,11 @@ class ManifestEnhancer {
 				supportedLocales.push("");
 			} else if (fileNameWithoutExtension.startsWith(i18nBundlePrefix)) {
 				const locale = fileNameWithoutExtension.replace(i18nBundlePrefix, "");
-				supportedLocales.push(locale);
+				if (isValidPropertiesFilenameLocale(locale)) {
+					supportedLocales.push(locale);
+				} else {
+					log.verbose(`Skipping invalid locale '${locale}' for bundle '${i18nBundleUrl}'`);
+				}
 			}
 		});
 		return supportedLocales.sort();

--- a/test/expected/build/application.o/dest/Component-preload.js
+++ b/test/expected/build/application.o/dest/Component-preload.js
@@ -4,7 +4,7 @@ sap.ui.require.preload({
 	"application/o/i18n/i18n.properties":'welcome=Hello world',
 	"application/o/i18n/i18n_en.properties":'welcome=Hello EN world',
 	"application/o/i18n/i18n_en_US.properties":'welcome=Hello EN US world',
-	"application/o/i18n/i18n_en_US_sapprc.properties":'welcome=Hello EN US sapprc world',
-	"application/o/manifest.json":'{"_version":"1.22.0","sap.app":{"id":"application.o","type":"application","applicationVersion":{"version":"1.0.0"},"title":"{{title}}","i18n":{"bundleUrl":"i18n/i18n.properties","supportedLocales":["","en","en_US","en_US_sapprc"]}},"sap.ui5":{"models":{"i18n":{"type":"sap.ui.model.resource.ResourceModel","settings":{"bundleName":"application.o.i18n.i18n","supportedLocales":["","en","en_US","en_US_sapprc"]}},"i18n-ui5":{"type":"sap.ui.model.resource.ResourceModel","settings":{"bundleUrl":"ui5://application/o/i18n/i18n.properties","supportedLocales":["","en","en_US","en_US_sapprc"]}}}}}'
+	"application/o/i18n/i18n_en_US_saptrc.properties":'welcome=Hello EN US saptrc world',
+	"application/o/manifest.json":'{"_version":"1.22.0","sap.app":{"id":"application.o","type":"application","applicationVersion":{"version":"1.0.0"},"title":"{{title}}","i18n":{"bundleUrl":"i18n/i18n.properties","supportedLocales":["","en","en_US","en_US_saptrc"]}},"sap.ui5":{"models":{"i18n":{"type":"sap.ui.model.resource.ResourceModel","settings":{"bundleName":"application.o.i18n.i18n","supportedLocales":["","en","en_US","en_US_saptrc"]}},"i18n-ui5":{"type":"sap.ui.model.resource.ResourceModel","settings":{"bundleUrl":"ui5://application/o/i18n/i18n.properties","supportedLocales":["","en","en_US","en_US_saptrc"]}}}}}'
 });
 //# sourceMappingURL=Component-preload.js.map

--- a/test/expected/build/application.o/dest/Component-preload.js
+++ b/test/expected/build/application.o/dest/Component-preload.js
@@ -5,6 +5,6 @@ sap.ui.require.preload({
 	"application/o/i18n/i18n_en.properties":'welcome=Hello EN world',
 	"application/o/i18n/i18n_en_US.properties":'welcome=Hello EN US world',
 	"application/o/i18n/i18n_en_US_saptrc.properties":'welcome=Hello EN US saptrc world',
-	"application/o/manifest.json":'{"_version":"1.22.0","sap.app":{"id":"application.o","type":"application","applicationVersion":{"version":"1.0.0"},"title":"{{title}}","i18n":{"bundleUrl":"i18n/i18n.properties","supportedLocales":["","en","en_US","en_US_saptrc"]}},"sap.ui5":{"models":{"i18n":{"type":"sap.ui.model.resource.ResourceModel","settings":{"bundleName":"application.o.i18n.i18n","supportedLocales":["","en","en_US","en_US_saptrc"]}},"i18n-ui5":{"type":"sap.ui.model.resource.ResourceModel","settings":{"bundleUrl":"ui5://application/o/i18n/i18n.properties","supportedLocales":["","en","en_US","en_US_saptrc"]}}}}}'
+	"application/o/manifest.json":'{"_version":"1.22.0","sap.app":{"id":"application.o","type":"application","applicationVersion":{"version":"1.0.0"},"title":"{{title}}","i18n":{"bundleUrl":"i18n/i18n.properties","supportedLocales":["","en","en-US","en-US-x-saptrc"]}},"sap.ui5":{"models":{"i18n":{"type":"sap.ui.model.resource.ResourceModel","settings":{"bundleName":"application.o.i18n.i18n","supportedLocales":["","en","en-US","en-US-x-saptrc"]}},"i18n-ui5":{"type":"sap.ui.model.resource.ResourceModel","settings":{"bundleUrl":"ui5://application/o/i18n/i18n.properties","supportedLocales":["","en","en-US","en-US-x-saptrc"]}}}}}'
 });
 //# sourceMappingURL=Component-preload.js.map

--- a/test/expected/build/application.o/dest/i18n/i18n_en_US_sapprc.properties
+++ b/test/expected/build/application.o/dest/i18n/i18n_en_US_sapprc.properties
@@ -1,1 +1,0 @@
-welcome=Hello EN US sapprc world

--- a/test/expected/build/application.o/dest/i18n/i18n_en_US_saptrc.properties
+++ b/test/expected/build/application.o/dest/i18n/i18n_en_US_saptrc.properties
@@ -1,0 +1,1 @@
+welcome=Hello EN US saptrc world

--- a/test/expected/build/application.o/dest/manifest.json
+++ b/test/expected/build/application.o/dest/manifest.json
@@ -12,8 +12,8 @@
       "supportedLocales": [
         "",
         "en",
-        "en_US",
-        "en_US_saptrc"
+        "en-US",
+        "en-US-x-saptrc"
       ]
     }
   },
@@ -26,8 +26,8 @@
           "supportedLocales": [
             "",
             "en",
-            "en_US",
-            "en_US_saptrc"
+            "en-US",
+            "en-US-x-saptrc"
           ]
         }
       },
@@ -38,8 +38,8 @@
           "supportedLocales": [
             "",
             "en",
-            "en_US",
-            "en_US_saptrc"
+            "en-US",
+            "en-US-x-saptrc"
           ]
         }
       }

--- a/test/expected/build/application.o/dest/manifest.json
+++ b/test/expected/build/application.o/dest/manifest.json
@@ -13,7 +13,7 @@
         "",
         "en",
         "en_US",
-        "en_US_sapprc"
+        "en_US_saptrc"
       ]
     }
   },
@@ -27,7 +27,7 @@
             "",
             "en",
             "en_US",
-            "en_US_sapprc"
+            "en_US_saptrc"
           ]
         }
       },
@@ -39,7 +39,7 @@
             "",
             "en",
             "en_US",
-            "en_US_sapprc"
+            "en_US_saptrc"
           ]
         }
       }

--- a/test/fixtures/application.o/webapp/i18n/i18n_en_US_sapprc.properties
+++ b/test/fixtures/application.o/webapp/i18n/i18n_en_US_sapprc.properties
@@ -1,1 +1,0 @@
-welcome=Hello EN US sapprc world

--- a/test/fixtures/application.o/webapp/i18n/i18n_en_US_saptrc.properties
+++ b/test/fixtures/application.o/webapp/i18n/i18n_en_US_saptrc.properties
@@ -1,0 +1,1 @@
+welcome=Hello EN US saptrc world

--- a/test/lib/processors/manifestEnhancer.js
+++ b/test/lib/processors/manifestEnhancer.js
@@ -3032,13 +3032,22 @@ test("manifestEnhancer#getSupportedLocales", async (t) => {
 	fs.readdir.withArgs("/i18n")
 		.callsArgWith(1, null, [
 			"i18n.properties",
+			"i18n_ar_001.properties",
+			"i18n_crn.properties",
 			"i18n_en.properties",
 			"i18n_en_US.properties",
-			"i18n_en_US_sapprc.properties",
+			"i18n_en_US_saptrc.properties",
+			"i18n_sr_Latn_RS.properties"
 		]);
 
 	const expectedLocales = [
-		"", "en", "en_US", "en_US_sapprc"
+		"",
+		"ar-001",
+		"crn",
+		"en",
+		"en-US",
+		"en-US-x-saptrc",
+		"sr-Latn-RS"
 	];
 
 	t.deepEqual(await manifestEnhancer.getSupportedLocales("./i18n/i18n.properties"), expectedLocales);
@@ -3059,7 +3068,7 @@ test("manifestEnhancer#getSupportedLocales", async (t) => {
 	t.true(t.context.logErrorSpy.notCalled, "No errors should be logged");
 });
 
-test("manifestEnhancer#getSupportedLocales (invalid locales)", async (t) => {
+test("manifestEnhancer#getSupportedLocales (invalid file names)", async (t) => {
 	const {fs} = t.context;
 	const {ManifestEnhancer} = t.context.__internals__;
 
@@ -3083,35 +3092,43 @@ test("manifestEnhancer#getSupportedLocales (invalid locales)", async (t) => {
 		// Invalid: Should be "zh_CN"
 		"i18n_zh_CN_.properties",
 
-		// Invalid: Runtime does not include "extension" in file request
+		// Invalid: Script section is only supported for "sr_Latn"
+		"i18n_en_Latn_US.properties",
+
+		// Invalid: Legacy Java locale format does have a BCP47 "extension" section
 		"i18n_sr_Latn_RS_variant_f_11.properties",
 
-		// Invalid: Runtime does not include "privateuse" in file request
+		// Invalid: Legacy Java locale format does have a BCP47 "private use" section
 		"i18n_sr_Latn_RS_variant_x_private.properties",
 
-		// Invalid: Runtime does not include "extension" / "privateuse" in file request
+		// Invalid: Legacy Java locale format does have BCP47 "extension" / "private use" sections
 		"i18n_sr_Latn_RS_variant_f_11_x_private.properties"
 	];
 
 	fs.readdir.withArgs("/i18n")
 		.callsArgWith(1, null, fileNames);
 
-	const expectedLocales = ["", "en"];
+	const expectedLocales = [
+		"",
+		"en"
+	];
 
 	t.deepEqual(await manifestEnhancer.getSupportedLocales("./i18n/i18n.properties"), expectedLocales);
 
 	t.is(fs.readdir.callCount, 1);
 
-	t.is(t.context.logWarnSpy.callCount, 5);
+	t.is(t.context.logWarnSpy.callCount, 6);
 	t.is(t.context.logWarnSpy.getCall(0).args[0],
 		"Skipping invalid file 'i18n_en-US.properties' for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(1).args[0],
 		"Skipping invalid file 'i18n_zh_CN_.properties' for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(2).args[0],
-		"Skipping invalid file 'i18n_sr_Latn_RS_variant_f_11.properties' for bundle 'i18n/i18n.properties'");
+		"Skipping invalid file 'i18n_en_Latn_US.properties' for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(3).args[0],
-		"Skipping invalid file 'i18n_sr_Latn_RS_variant_x_private.properties' for bundle 'i18n/i18n.properties'");
+		"Skipping invalid file 'i18n_sr_Latn_RS_variant_f_11.properties' for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(4).args[0],
+		"Skipping invalid file 'i18n_sr_Latn_RS_variant_x_private.properties' for bundle 'i18n/i18n.properties'");
+	t.is(t.context.logWarnSpy.getCall(5).args[0],
 		"Skipping invalid file 'i18n_sr_Latn_RS_variant_f_11_x_private.properties' for bundle 'i18n/i18n.properties'");
 	t.true(t.context.logVerboseSpy.notCalled, "No verbose messages should be logged");
 	t.true(t.context.logErrorSpy.notCalled, "No errors should be logged");

--- a/test/lib/processors/manifestEnhancer.js
+++ b/test/lib/processors/manifestEnhancer.js
@@ -3051,7 +3051,8 @@ test("manifestEnhancer#getSupportedLocales", async (t) => {
 		"../../../../../../../../../../../../resources/sap/ui/demo/app/i18n/i18n.properties"
 	), expectedLocales);
 
-	t.is(fs.readdir.callCount, 4);
+	// findSupportedLocales caches requests, so for the same bundle readdir is only called once
+	t.is(fs.readdir.callCount, 1);
 
 	t.true(t.context.logVerboseSpy.notCalled, "No verbose messages should be logged");
 	t.true(t.context.logWarnSpy.notCalled, "No warnings should be logged");
@@ -3101,18 +3102,18 @@ test("manifestEnhancer#getSupportedLocales (invalid locales)", async (t) => {
 
 	t.is(fs.readdir.callCount, 1);
 
-	t.is(t.context.logVerboseSpy.callCount, 5);
-	t.is(t.context.logVerboseSpy.getCall(0).args[0],
-		"Skipping invalid locale 'en-US' for bundle 'i18n/i18n.properties'");
-	t.is(t.context.logVerboseSpy.getCall(1).args[0],
-		"Skipping invalid locale 'zh_CN_' for bundle 'i18n/i18n.properties'");
-	t.is(t.context.logVerboseSpy.getCall(2).args[0],
-		"Skipping invalid locale 'sr_Latn_RS_variant_f_11' for bundle 'i18n/i18n.properties'");
-	t.is(t.context.logVerboseSpy.getCall(3).args[0],
-		"Skipping invalid locale 'sr_Latn_RS_variant_x_private' for bundle 'i18n/i18n.properties'");
-	t.is(t.context.logVerboseSpy.getCall(4).args[0],
-		"Skipping invalid locale 'sr_Latn_RS_variant_f_11_x_private' for bundle 'i18n/i18n.properties'");
-	t.true(t.context.logWarnSpy.notCalled, "No warnings should be logged");
+	t.is(t.context.logWarnSpy.callCount, 5);
+	t.is(t.context.logWarnSpy.getCall(0).args[0],
+		"Skipping invalid file 'i18n_en-US.properties' for bundle 'i18n/i18n.properties'");
+	t.is(t.context.logWarnSpy.getCall(1).args[0],
+		"Skipping invalid file 'i18n_zh_CN_.properties' for bundle 'i18n/i18n.properties'");
+	t.is(t.context.logWarnSpy.getCall(2).args[0],
+		"Skipping invalid file 'i18n_sr_Latn_RS_variant_f_11.properties' for bundle 'i18n/i18n.properties'");
+	t.is(t.context.logWarnSpy.getCall(3).args[0],
+		"Skipping invalid file 'i18n_sr_Latn_RS_variant_x_private.properties' for bundle 'i18n/i18n.properties'");
+	t.is(t.context.logWarnSpy.getCall(4).args[0],
+		"Skipping invalid file 'i18n_sr_Latn_RS_variant_f_11_x_private.properties' for bundle 'i18n/i18n.properties'");
+	t.true(t.context.logVerboseSpy.notCalled, "No verbose messages should be logged");
 	t.true(t.context.logErrorSpy.notCalled, "No errors should be logged");
 });
 

--- a/test/lib/processors/manifestEnhancer.js
+++ b/test/lib/processors/manifestEnhancer.js
@@ -3173,25 +3173,28 @@ test("manifestEnhancer#getSupportedLocales (invalid file names)", async (t) => {
 
 	t.is(t.context.logWarnSpy.callCount, 10);
 	t.is(t.context.logWarnSpy.getCall(0).args[0],
-		"Skipping invalid file 'i18n_en-US.properties' for bundle 'i18n/i18n.properties'");
+		"Ignoring unexpected locale in filename 'i18n_en-US.properties' for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(1).args[0],
-		"Skipping invalid file 'i18n_zh_CN_.properties' for bundle 'i18n/i18n.properties'");
+		"Ignoring unexpected locale in filename 'i18n_zh_CN_.properties' for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(2).args[0],
-		"Skipping invalid file 'i18n_en_Latn_US.properties' for bundle 'i18n/i18n.properties'");
+		"Ignoring unexpected locale in filename 'i18n_en_Latn_US.properties' for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(3).args[0],
-		"Skipping invalid file 'i18n_sr_Latn_RS_variant_f_11.properties' for bundle 'i18n/i18n.properties'");
+		"Ignoring unexpected locale in filename 'i18n_sr_Latn_RS_variant_f_11.properties' " +
+		"for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(4).args[0],
-		"Skipping invalid file 'i18n_sr_Latn_RS_variant_x_private.properties' for bundle 'i18n/i18n.properties'");
+		"Ignoring unexpected locale in filename 'i18n_sr_Latn_RS_variant_x_private.properties' " +
+		"for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(5).args[0],
-		"Skipping invalid file 'i18n_sr_Latn_RS_variant_f_11_x_private.properties' for bundle 'i18n/i18n.properties'");
+		"Ignoring unexpected locale in filename 'i18n_sr_Latn_RS_variant_f_11_x_private.properties' " +
+		"for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(6).args[0],
-		"Skipping invalid file 'i18n_de_CH_var.properties' for bundle 'i18n/i18n.properties'");
+		"Ignoring unexpected locale in filename 'i18n_de_CH_var.properties' for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(7).args[0],
-		"Skipping invalid file 'i18n_de_CH_variant11.properties' for bundle 'i18n/i18n.properties'");
+		"Ignoring unexpected locale in filename 'i18n_de_CH_variant11.properties' for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(8).args[0],
-		"Skipping invalid file 'i18n_de_CH_001FOOBAR.properties' for bundle 'i18n/i18n.properties'");
+		"Ignoring unexpected locale in filename 'i18n_de_CH_001FOOBAR.properties' for bundle 'i18n/i18n.properties'");
 	t.is(t.context.logWarnSpy.getCall(9).args[0],
-		"Skipping invalid file 'i18n_en_US_x_saprigi.properties' for bundle 'i18n/i18n.properties'");
+		"Ignoring unexpected locale in filename 'i18n_en_US_x_saprigi.properties' for bundle 'i18n/i18n.properties'");
 	t.true(t.context.logVerboseSpy.notCalled, "No verbose messages should be logged");
 	t.true(t.context.logErrorSpy.notCalled, "No errors should be logged");
 });


### PR DESCRIPTION
This fixes two problems that could have occurred:

A properties file with an invalid locale was still taken into the list of supported locales, which then caused a runtime exception in the ResourceBundle as it validates the input.

Another problem was that properties files could have a valid name according to BCP47, but the file won't be ever requested with that name.
This is due to the fact that the ResourceBundle does use the legacy Java locale format (using underscores instead of dashes) for the request URL.

In both cases, the properties file is now ignored and no entry for the supportedLocales is created.

Only locales that are valid according to the legacy Java locale format are considered.
However, there is one special case: sr_Latn is also requested by the UI5 runtime, although it contains a BCP47 script, which is not valid according to the legacy Java locale format.