### PR TITLE
[INTERNAL] Fix VisitorKeys consistency test

### DIFF
--- a/test/lib/lbt/analyzer/JSModuleAnalyzer.js
+++ b/test/lib/lbt/analyzer/JSModuleAnalyzer.js
@@ -129,7 +129,7 @@ test("Check for consistency between VisitorKeys and EnrichedVisitorKeys", (t) =>
 	// Only then, the if-clause below should be changed to the new ecmaVersion to prevent the test
 	// from failing when new VisitorKeys are available via espree.
 
-	if (ecmaVersion > 2022) {
+	if (ecmaVersion > 2023) {
 		Object.keys(VisitorKeys).forEach( (type) => {
 			// Ignore deprecated keys:
 			// - ExperimentalSpreadProperty => SpreadElement


### PR DESCRIPTION
The ES2023 support change (via #1034) missed to update the ECMA version
to activate the VisitorKeys consistency test.

(cherry picked from commit 8afc5c1c5679cfc203f371c0e61634a9892eb41e)