### PR TITLE
[FIX] minify: In case of error, include full resource path in the error messsage

### DIFF
--- a/lib/processors/minifier.js
+++ b/lib/processors/minifier.js
@@ -274,6 +274,7 @@ export default async function({
 			filename,
 			dbgFilename,
 			code,
+			resourcePath,
 			sourceMapOptions
 		}, taskUtil);
 		resource.setString(result.code);

--- a/lib/processors/minifierWorker.js
+++ b/lib/processors/minifierWorker.js
@@ -30,6 +30,7 @@ const copyrightCommentsAndBundleCommentPattern = /copyright|\(c\)(?:[0-9]+|\s+[0
  * @param {string} parameters.filename
  * @param {string} parameters.dbgFilename
  * @param {string} parameters.code
+ * @param {string} parameters.resourcePath
  * @param {object} parameters.sourceMapOptions
  * @returns {Promise<undefined>} Promise resolving once minification of the resource has finished
  */
@@ -37,6 +38,7 @@ export default async function execMinification({
 	filename,
 	dbgFilename,
 	code,
+	resourcePath,
 	sourceMapOptions
 }) {
 	try {
@@ -61,7 +63,7 @@ export default async function execMinification({
 	} catch (err) {
 		// Note: err.filename contains the debug-name
 		throw new Error(
-			`Minification failed with error: ${err.message} in file ${filename} ` +
+			`Minification failed with error: ${err.message} in file ${resourcePath} ` +
 			`(line ${err.line}, col ${err.col}, pos ${err.pos})`, {
 				cause: err
 			});


### PR DESCRIPTION
As suggested by Vest in https://github.com/SAP/ui5-tooling/issues/890#issuecomment-2580779768, this should make it easier to identify the resource causing an error in the minify task.