### PR TITLE
[FEATURE]: Rewrite dataSource uri for sap.cloud applications

### DIFF
--- a/lib/processors/manifestEnhancer.js
+++ b/lib/processors/manifestEnhancer.js
@@ -258,6 +258,26 @@ class ManifestEnhancer {
 		}
 	}
 
+	processDataSourceUri() {
+		const sapCloud = this.manifest["sap.cloud"];
+		const sapApp = this.manifest["sap.app"];
+		// On BTP with approuter the uri with a slash is fetched from the approuter directly
+		// and only without the slash the correct path via the destination configured in sap.cloud is used
+		if (sapApp?.dataSources && sapCloud) {
+			for (const sDataSourceName in sapApp.dataSources) {
+				if (typeof sDataSourceName === "string") {
+					const oDataSource = sapApp.dataSources[sDataSourceName];
+					if (oDataSource.uri) {
+						if (oDataSource.uri[0] === "/") {
+							oDataSource.uri = oDataSource.uri.substring(1);
+						}
+					}
+				}
+			}
+			this.markModified();
+		}
+	}
+
 	/**
 	 *	Processes the terminologies and enhanceWith bundles of a bundle configuration.
 	 *
@@ -378,7 +398,8 @@ class ManifestEnhancer {
 		} else {
 			await Promise.all([
 				this.processSapAppI18n(),
-				this.processSapUi5Models()
+				this.processSapUi5Models(),
+				this.processDataSourceUri()
 			]);
 		}
 

--- a/lib/tasks/enhanceManifest.js
+++ b/lib/tasks/enhanceManifest.js
@@ -5,7 +5,8 @@ import fsInterface from "@ui5/fs/fsInterface";
 /**
  * Task for transforming the manifest.json file.
  * Adds missing information based on the available project resources,
- * for example the locales supported by the present i18n resources.
+ * for example the locales supported by the present i18n resources
+ * or removing the first / of a data source uri if sap.cloud is configured.
  *
  * @public
  * @function default


### PR DESCRIPTION
Hi colleagues,

currently the package '@sap/ui5-builder-webide-extension' rewrites the dataSource uri and removes any leading slash for sap.cloud applications. 
This is needed, because only when no leading slash exists will the source be correctly queried via its destination, which is defined in sap.cloud.

Because the package didn't receive any update in 3 years, and their ui5 tooling dependencies are outdated, I open this PR to add the rewrite to the native UI5 Tooling to replace the '@sap/ui5-builder-webide-extension' package.

BR,
Marten