### PR TITLE
[INTERNAL] azure-pipelines.yml: add node v24 to test matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,15 @@ strategy:
     windows_node_22:
       imageName: 'windows-2022'
       node_version: 22.x
+    linux_node_24:
+      imageName: 'ubuntu-24.04'
+      node_version: 24.x
+    mac_node_24:
+      imageName: 'macos-13'
+      node_version: 24.x
+    windows_node_24:
+      imageName: 'windows-2022'
+      node_version: 24.x
 
 pool:
   vmImage: $(imageName)

--- a/test/utils/fshelper.js
+++ b/test/utils/fshelper.js
@@ -3,7 +3,7 @@ import path from "node:path";
 
 export async function findFiles(dirPath) {
 	const files = await readdir(dirPath, {withFileTypes: true, recursive: true});
-	return files.filter((file) => file.isFile()).map((file) => path.join(file.path, file.name));
+	return files.filter((file) => file.isFile()).map((file) => path.join(file.parentPath || file.path, file.name));
 }
 
 export async function readFileContent(filePath) {


### PR DESCRIPTION
Fix use of deprecated node:fs#Dirent.path. Node v24 removed it, however
in older versions the successor "parentPath" is not yet available.
Therefore we need to fallback to Dirent.path if Dirent.parentPath is
undefined.