### PR TITLE
[FEATURE] Add 'flexBundle'-flag in the manifest via generateFlexChangeBundle

### DIFF
--- a/lib/tasks/bundlers/generateFlexChangesBundle.js
+++ b/lib/tasks/bundlers/generateFlexChangesBundle.js
@@ -14,7 +14,7 @@ import semver from "semver";
  * at runtime.
  * If a change bundle is created, "sap.ui.fl" is added as a dependency to the manifest.json if not already present -
  * if the dependency is already listed but lazy-loaded, lazy loading is disabled.
- * If minUI5Version >= 1.73 flexibility-bundle.json will be create.
+ * If minUI5Version >= 1.73 flexibility-bundle.json is created.
  * If there are control variants and minUI5Version < 1.73 build will break and throw an error.
  *
  * @public
@@ -24,8 +24,8 @@ import semver from "semver";
  * @param {object} parameters Parameters
  * @param {@ui5/fs/DuplexCollection} parameters.workspace DuplexCollection to read and write files
  * @param {@ui5/project/build/helpers/TaskUtil|object} [parameters.taskUtil] TaskUtil
- * @param {object} [parameters.options] Options
- * @param {string} [parameters.options.projectNamespace] Project Namespace
+ * @param {object} [options] Options
+ * @param {string} [options.projectNamespace] Project Namespace
  * @returns {Promise<undefined>} Promise resolving with <code>undefined</code> once data has been written
  */
 export default async function({workspace, taskUtil, options = {}}) {
@@ -38,29 +38,34 @@ export default async function({workspace, taskUtil, options = {}}) {
 		pathPrefix = `/resources/${namespace}`;
 	}
 
-	function updateJson(data) {
-		// ensure the existence of the libs section in the dependencies
+	function updateJson(data, bBundleCreated) {
 		data["sap.ui5"] = data["sap.ui5"] || {};
-		data["sap.ui5"].dependencies = data["sap.ui5"].dependencies || {};
-		const mLibs = data["sap.ui5"].dependencies.libs = data["sap.ui5"].dependencies.libs || {};
+		// explicit set the flag to inform the runtime if a bundle is present before the preload can be interpreted
+		data["sap.ui5"].flexBundle = bBundleCreated;
 
-		if (mLibs["sap.ui.fl"]) {
-			log.verbose("sap.ui.fl found in manifest.json");
-			if (mLibs["sap.ui.fl"].lazy) {
-				log.verbose("sap.ui.fl 'lazy' attribute found in manifest.json, setting it to false...");
-				mLibs["sap.ui.fl"].lazy = false;
+		if (bBundleCreated) {
+			// ensure the existence of the libs section in the dependencies
+			data["sap.ui5"].dependencies = data["sap.ui5"].dependencies || {};
+			const mLibs = data["sap.ui5"].dependencies.libs = data["sap.ui5"].dependencies.libs || {};
+
+			if (mLibs["sap.ui.fl"]) {
+				log.verbose("sap.ui.fl found in manifest.json");
+				if (mLibs["sap.ui.fl"].lazy) {
+					log.verbose("sap.ui.fl 'lazy' attribute found in manifest.json, setting it to false...");
+					mLibs["sap.ui.fl"].lazy = false;
+				}
+			} else {
+				log.verbose("sap.ui.fl not found in manifest.json, inserting it...");
+				mLibs["sap.ui.fl"] = {};
 			}
-		} else {
-			log.verbose("sap.ui.fl not found in manifest.json, inserting it...");
-			mLibs["sap.ui.fl"] = {};
 		}
 	}
 
-	async function updateFLdependency() {
+	async function updateManifestWithFlDependencyAndFlexBundleFlag(bBundleCreated) {
 		const manifestResource = await workspace.byPath(`${pathPrefix}/manifest.json`);
 		const manifestContent = JSON.parse(await manifestResource.getString());
 
-		updateJson(manifestContent);
+		updateJson(manifestContent, bBundleCreated);
 		manifestResource.setString(JSON.stringify(manifestContent, null, "\t"));
 
 		await workspace.write(manifestResource);
@@ -108,10 +113,9 @@ export default async function({workspace, taskUtil, options = {}}) {
 			log.verbose("Writing flexibility changes bundle");
 			return workspace.write(resource);
 		}));
-		// Add the sap.ui.fl dependency if a bundle has been created
-		if (processedResources.length > 0) {
-			await updateFLdependency();
-		}
+		// Add the sap.ui.fl dependency if a bundle has been created and flag if a bundle was created
+		const bBundleCreated = processedResources.length > 0;
+		await updateManifestWithFlDependencyAndFlexBundleFlag(bBundleCreated);
 
 		// Do not write bundled source files to build result
 		if (taskUtil) {

--- a/test/lib/tasks/bundlers/generateFlexChangesBundle.js
+++ b/test/lib/tasks/bundlers/generateFlexChangesBundle.js
@@ -8,13 +8,13 @@ function createPlaceholderResource(content) {
 		name: "file",
 		getBuffer: async () => JSON.stringify(content),
 		getString: () => JSON.stringify(content),
-		setString: (string) => undefined
+		setString: () => undefined
 	};
 }
 
 function createPlaceholderWorkspace(changes, manifest, flexBundle) {
 	return {
-		byGlob: async (path) => changes.map(createPlaceholderResource),
+		byGlob: async () => changes.map(createPlaceholderResource),
 		byPath: async (path) => {
 			if ( path.includes("manifest.json") ) {
 				return createPlaceholderResource(manifest);
@@ -151,6 +151,17 @@ function createPlaceholderWorkspace(changes, manifest, flexBundle) {
 
 		const path = await stub.getCall(0).args[0].getPath();
 		t.is(path, "/resources/mypath/changes/flexibility-bundle.json");
+
+		const writtenManifest = JSON.parse(await stub.getCall(1).args[0].getString());
+		t.deepEqual(writtenManifest, {
+			"sap.ui5": {
+				dependencies: {
+					minUI5Version: minVersion
+				},
+				flexBundle: true
+			}
+		}, "Result must contain the same content");
+
 	});
 });
 


### PR DESCRIPTION
…FlexChangesBundle task

Currently, the runtime checks the existence of the flexibility-bundle.json depending on the preloading of the bundle itself. This preload of all component sources may not be in time for annotation changes, which are part of the preprocessing and require a more explicit hint, if the bundle is present and should be requested. This commit adds this hint with a flag in the "sap.ui5" subsection in the manifest.

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/main/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/main/CONTRIBUTING.md#how-to-contribute) section 
- [x] [No merge commits](https://github.com/SAP/ui5-tooling/blob/main/docs/Guidelines.md#no-merge-commits)
- [x] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/main/docs/Guidelines.md#commit-message-style)
