### PR TITLE
[FIX] Downgrade cheerio to v1.0.0 to resolve Node compatibility issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@jridgewell/sourcemap-codec": "^1.5.5",
 				"@ui5/fs": "^4.0.1",
 				"@ui5/logger": "^4.0.1",
-				"cheerio": "1.1.0",
+				"cheerio": "1.0.0",
 				"escape-unicode": "^0.2.0",
 				"escope": "^4.0.0",
 				"espree": "^10.4.0",
@@ -2285,20 +2285,21 @@
 			}
 		},
 		"node_modules/cheerio": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.0.tgz",
-			"integrity": "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+			"integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+			"license": "MIT",
 			"dependencies": {
 				"cheerio-select": "^2.1.0",
 				"dom-serializer": "^2.0.0",
 				"domhandler": "^5.0.3",
-				"domutils": "^3.2.2",
+				"domutils": "^3.1.0",
 				"encoding-sniffer": "^0.2.0",
-				"htmlparser2": "^10.0.0",
-				"parse5": "^7.3.0",
-				"parse5-htmlparser2-tree-adapter": "^7.1.0",
+				"htmlparser2": "^9.1.0",
+				"parse5": "^7.1.2",
+				"parse5-htmlparser2-tree-adapter": "^7.0.0",
 				"parse5-parser-stream": "^7.1.2",
-				"undici": "^7.10.0",
+				"undici": "^6.19.5",
 				"whatwg-mimetype": "^4.0.0"
 			},
 			"engines": {
@@ -4582,9 +4583,9 @@
 			"dev": true
 		},
 		"node_modules/htmlparser2": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-			"integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+			"integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
 			"funding": [
 				"https://github.com/fb55/htmlparser2?sponsor=1",
 				{
@@ -4592,22 +4593,12 @@
 					"url": "https://github.com/sponsors/fb55"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.3",
-				"domutils": "^3.2.1",
-				"entities": "^6.0.0"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/entities": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
+				"domutils": "^3.1.0",
+				"entities": "^4.5.0"
 			}
 		},
 		"node_modules/http-cache-semantics": {
@@ -8643,11 +8634,12 @@
 			"integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
 		},
 		"node_modules/undici": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.15.0.tgz",
-			"integrity": "sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==",
+			"version": "6.21.3",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+			"integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=20.18.1"
+				"node": ">=18.17"
 			}
 		},
 		"node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
 		"@jridgewell/sourcemap-codec": "^1.5.5",
 		"@ui5/fs": "^4.0.1",
 		"@ui5/logger": "^4.0.1",
-		"cheerio": "1.1.0",
+		"cheerio": "1.0.0",
 		"escape-unicode": "^0.2.0",
 		"escope": "^4.0.0",
 		"espree": "^10.4.0",


### PR DESCRIPTION
Cheerio v1.1.0 upgraded their dependency to "undici" which now requires "node": ">=20.18.1". This is not compatibly with the current Node support in this project.

See: https://github.com/cheeriojs/cheerio/issues/4747
