### PR TITLE
[INTERNAL] generateLibraryPreload: Rename experimental content bundle and add manifest.json flag

### DIFF
--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -491,11 +491,18 @@ async function createManifest(
 				}
 			}
 
-			return {
+			const libraryMetadata = {
 				i18n: i18n(),
 				css: css(),
 				content: content()
 			};
+
+			if (process.env.UI5_CLI_EXPERIMENTAL_BUNDLE_INFO_PRELOAD) {
+				// Add flag indicating that the (currently experimental) bundleVersion 2 preload bundling is used
+				libraryMetadata.bundleVersion = 2;
+			}
+
+			return libraryMetadata;
 		}
 
 		const sapUI5 = {

--- a/lib/processors/manifestEnhancer.js
+++ b/lib/processors/manifestEnhancer.js
@@ -441,6 +441,12 @@ class ManifestEnhancer {
 
 		if (this.manifest["sap.app"].type === "library") {
 			await this.processSapUi5LibraryI18n();
+
+			if (process.env.UI5_CLI_EXPERIMENTAL_BUNDLE_INFO_PRELOAD) {
+				// Add flag indicating that the (currently experimental) bundleVersion 2 preload bundling is used
+				this.manifest["sap.ui5"].library ??= {};
+				this.manifest["sap.ui5"].library.bundleVersion = 2;
+			}
 		} else {
 			await Promise.all([
 				this.processSapAppI18n(),

--- a/lib/tasks/bundlers/generateLibraryPreload.js
+++ b/lib/tasks/bundlers/generateLibraryPreload.js
@@ -141,7 +141,7 @@ function getBundleInfoPreloadDefinition(namespace, excludes, coreVersion) {
 	},
 	{
 		mode: "bundleInfo",
-		name: `${namespace}/library-content.js`,
+		name: `${namespace}/_library-content.js`,
 		filters: getDefaultLibraryPreloadFilters(namespace, excludes),
 		resolve: false,
 		resolveConditional: false,
@@ -181,7 +181,7 @@ function getBundleInfoPreloadDefinition(namespace, excludes, coreVersion) {
 
 function getContentBundleDefinition(namespace, excludes) {
 	return {
-		name: `${namespace}/library-content.js`,
+		name: `${namespace}/_library-content.js`,
 		sections: [{
 			mode: "provided",
 			filters: getExperimentalDefaultLibraryPreloadFilters(namespace, excludes),
@@ -525,6 +525,24 @@ export default async function({workspace, taskUtil, options: {skipBundles = [], 
 								`Using experimental bundling with bundle info preload ` +
 								`for library ${libraryNamespace} in project ${projectName}`);
 							log.info(`Detected sap.ui.core version is ${coreVersion || "unknown"}`);
+
+
+							if (skipBundles.includes(`${libraryNamespace}/library-preload.js`) &&
+								!skipBundles.includes(`${libraryNamespace}/_library-content.js`)) {
+								// If the standard preload bundle is skipped, ensure to also skip the content bundle,
+								// since they depend on each other
+								skipBundles.push(`${libraryNamespace}/_library-content.js`);
+							}
+
+							if (skipBundles.includes(`${libraryNamespace}/_library-content.js`) &&
+								!skipBundles.includes(`${libraryNamespace}/library-preload.js`)) {
+								// If the content bundle is skipped, the default preload bundle must be skipped as well
+								throw new Error(
+									`A custom bundle '${libraryNamespace}/_library-content.js' has been defined, ` +
+									`but it also requires a corresponding custom bundle definition for ` +
+									`'${libraryNamespace}/library-preload.js'`);
+							}
+
 							// Experimental bundling with bundle info preload
 							results = await Promise.all([
 								execModuleBundlerIfNeeded({


### PR DESCRIPTION
* Rename the new bundle to _library-content.js
* Add a marker to the generated manifest.json: `"sap.ui5".library.bundleVersion` with a value `2`

JIRA: CPOUI5FOUNDATION-1165