### PR TITLE
[FIX] Bundling: generateFlexChangesBundle should not rely on existing manifest.json

### DIFF
--- a/lib/tasks/bundlers/generateFlexChangesBundle.js
+++ b/lib/tasks/bundlers/generateFlexChangesBundle.js
@@ -63,6 +63,10 @@ export default async function({workspace, taskUtil, options = {}}) {
 
 	async function updateManifestWithFlDependencyAndFlexBundleFlag(bBundleCreated) {
 		const manifestResource = await workspace.byPath(`${pathPrefix}/manifest.json`);
+		if (!manifestResource) {
+			log.verbose("No manifest.json found, skipping update of sap.ui.fl dependency and flexBundle flag");
+			return;
+		}
 		const manifestContent = JSON.parse(await manifestResource.getString());
 
 		updateJson(manifestContent, bBundleCreated);
@@ -73,6 +77,10 @@ export default async function({workspace, taskUtil, options = {}}) {
 
 	async function readManifestMinUI5Version() {
 		const manifestResource = await workspace.byPath(`${pathPrefix}/manifest.json`);
+		if (!manifestResource) {
+			log.verbose("No manifest.json found, cannot read minUI5Version");
+			return [];
+		}
 		const manifestContent = JSON.parse(await manifestResource.getString());
 
 		manifestContent["sap.ui5"] = manifestContent["sap.ui5"] || {};

--- a/test/lib/tasks/bundlers/generateFlexChangesBundle.js
+++ b/test/lib/tasks/bundlers/generateFlexChangesBundle.js
@@ -636,7 +636,7 @@ test("task does not fail when manifest.json is missing but changes exist", async
 		});
 	}, "Task should not fail when manifest.json is missing even with changes");
 
-	// Verify it's not trying to write to manifest.json
+	// Verify the task created the flexibility-bundle.json
 	const writeCalls = [];
 	for (let i = 0; i < placeholderWorkspace.write.callCount; i++) {
 		const call = placeholderWorkspace.write.getCall(i);
@@ -644,6 +644,9 @@ test("task does not fail when manifest.json is missing but changes exist", async
 		writeCalls.push(path);
 	}
 
+	// Should have written flexibility-bundle.json but NOT manifest.json
+	t.true(writeCalls.some((path) => path.includes("flexibility-bundle.json")),
+		"flexibility-bundle.json should be created");
 	t.false(writeCalls.some((path) => path.includes("manifest.json")),
 		"No manifest.json write should occur when manifest is missing");
 });

--- a/test/lib/tasks/bundlers/generateFlexChangesBundle.js
+++ b/test/lib/tasks/bundlers/generateFlexChangesBundle.js
@@ -579,3 +579,71 @@ test("flexBundle property overrides existing value when bundle is created", asyn
 	t.true(manifestContent["sap.ui5"].flexBundle, "flexBundle should be overridden to true when bundle is created");
 	t.deepEqual(manifestContent["sap.ui5"].dependencies.libs["sap.ui.fl"], {}, "sap.ui.fl dependency should be added");
 });
+
+test("task does not fail when manifest.json is missing and no changes exist", async (t) => {
+	const placeholderWorkspace = {
+		byGlob: async () => [], // No changes
+		byPath: async (path) => {
+			// Return null for all paths (no manifest.json, no flexibility-bundle.json)
+			return null;
+		},
+		write: sinon.stub().returnsArg(0)
+	};
+
+	// This should not throw an error
+	await t.notThrowsAsync(async () => {
+		await generateFlexChangesBundle({
+			workspace: placeholderWorkspace,
+			taskUtil: false,
+			options: {
+				projectNamespace: "sap/ui/demo/app"
+			}
+		});
+	}, "Task should not fail when manifest.json is missing");
+
+	// No write calls should have been made since there's no manifest and no changes
+	t.is(placeholderWorkspace.write.callCount, 0, "workspace.write should not be called when manifest is missing");
+});
+
+test("task does not fail when manifest.json is missing but changes exist", async (t) => {
+	const changeList = [{
+		"fileName": "test_change",
+		"fileType": "change",
+		"changeType": "rename",
+		"reference": "test.Component",
+		"content": {},
+		"selector": {"id": "testId"},
+		"layer": "CUSTOMER"
+	}];
+
+	const placeholderWorkspace = {
+		byGlob: async () => changeList.map((change) => createPlaceholderResource(change)),
+		byPath: async (path) => {
+			// Return null for all paths (no manifest.json, no flexibility-bundle.json)
+			return null;
+		},
+		write: sinon.stub().returnsArg(0)
+	};
+
+	// This should not throw an error
+	await t.notThrowsAsync(async () => {
+		await generateFlexChangesBundle({
+			workspace: placeholderWorkspace,
+			taskUtil: false,
+			options: {
+				projectNamespace: "sap/ui/demo/app"
+			}
+		});
+	}, "Task should not fail when manifest.json is missing even with changes");
+
+	// Verify it's not trying to write to manifest.json
+	const writeCalls = [];
+	for (let i = 0; i < placeholderWorkspace.write.callCount; i++) {
+		const call = placeholderWorkspace.write.getCall(i);
+		const path = call.args[0].getPath ? await call.args[0].getPath() : "unknown";
+		writeCalls.push(path);
+	}
+
+	t.false(writeCalls.some((path) => path.includes("manifest.json")),
+		"No manifest.json write should occur when manifest is missing");
+});


### PR DESCRIPTION
When running the `generateFlexChangesBundle` task, `manifest.json` might not be present.

Follow-up of https://github.com/SAP/ui5-builder/pull/1164