### PR TITLE
[INTERNAL] Pin eslint-plugin-jsdoc to 61.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"eslint": "^9.39.2",
 				"eslint-config-google": "^0.14.0",
 				"eslint-plugin-ava": "^15.1.0",
-				"eslint-plugin-jsdoc": "^52.0.4",
+				"eslint-plugin-jsdoc": "61.5.0",
 				"esmock": "^2.7.3",
 				"globals": "^16.5.0",
 				"line-column": "^1.0.2",
@@ -535,20 +535,30 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.52.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.52.0.tgz",
-			"integrity": "sha512-BXuN7BII+8AyNtn57euU2Yxo9yA/KUDNzrpXyi3pfqKmBhhysR6ZWOebFh3vyPoqA3/j1SOvGgucElMGwlXing==",
+			"version": "0.76.0",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.76.0.tgz",
+			"integrity": "sha512-g+RihtzFgGTx2WYCuTHbdOXJeAlGnROws0TeALx9ow/ZmOROOZkVg5wp/B44n0WJgI4SQFP1eWM2iRPlU2Y14w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.8",
-				"@typescript-eslint/types": "^8.34.1",
+				"@typescript-eslint/types": "^8.46.0",
 				"comment-parser": "1.4.1",
 				"esquery": "^1.6.0",
-				"jsdoc-type-pratt-parser": "~4.1.0"
+				"jsdoc-type-pratt-parser": "~6.10.0"
 			},
 			"engines": {
 				"node": ">=20.11.0"
+			}
+		},
+		"node_modules/@es-joy/resolve.exports": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+			"integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -1389,6 +1399,19 @@
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/@sindresorhus/base62": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+			"integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@sindresorhus/merge-streams": {
@@ -3910,22 +3933,26 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "52.0.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-52.0.4.tgz",
-			"integrity": "sha512-be5OzGlLExvcK13Il3noU7/v7WmAQGenTmCaBKf1pwVtPOb6X+PGFVnJad0QhMj4KKf45XjE4hbsBxv25q1fTg==",
+			"version": "61.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-61.5.0.tgz",
+			"integrity": "sha512-PR81eOGq4S7diVnV9xzFSBE4CDENRQGP0Lckkek8AdHtbj+6Bm0cItwlFnxsLFriJHspiE3mpu8U20eODyToIg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.52.0",
+				"@es-joy/jsdoccomment": "~0.76.0",
+				"@es-joy/resolve.exports": "1.2.0",
 				"are-docs-informative": "^0.0.2",
 				"comment-parser": "1.4.1",
-				"debug": "^4.4.1",
+				"debug": "^4.4.3",
 				"escape-string-regexp": "^4.0.0",
 				"espree": "^10.4.0",
 				"esquery": "^1.6.0",
+				"html-entities": "^2.6.0",
+				"object-deep-merge": "^2.0.0",
 				"parse-imports-exports": "^0.2.4",
-				"semver": "^7.7.2",
-				"spdx-expression-parse": "^4.0.0"
+				"semver": "^7.7.3",
+				"spdx-expression-parse": "^4.0.0",
+				"to-valid-identifier": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=20.11.0"
@@ -4958,6 +4985,23 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/html-entities": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+			"integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/mdevils"
+				},
+				{
+					"type": "patreon",
+					"url": "https://patreon.com/mdevils"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -5746,13 +5790,13 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
-			"integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-6.10.0.tgz",
+			"integrity": "sha512-+LexoTRyYui5iOhJGn13N9ZazL23nAHGkXsa1p/C8yeq79WRfLBag6ZZ0FQG2aRoc9yfo59JT9EYCQonOkHKkQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/jsdoc/node_modules/escape-string-regexp": {
@@ -7059,6 +7103,13 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/object-deep-merge": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
+			"integrity": "sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8076,6 +8127,19 @@
 			"license": "MIT",
 			"dependencies": {
 				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/reserved-identifiers": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+			"integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/resolve": {
@@ -9252,6 +9316,23 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/to-valid-identifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+			"integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/base62": "^1.0.0",
+				"reserved-identifiers": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/token-types": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
 		"eslint": "^9.39.2",
 		"eslint-config-google": "^0.14.0",
 		"eslint-plugin-ava": "^15.1.0",
-		"eslint-plugin-jsdoc": "^52.0.4",
+		"eslint-plugin-jsdoc": "61.5.0",
 		"esmock": "^2.7.3",
 		"globals": "^16.5.0",
 		"line-column": "^1.0.2",


### PR DESCRIPTION
Higher versions require a slightly higher Node.js version (20.19.0) than currently required by this project (20.11.0)
