### PR TITLE
[FIX] manifestCreator: Omit supportedThemes for manifest version 2.0.0

### DIFF
--- a/lib/processors/manifestCreator.js
+++ b/lib/processors/manifestCreator.js
@@ -23,6 +23,7 @@ const APP_DESCRIPTOR_V3_OTHER_SECTIONS = new Version("1.1.0");
 const APP_DESCRIPTOR_V5 = new Version("1.4.0");
 const APP_DESCRIPTOR_V10 = new Version("1.9.0");
 const APP_DESCRIPTOR_V22 = new Version("1.21.0");
+const APP_DESCRIPTOR_V2_0_0 = new Version("2.0.0");
 
 // namespaces used in .library files
 const XMLNS_UILIB = "http://www.sap.com/sap.ui.library.xsd";
@@ -382,11 +383,14 @@ async function createManifest(
 		const sapUi = {
 			_version: sectionVersion(APP_DESCRIPTOR_V3_OTHER_SECTIONS),
 			technology: "UI5",
-			deviceTypes: deviceTypes(),
-			supportedThemes: collectThemes()
+			deviceTypes: deviceTypes()
 		};
 
-		log.verbose(`  sap.ui/supportedThemes determined from resources: '${sapUi.supportedThemes.join(", ")}'`);
+		// The "supportedThemes" property is not allowed in manifest version 2.0.0 and higher
+		if ( descriptorVersion.compare(APP_DESCRIPTOR_V2_0_0) < 0 ) {
+			sapUi.supportedThemes = collectThemes();
+			log.verbose(`  sap.ui/supportedThemes determined from resources: '${sapUi.supportedThemes.join(", ")}'`);
+		}
 
 		return sapUi;
 	}

--- a/test/lib/processors/manifestCreator.js
+++ b/test/lib/processors/manifestCreator.js
@@ -600,6 +600,83 @@ test.serial("manifest creation with themes", async (t) => {
 		"  sap.ui/supportedThemes determined from resources: 'base, sap_foo'");
 });
 
+test.serial("manifest creation with themes omits supportedThemes for manifest version 2.0.0", async (t) => {
+	const {manifestCreator, errorLogStub, verboseLogStub, getProjectVersion} = t.context;
+
+	const prefix = "/resources/sap/ui/test/";
+
+	const expectedManifestContent = JSON.stringify({
+		"_version": "2.0.0",
+		"sap.app": {
+			"id": "sap.ui.test",
+			"type": "library",
+			"embeds": [],
+			"applicationVersion": {
+				"version": "1.0.0"
+			},
+			"title": "sap.ui.test",
+			"resources": "resources.json",
+			"offline": true
+		},
+		"sap.ui": {
+			"technology": "UI5"
+		},
+		"sap.ui5": {
+			"dependencies": {
+				"libs": {}
+			},
+			"library": {
+				"i18n": false
+			}
+		}
+	}, null, 2);
+
+	const libraryResource = {
+		getPath: () => {
+			return prefix + ".library";
+		},
+		getString: async () => {
+			return `<?xml version="1.0" encoding="UTF-8" ?>
+			<library xmlns="http://www.sap.com/sap.ui.library.xsd" >
+				<name>sap.ui.test</name>
+				<version>1.0.0</version>
+			</library>`;
+		}
+	};
+
+	const resources = [];
+	["base", "sap_foo"].forEach((name) => {
+		resources.push({
+			getPath: () => {
+				return `${prefix}themes/${name}/some.less`;
+			}
+		});
+		resources.push({
+			getPath: () => {
+				return `${prefix}themes/${name}/library.source.less`;
+			}
+		});
+	});
+	resources.push({
+		getPath: () => {
+			return `${prefix}js/lib/themes/invalid/some.css`;
+		}
+	});
+
+	const result = await manifestCreator({
+		libraryResource,
+		resources,
+		getProjectVersion,
+		options: {descriptorVersion: "2.0.0"}
+	});
+	t.is(await result.getString(), expectedManifestContent, "Correct result returned");
+
+	t.is(errorLogStub.callCount, 0);
+	t.false(verboseLogStub.getCalls().some((call) => {
+		return typeof call.args[0] === "string" && call.args[0].includes("sap.ui/supportedThemes");
+	}), "No supportedThemes verbose log entry");
+});
+
 test.serial("manifest creation for sap/apf", async (t) => {
 	const {manifestCreator, errorLogStub, verboseLogStub, getProjectVersion} = t.context;
 


### PR DESCRIPTION
The sap.ui/supportedThemes property is not allowed in manifest version
2.0.0 and higher. Only generate it when the target descriptor version is
lower than 2.0.0.

JIRA: CPOUI5FOUNDATION-961
